### PR TITLE
AVM 1.0 foundation: architecture contract and canonical LinkStore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,16 @@ endif()
 
 add_test( NAME unit_tests COMMAND avm_unit_test )
 
+# The AVM 1.0 core is tested independently from the legacy JSON interpreter
+# and from the optional Windows LinksPlatform DLL.
+add_executable( avm_link_store_test
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/link_store_test.cpp" )
+
+target_include_directories( avm_link_store_test PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+add_test( NAME link_store_tests COMMAND avm_link_store_test )
+
 foreach( TEST_FILE ${TEST_FILES} )
     add_test(
         NAME "json_roundtrip_${TEST_FILE}"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,144 @@
+# AVM 1.0 architecture contract
+
+This document defines the engineering boundaries for the AVM 1.0 foundation. It intentionally does not define the whole Meta-Theory of Links (MTS); it defines how AVM stores and executes associative structures.
+
+## Layers
+
+```text
+A0  Link model       LinkId -> (begin, end)
+A1  LinkStore        canonical identity, queries and explicit writes
+A2  Relations Model  (relation, subject, object) <-> nested dyads
+A3  Execution        context + relation dispatch + program evaluation
+A4  Projection       JSON, Anum and other external representations
+A5  Backend          in-memory, LinksPlatform, PMM or another store
+```
+
+A higher layer must not silently redefine a lower layer.
+
+## A0. Link model
+
+The physical primitive of the AVM 1.0 core is a directed dyad:
+
+```text
+LinkId -> (begin: LinkId, end: LinkId)
+```
+
+`LinkId` is an opaque identity. Semantic code must not derive meaning from a C++ pointer value or from the physical layout of a backend.
+
+An independent identity is bootstrapped as a self-link `(x, x)`. This keeps the reference in-memory implementation link-only instead of introducing a second physical "atom" record type.
+
+## A1. LinkStore
+
+The canonical storage contract separates reads from writes.
+
+| Operation | May mutate | Meaning |
+|---|---:|---|
+| `create_point()` | yes | Introduce a new independent self-link identity |
+| `intern(begin,end)` | yes | Return the canonical link for a pair, creating it when missing |
+| `find(begin,end)` | no | Find an existing exact pair |
+| `get(id)` | no | Read endpoints |
+| `outgoing(begin)` | no | Read links that begin at an identity |
+| `incoming(end)` | no | Read links that end at an identity |
+
+The important invariant is:
+
+```text
+find(a, b) never creates Link(a, b)
+```
+
+and canonicalization means:
+
+```text
+intern(a, b) == intern(a, b)
+```
+
+inside one logical store.
+
+## A2. Relations Model compatibility
+
+`jsonRVM` represents an executable entity as the triplet:
+
+```text
+(relation, subject, object)
+```
+
+AVM uses one canonical nesting order:
+
+```text
+subject_object = Link(subject, object)
+entity         = Link(relation, subject_object)
+```
+
+therefore:
+
+```text
+(relation, subject, object)
+= (relation, (subject, object))
+```
+
+The Relations Model codec is responsible for this mapping. `LinkStore` itself does not know what a relation, subject or object is.
+
+## A3. Execution
+
+The target executor accepts a root/entity `LinkId`, not a JSON AST. It decodes a Relations Model entity, constructs an explicit execution context and dispatches by relation identity.
+
+Native C++ handlers are allowed as a bootstrap vocabulary, but their keys are relation `LinkId`s in the associative store. User-defined program bodies must eventually have an associative representation rather than living only in `std::map` or `nlohmann::json` objects.
+
+The current `interpret(const json&)`, string operator dispatch, `func_env` and `param_stack` are compatibility mechanisms. They are not the target AVM 1.0 execution model and must be removed after their observable behavior is covered by the associative path.
+
+## A4. Projection
+
+JSON and Anum are external representations.
+
+```text
+external representation
+-> parser / codec / projection
+-> LinkStore + Relations Model
+-> execution
+```
+
+The executor must not depend on `nlohmann::json` as its internal instruction type.
+
+For Anum, AVM follows the separation already used by the Anum/MTS work:
+
+```text
+raw(A) != den(A)
+load(A) does not imply materializing den(A)
+find(A) is non-mutating
+realize(A) is an explicit materializing operation
+```
+
+The Anum parser and context projection belong outside the storage layer.
+
+## A5. Backend
+
+Storage backends implement the same `LinkStore` semantics. They do not define VM relations, JSON rules or Anum semantics.
+
+The first backend is `InMemoryLinkStore`. Persistent adapters are added only after the core identity/query contract is covered by conformance tests.
+
+## Core invariants
+
+1. One physical core primitive: a directed dyad.
+2. Opaque link identity.
+3. Canonical identity for an exact pair.
+4. Read/query operations do not materialize missing links.
+5. Relations Model triplets use exactly `(relation, (subject, object))`.
+6. JSON is a projection, not the VM instruction storage.
+7. Execution consumes link identities.
+8. User-defined code and call state migrate into the associative model.
+9. Backend implementation is independent from VM semantics.
+10. Legacy paths are deleted after migration; Git is the history store.
+
+## Migration sequence
+
+The implementation sequence is tracked by epic #31 and issues #21-#27:
+
+```text
+architecture contract
+-> LinkStore
+-> Relations Model codec
+-> execution context/kernel
+-> program-as-links
+-> Anum boundary
+-> persistence + end-to-end integration
+```

--- a/include/avm/link_store.h
+++ b/include/avm/link_store.h
@@ -6,6 +6,7 @@
 #include <map>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 

--- a/include/avm/link_store.h
+++ b/include/avm/link_store.h
@@ -1,0 +1,147 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+using LinkId = std::uint64_t;
+inline constexpr LinkId invalid_link_id = 0;
+
+struct Link
+{
+    LinkId begin;
+    LinkId end;
+
+    bool operator==(const Link &) const = default;
+};
+
+class LinkStore
+{
+public:
+    virtual ~LinkStore() = default;
+
+    // A point is a self-link. It is the only bootstrap operation needed to
+    // introduce a new independent identity into an otherwise link-only store.
+    virtual LinkId create_point() = 0;
+
+    // Return the canonical identity of (begin, end), creating it if necessary.
+    virtual LinkId intern(LinkId begin, LinkId end) = 0;
+
+    // Read operations never materialize missing links.
+    virtual std::optional<LinkId> find(LinkId begin, LinkId end) const = 0;
+    virtual Link get(LinkId id) const = 0;
+    virtual std::vector<LinkId> outgoing(LinkId begin) const = 0;
+    virtual std::vector<LinkId> incoming(LinkId end) const = 0;
+    virtual bool contains(LinkId id) const = 0;
+    virtual std::size_t size() const = 0;
+};
+
+class InMemoryLinkStore final : public LinkStore
+{
+public:
+    LinkId create_point() override
+    {
+        const LinkId id = allocate_id();
+        insert_link(id, Link{id, id});
+        return id;
+    }
+
+    LinkId intern(LinkId begin, LinkId end) override
+    {
+        require_existing_endpoint(begin, "begin");
+        require_existing_endpoint(end, "end");
+
+        if (const auto existing = find(begin, end))
+            return *existing;
+
+        const LinkId id = allocate_id();
+        insert_link(id, Link{begin, end});
+        return id;
+    }
+
+    std::optional<LinkId> find(LinkId begin, LinkId end) const override
+    {
+        const auto it = exact_.find({begin, end});
+        if (it == exact_.end())
+            return std::nullopt;
+        return it->second;
+    }
+
+    Link get(LinkId id) const override
+    {
+        const auto it = links_.find(id);
+        if (it == links_.end())
+            throw std::out_of_range("unknown LinkId");
+        return it->second;
+    }
+
+    std::vector<LinkId> outgoing(LinkId begin) const override
+    {
+        const auto it = outgoing_.find(begin);
+        if (it == outgoing_.end())
+            return {};
+        return it->second;
+    }
+
+    std::vector<LinkId> incoming(LinkId end) const override
+    {
+        const auto it = incoming_.find(end);
+        if (it == incoming_.end())
+            return {};
+        return it->second;
+    }
+
+    bool contains(LinkId id) const override
+    {
+        return links_.contains(id);
+    }
+
+    std::size_t size() const override
+    {
+        return links_.size();
+    }
+
+private:
+    using Pair = std::pair<LinkId, LinkId>;
+
+    LinkId allocate_id()
+    {
+        if (next_id_ == invalid_link_id || next_id_ == std::numeric_limits<LinkId>::max())
+            throw std::overflow_error("LinkId space exhausted");
+        return next_id_++;
+    }
+
+    void require_existing_endpoint(LinkId id, const char *role) const
+    {
+        if (!contains(id))
+            throw std::invalid_argument(std::string("unknown ") + role + " LinkId");
+    }
+
+    void insert_link(LinkId id, Link link)
+    {
+        const Pair pair{link.begin, link.end};
+        if (exact_.contains(pair))
+            throw std::logic_error("attempt to insert duplicate canonical link");
+
+        links_.emplace(id, link);
+        exact_.emplace(pair, id);
+        outgoing_[link.begin].push_back(id);
+        incoming_[link.end].push_back(id);
+    }
+
+    LinkId next_id_{1};
+    std::map<LinkId, Link> links_;
+    std::map<Pair, LinkId> exact_;
+    std::map<LinkId, std::vector<LinkId>> outgoing_;
+    std::map<LinkId, std::vector<LinkId>> incoming_;
+};
+
+} // namespace avm

--- a/test/link_store_test.cpp
+++ b/test/link_store_test.cpp
@@ -1,0 +1,74 @@
+#include "avm/link_store.h"
+
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+
+namespace
+{
+
+bool contains_id(const std::vector<avm::LinkId> &ids, avm::LinkId id)
+{
+    return std::find(ids.begin(), ids.end(), id) != ids.end();
+}
+
+} // namespace
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+
+    assert(store.size() == 0);
+
+    const avm::LinkId a = store.create_point();
+    const avm::LinkId b = store.create_point();
+
+    assert(a != avm::invalid_link_id);
+    assert(b != avm::invalid_link_id);
+    assert(a != b);
+    assert(store.get(a) == (avm::Link{a, a}));
+    assert(store.get(b) == (avm::Link{b, b}));
+    assert(store.find(a, a) == a);
+    assert(store.find(b, b) == b);
+
+    const std::size_t before_find = store.size();
+    assert(!store.find(a, b).has_value());
+    assert(store.size() == before_find);
+
+    const avm::LinkId ab = store.intern(a, b);
+    assert(store.get(ab) == (avm::Link{a, b}));
+    assert(store.find(a, b) == ab);
+
+    const std::size_t before_reintern = store.size();
+    assert(store.intern(a, b) == ab);
+    assert(store.size() == before_reintern);
+
+    assert(contains_id(store.outgoing(a), a));
+    assert(contains_id(store.outgoing(a), ab));
+    assert(contains_id(store.incoming(b), b));
+    assert(contains_id(store.incoming(b), ab));
+
+    bool invalid_endpoint_rejected = false;
+    try
+    {
+        static_cast<void>(store.intern(a, 999999));
+    }
+    catch (const std::invalid_argument &)
+    {
+        invalid_endpoint_rejected = true;
+    }
+    assert(invalid_endpoint_rejected);
+
+    bool invalid_get_rejected = false;
+    try
+    {
+        static_cast<void>(store.get(999999));
+    }
+    catch (const std::out_of_range &)
+    {
+        invalid_get_rejected = true;
+    }
+    assert(invalid_get_rejected);
+
+    return 0;
+}


### PR DESCRIPTION
## Что сделано

Начата реализация epic #31 с двух фундаментальных шагов.

- Добавлен `docs/architecture.md` с границами Link model / LinkStore / Relations Model / Execution / Projection / Backend.
- Зафиксирован canonical triplet nesting для следующего этапа: `(relation, (subject, object))`.
- Добавлен новый независимый core API `include/avm/link_store.h`.
- `LinkId` отделён от C++ pointer identity.
- `InMemoryLinkStore` поддерживает canonical `intern(begin,end)`, non-mutating `find`, `get`, `outgoing`, `incoming`.
- Независимые identity вводятся как self-links, без второго физического atom record type.
- Добавлен standalone `avm_link_store_test`, который не зависит от legacy JSON interpreter и Windows LinksPlatform DLL.

## Почему это первый шаг

Текущий `interpret(json)` уже умеет вычислять NOT/AND/OR/If/Def/Call, но программа и call state остаются JSON/C++ структурами вне асети. До переноса execution semantics нужен стабильный физический контракт `L → L²`, иначе новый executor снова окажется привязан к `rel_t` и глобальному storage.

## Проверяемые инварианты

- `intern(a,b) == intern(a,b)`;
- `find(a,b)` не создаёт отсутствующую связь;
- self-link является обычным Link;
- exact/outgoing/incoming indexes согласованы;
- invalid endpoints rejected explicitly;
- новый core test не включает JSON runtime.

Closes #21
Closes #22

Следующий этап после merge: #23 — Relations Model triplet↔dyads codec и conformance с jsonRVM.