### PR TITLE
Relations Model compatibility: encode triplets as nested dyads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,14 @@ target_include_directories( avm_link_store_test PRIVATE
 
 add_test( NAME link_store_tests COMMAND avm_link_store_test )
 
+add_executable( avm_relations_model_test
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/relations_model_test.cpp" )
+
+target_include_directories( avm_relations_model_test PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+add_test( NAME relations_model_tests COMMAND avm_relations_model_test )
+
 foreach( TEST_FILE ${TEST_FILES} )
     add_test(
         NAME "json_roundtrip_${TEST_FILE}"

--- a/docs/jsonrvm-compatibility.md
+++ b/docs/jsonrvm-compatibility.md
@@ -1,0 +1,95 @@
+# jsonRVM / AVM compatibility
+
+This document fixes the first compatibility contract between the triplet-based Relations Model used by `jsonRVM` and the dyadic associative network used by AVM.
+
+## Relations Model entity
+
+`jsonRVM` represents a triune entity with three roles:
+
+```text
+(relation, subject, object)
+```
+
+The JSON projection uses:
+
+```json
+{
+  "$rel": "relation",
+  "$sub": "subject",
+  "$obj": "object"
+}
+```
+
+The execution meaning belongs to the Relations Model/executor layer. This document only defines the structural projection into AVM links.
+
+## Canonical dyadic projection
+
+AVM uses nested ordered pairs in one fixed order:
+
+```text
+subject_object = Link(subject, object)
+entity         = Link(relation, subject_object)
+```
+
+Therefore:
+
+```text
+(relation, subject, object)
+=
+(relation, (subject, object))
+```
+
+No separate physical triplet record is required by the AVM core.
+
+## Round-trip
+
+For a materialized triplet `t`:
+
+```text
+encode(t) -> entity LinkId
+decode(entity LinkId) -> t
+```
+
+must preserve all three roles exactly.
+
+Because both inner and outer pairs are canonical links, repeated encoding returns the same identities inside one logical store.
+
+## Non-mutating lookup
+
+Finding a triplet is intentionally different from encoding/materializing it.
+
+```text
+find_relation_entity(relation, subject, object)
+```
+
+performs:
+
+```text
+find(subject, object)
+then, only if it exists,
+find(relation, subject_object)
+```
+
+It must not create the inner `(subject, object)` pair while checking whether the triplet exists.
+
+This is the same engineering distinction later required by the Anum boundary:
+
+```text
+description/query != realization/write
+```
+
+## Recursive use
+
+Every role is a `LinkId`, so an encoded entity can itself be used as the relation, subject or object of another entity. This preserves the recursive/homoiconic character of the Relations Model without adding another storage primitive.
+
+## Execution is the next layer
+
+This codec does not:
+
+- dispatch a relation;
+- parse JSON;
+- interpret `$ref` paths;
+- define MVC behavior;
+- implement Anum semantics.
+
+Those operations build on top of the structural identity established here.

--- a/include/avm/relations_model.h
+++ b/include/avm/relations_model.h
@@ -45,11 +45,7 @@ inline RelationEntity decode_relation_entity(const LinkStore &store, LinkId enti
     const Link outer = store.get(entity);
     const Link subject_object = store.get(outer.end);
 
-    return RelationEntity{
-        .relation = outer.begin,
-        .subject = subject_object.begin,
-        .object = subject_object.end,
-    };
+    return RelationEntity{outer.begin, subject_object.begin, subject_object.end};
 }
 
 } // namespace avm

--- a/include/avm/relations_model.h
+++ b/include/avm/relations_model.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "avm/link_store.h"
+
+#include <optional>
+
+namespace avm
+{
+
+struct RelationEntity
+{
+    LinkId relation;
+    LinkId subject;
+    LinkId object;
+
+    bool operator==(const RelationEntity &) const = default;
+};
+
+// Canonical Relations Model projection:
+//
+//   (relation, subject, object)
+//       == (relation, (subject, object))
+//
+// The inner subject-object dyad and the outer entity dyad are both interned,
+// so repeated encoding reuses the same canonical LinkIds.
+inline LinkId encode_relation_entity(LinkStore &store, const RelationEntity &entity)
+{
+    const LinkId subject_object = store.intern(entity.subject, entity.object);
+    return store.intern(entity.relation, subject_object);
+}
+
+// Look up an already materialized Relations Model entity without creating the
+// inner subject-object dyad or the outer entity dyad.
+inline std::optional<LinkId> find_relation_entity(const LinkStore &store, const RelationEntity &entity)
+{
+    const auto subject_object = store.find(entity.subject, entity.object);
+    if (!subject_object)
+        return std::nullopt;
+
+    return store.find(entity.relation, *subject_object);
+}
+
+inline RelationEntity decode_relation_entity(const LinkStore &store, LinkId entity)
+{
+    const Link outer = store.get(entity);
+    const Link subject_object = store.get(outer.end);
+
+    return RelationEntity{
+        .relation = outer.begin,
+        .subject = subject_object.begin,
+        .object = subject_object.end,
+    };
+}
+
+} // namespace avm

--- a/test/relations_model_test.cpp
+++ b/test/relations_model_test.cpp
@@ -1,0 +1,49 @@
+#include "avm/relations_model.h"
+
+#include <cassert>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+
+    const avm::LinkId relation = store.create_point();
+    const avm::LinkId relation2 = store.create_point();
+    const avm::LinkId subject = store.create_point();
+    const avm::LinkId object = store.create_point();
+
+    const avm::RelationEntity source{relation, subject, object};
+
+    const std::size_t before_find = store.size();
+    assert(!avm::find_relation_entity(store, source).has_value());
+    assert(store.size() == before_find);
+    assert(!store.find(subject, object).has_value());
+
+    const avm::LinkId encoded = avm::encode_relation_entity(store, source);
+    assert(avm::decode_relation_entity(store, encoded) == source);
+    assert(avm::find_relation_entity(store, source) == encoded);
+
+    const auto subject_object = store.find(subject, object);
+    assert(subject_object.has_value());
+    assert(store.get(encoded) == (avm::Link{relation, *subject_object}));
+
+    const std::size_t before_reencode = store.size();
+    assert(avm::encode_relation_entity(store, source) == encoded);
+    assert(store.size() == before_reencode);
+
+    const avm::RelationEntity same_so_other_relation{relation2, subject, object};
+    const avm::LinkId encoded2 = avm::encode_relation_entity(store, same_so_other_relation);
+    assert(encoded2 != encoded);
+    assert(store.find(subject, object) == subject_object);
+    assert(avm::decode_relation_entity(store, encoded2) == same_so_other_relation);
+
+    const avm::RelationEntity self{subject, subject, subject};
+    const avm::LinkId self_encoded = avm::encode_relation_entity(store, self);
+    assert(self_encoded == subject);
+    assert(avm::decode_relation_entity(store, self_encoded) == self);
+
+    const avm::RelationEntity nested{encoded, encoded2, self_encoded};
+    const avm::LinkId nested_encoded = avm::encode_relation_entity(store, nested);
+    assert(avm::decode_relation_entity(store, nested_encoded) == nested);
+
+    return 0;
+}

--- a/test/relations_model_test.cpp
+++ b/test/relations_model_test.cpp
@@ -13,17 +13,24 @@ int main()
 
     const avm::RelationEntity source{relation, subject, object};
 
+    // A lookup for an absent triplet must not even create its inner (subject, object) dyad.
     const std::size_t before_find = store.size();
     assert(!avm::find_relation_entity(store, source).has_value());
     assert(store.size() == before_find);
     assert(!store.find(subject, object).has_value());
+
+    // The same rule holds when the inner dyad already exists but the outer entity does not.
+    const avm::LinkId subject_object_preexisting = store.intern(subject, object);
+    const std::size_t before_outer_find = store.size();
+    assert(!avm::find_relation_entity(store, source).has_value());
+    assert(store.size() == before_outer_find);
 
     const avm::LinkId encoded = avm::encode_relation_entity(store, source);
     assert(avm::decode_relation_entity(store, encoded) == source);
     assert(avm::find_relation_entity(store, source) == encoded);
 
     const auto subject_object = store.find(subject, object);
-    assert(subject_object.has_value());
+    assert(subject_object == subject_object_preexisting);
     assert(store.get(encoded) == (avm::Link{relation, *subject_object}));
 
     const std::size_t before_reencode = store.size();


### PR DESCRIPTION
## Что сделано

Реализация #23 поверх foundation PR #32.

- Добавлен typed `RelationEntity { relation, subject, object }`.
- Канонический encode:
  - `subject_object = Link(subject, object)`
  - `entity = Link(relation, subject_object)`
- Добавлен обратный decode.
- Добавлен **non-mutating** `find_relation_entity`: если внутренний `(subject,object)` отсутствует, поиск не создаёт его.
- Добавлена документация `docs/jsonrvm-compatibility.md` с точным соответствием `$rel/$sub/$obj`.
- Добавлен независимый conformance test для round-trip, canonical reuse, self-links и рекурсивного вложения entity IDs.

## Зачем

Это первый конкретный инженерный мост между триплетной Relations Model из `jsonRVM` и двумерной асетью AVM. Внутреннее хранилище остаётся только `L → L²`; semantic triplet восстанавливается losslessly поверх двух links.

Closes #23

Следующий этап: #24 — execution kernel, принимающий root/entity `LinkId` и dispatching relation by link identity.