### PR TITLE
AVM execution kernel: dispatch Relations Model entities by relation LinkId

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,6 +112,14 @@ target_include_directories( avm_relations_model_test PRIVATE
 
 add_test( NAME relations_model_tests COMMAND avm_relations_model_test )
 
+add_executable( avm_executor_test
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/executor_test.cpp" )
+
+target_include_directories( avm_executor_test PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
+
+add_test( NAME executor_tests COMMAND avm_executor_test )
+
 foreach( TEST_FILE ${TEST_FILES} )
     add_test(
         NAME "json_roundtrip_${TEST_FILE}"

--- a/docs/execution-kernel.md
+++ b/docs/execution-kernel.md
@@ -1,0 +1,64 @@
+# AVM execution kernel
+
+The AVM 1.0 execution kernel runs a Relations Model entity by its `LinkId`.
+It does not parse JSON and it does not dispatch operators by textual names.
+
+## Execution path
+
+```text
+entity LinkId
+    |
+    v
+decode_relation_entity
+    |
+    v
+ExecutionContext
+    |
+    v
+relation LinkId -> native bootstrap handler
+    |
+    v
+result LinkId
+```
+
+## Execution context
+
+The minimal context carries the instantiated Relations Model entity:
+
+```text
+entity
+relation
+subject
+object
+parent (optional)
+```
+
+The context is explicit. It replaces the idea that execution state can live only in hidden global C++ structures.
+
+## Native bootstrap boundary
+
+A native handler is registered by a relation `LinkId`:
+
+```text
+relation identity -> C++ handler
+```
+
+This is deliberately a bootstrap mechanism. It lets the first executable relations exist before user-defined program structures have been migrated into the associative store.
+
+The native registry must not become a second program database. User-defined function bodies, parameters, bindings and call frames are migrated into links by the next stage of the AVM 1.0 roadmap.
+
+## Invariants
+
+1. `Executor::execute` accepts an entity `LinkId`, not a JSON expression.
+2. Relation dispatch uses a relation `LinkId`, not a string such as `"Not"` or `"If"`.
+3. The entity is decoded through the canonical Relations Model codec.
+4. Unknown relations fail explicitly and do not mutate the store.
+5. A native handler must return an existing `LinkId`.
+6. Parent context is explicit and can later support nested execution/call frames.
+7. The executor depends on `LinkStore` semantics, not on a physical storage backend.
+
+## Compatibility path
+
+The existing `interpret(const json&)`, `resolve_operator`, `func_env` and `param_stack` remain temporarily for behavioral compatibility tests. They are not part of the target kernel.
+
+They will be removed after their behavior is represented and executed through links as tracked by issue #25.

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -7,6 +7,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 
 namespace avm
 {

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "avm/relations_model.h"
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+namespace avm
+{
+
+struct ExecutionContext
+{
+    LinkId entity;
+    LinkId relation;
+    LinkId subject;
+    LinkId object;
+    std::optional<LinkId> parent;
+};
+
+class Executor;
+using NativeRelationHandler = std::function<LinkId(const ExecutionContext &, Executor &)>;
+
+class Executor
+{
+public:
+    explicit Executor(LinkStore &store)
+        : store_(store)
+    {
+    }
+
+    LinkStore &store()
+    {
+        return store_;
+    }
+
+    const LinkStore &store() const
+    {
+        return store_;
+    }
+
+    void register_native(LinkId relation, NativeRelationHandler handler)
+    {
+        if (!store_.contains(relation))
+            throw std::invalid_argument("native relation is not present in LinkStore");
+        if (!handler)
+            throw std::invalid_argument("native relation handler is empty");
+
+        const auto [it, inserted] = native_handlers_.emplace(relation, std::move(handler));
+        if (!inserted)
+            throw std::logic_error("native relation handler is already registered");
+    }
+
+    bool has_native(LinkId relation) const
+    {
+        return native_handlers_.contains(relation);
+    }
+
+    LinkId execute(LinkId entity, std::optional<LinkId> parent = std::nullopt)
+    {
+        if (!store_.contains(entity))
+            throw std::invalid_argument("execution entity is not present in LinkStore");
+
+        const RelationEntity decoded = decode_relation_entity(store_, entity);
+        const ExecutionContext context{
+            entity,
+            decoded.relation,
+            decoded.subject,
+            decoded.object,
+            parent,
+        };
+
+        const auto handler = native_handlers_.find(context.relation);
+        if (handler == native_handlers_.end())
+            throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
+
+        const LinkId result = handler->second(context, *this);
+        if (!store_.contains(result))
+            throw std::runtime_error("native relation returned an unknown LinkId");
+
+        return result;
+    }
+
+private:
+    LinkStore &store_;
+    std::map<LinkId, NativeRelationHandler> native_handlers_;
+};
+
+} // namespace avm

--- a/test/executor_test.cpp
+++ b/test/executor_test.cpp
@@ -1,0 +1,113 @@
+#include "avm/executor.h"
+
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+
+    const avm::LinkId identity_relation = store.create_point();
+    const avm::LinkId subject_relation = store.create_point();
+    const avm::LinkId unknown_relation = store.create_point();
+    const avm::LinkId subject = store.create_point();
+    const avm::LinkId object = store.create_point();
+
+    avm::Executor executor(store);
+
+    executor.register_native(
+        identity_relation,
+        [](const avm::ExecutionContext &context, avm::Executor &) {
+            return context.object;
+        });
+
+    executor.register_native(
+        subject_relation,
+        [subject](const avm::ExecutionContext &context, avm::Executor &) {
+            assert(context.subject == subject);
+            return context.subject;
+        });
+
+    const avm::LinkId identity_entity = avm::encode_relation_entity(
+        store, avm::RelationEntity{identity_relation, subject, object});
+
+    assert(executor.execute(identity_entity) == object);
+
+    std::optional<avm::ExecutionContext> captured_context;
+    const avm::LinkId parent_relation = store.create_point();
+    executor.register_native(
+        parent_relation,
+        [&captured_context](const avm::ExecutionContext &context, avm::Executor &) {
+            captured_context = context;
+            return context.object;
+        });
+
+    const avm::LinkId parent_entity = avm::encode_relation_entity(
+        store, avm::RelationEntity{parent_relation, subject, object});
+
+    assert(executor.execute(parent_entity, identity_entity) == object);
+    assert(captured_context.has_value());
+    assert(captured_context->entity == parent_entity);
+    assert(captured_context->relation == parent_relation);
+    assert(captured_context->subject == subject);
+    assert(captured_context->object == object);
+    assert(captured_context->parent == identity_entity);
+
+    const avm::LinkId subject_entity = avm::encode_relation_entity(
+        store, avm::RelationEntity{subject_relation, subject, object});
+    assert(executor.execute(subject_entity) == subject);
+
+    const avm::LinkId unknown_entity = avm::encode_relation_entity(
+        store, avm::RelationEntity{unknown_relation, subject, object});
+    const std::size_t before_unknown_execute = store.size();
+
+    bool unknown_rejected = false;
+    try
+    {
+        static_cast<void>(executor.execute(unknown_entity));
+    }
+    catch (const std::runtime_error &)
+    {
+        unknown_rejected = true;
+    }
+    assert(unknown_rejected);
+    assert(store.size() == before_unknown_execute);
+
+    bool duplicate_handler_rejected = false;
+    try
+    {
+        executor.register_native(
+            identity_relation,
+            [](const avm::ExecutionContext &context, avm::Executor &) {
+                return context.object;
+            });
+    }
+    catch (const std::logic_error &)
+    {
+        duplicate_handler_rejected = true;
+    }
+    assert(duplicate_handler_rejected);
+
+    const avm::LinkId invalid_result_relation = store.create_point();
+    executor.register_native(
+        invalid_result_relation,
+        [](const avm::ExecutionContext &, avm::Executor &) {
+            return static_cast<avm::LinkId>(999999);
+        });
+    const avm::LinkId invalid_result_entity = avm::encode_relation_entity(
+        store, avm::RelationEntity{invalid_result_relation, subject, object});
+
+    bool invalid_result_rejected = false;
+    try
+    {
+        static_cast<void>(executor.execute(invalid_result_entity));
+    }
+    catch (const std::runtime_error &)
+    {
+        invalid_result_rejected = true;
+    }
+    assert(invalid_result_rejected);
+
+    return 0;
+}


### PR DESCRIPTION
## Что сделано

Реализация #24 поверх уже слитых #21–#23.

- Добавлен `ExecutionContext` с явными `entity/relation/subject/object/parent`.
- Добавлен `Executor::execute(LinkId)`: executor принимает associative entity ID, а не JSON AST.
- Entity декодируется через canonical Relations Model codec.
- Native bootstrap handlers регистрируются по **relation LinkId**, а не по строкам операторов.
- Неизвестная relation завершается явной ошибкой и не мутирует store.
- Native handler обязан вернуть существующий `LinkId`.
- Добавлены тесты object/pass-through и subject primitives, parent context, duplicate handler, unknown relation и invalid result.
- Добавлена документация bootstrap boundary и явно зафиксировано, что `interpret(json)`, `resolve_operator`, `func_env`, `param_stack` — временный compatibility path до #25.

## Первый новый execution path

```text
LinkStore entity
→ decode (relation, subject, object)
→ ExecutionContext
→ dispatch relation LinkId
→ native bootstrap relation
→ result LinkId
```

В этом пути нет `nlohmann::json` и нет сравнения строк `"Not"/"If"/"Call"`.

Closes #24

Следующий этап: #25 — перенос самой программы, bindings и call frames в links с удалением JSON execution side-channel.