### PR TITLE
Fix CI lint checks to scan all source directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         run: |
           MAX_LINES=1500
           FAILED=0
-          for file in $(find src/ -name "*.cpp" -o -name "*.h" 2>/dev/null) include/avm.h; do
+          for file in $(find src/ include/ -name "*.cpp" -o -name "*.h" 2>/dev/null); do
             lines=$(wc -l < "$file")
             if [ "$lines" -gt "$MAX_LINES" ]; then
               echo "ERROR: $file has $lines lines (max: $MAX_LINES)"
@@ -73,5 +73,5 @@ jobs:
         continue-on-error: true
         run: |
           sudo apt-get install -y clang-format-17 > /dev/null 2>&1
-          echo "Checking src/ and include/avm.h formatting..."
-          clang-format-17 --dry-run --Werror src/*.cpp include/avm.h 2>&1 || echo "::warning::Code formatting issues found. Run clang-format to fix."
+          echo "Checking formatting of source files..."
+          find src/ include/ -name "*.cpp" -o -name "*.h" | xargs clang-format-17 --dry-run --Werror 2>&1 || echo "::warning::Code formatting issues found. Run clang-format to fix."


### PR DESCRIPTION
## Summary

Follow-up fix for #5 — the CI lint checks (file size and clang-format) were only scanning `src/` with a hardcoded path for `include/avm.h`. This made them fragile: any new `.h` or `.cpp` files added to `include/` would be missed.

### Changes

- Updated file size check to use `find src/ include/` instead of `find src/` + hardcoded `include/avm.h`
- Updated clang-format check to dynamically find all source files in both `src/` and `include/` directories

## Test Plan

- [x] Verified locally that the updated `find` commands correctly discover all source files
- [x] Build and tests pass locally

Relates to #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)