### PR TITLE
CI/CD: harden AVM 1.0 core gates and tagged artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
+    tags: ['v*']
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -12,7 +13,7 @@ on:
       - 'LICENSE'
       - '.gitignore'
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
       - '**.md'
       - '**.txt'
@@ -21,53 +22,136 @@ on:
       - '**.gif'
       - 'LICENSE'
       - '.gitignore'
+  workflow_dispatch:
 
 jobs:
-  build:
+  quality:
+    name: Quality gates
+    runs-on: ubuntu-latest
     timeout-minutes: 5
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-      fail-fast: false
-
-    runs-on: ${{ matrix.os }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Check file sizes
-        if: runner.os == 'Linux'
+      - name: Check source file sizes
+        shell: bash
         run: |
+          set -euo pipefail
           MAX_LINES=1500
           FAILED=0
-          for file in $(find src/ include/ -name "*.cpp" -o -name "*.h" 2>/dev/null); do
+          while IFS= read -r file; do
             lines=$(wc -l < "$file")
             if [ "$lines" -gt "$MAX_LINES" ]; then
               echo "ERROR: $file has $lines lines (max: $MAX_LINES)"
               FAILED=1
             fi
-          done
-          if [ "$FAILED" -eq 1 ]; then
-            echo "File size check failed. Please split large files into smaller modules."
+          done < <(find src include -type f \( -name '*.cpp' -o -name '*.h' \) -print)
+          if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
-          echo "All source files are within the $MAX_LINES line limit."
 
-      - name: Check formatting with clang-format
-        if: runner.os == 'Linux'
-        continue-on-error: true
+      - name: Check AVM 1.0 core formatting
+        shell: bash
         run: |
-          sudo apt-get install -y clang-format-17 > /dev/null 2>&1
-          echo "Checking formatting of source files..."
-          find src/ include/ -name "*.cpp" -o -name "*.h" | xargs clang-format-17 --dry-run --Werror 2>&1 || echo "::warning::Code formatting issues found. Run clang-format to fix."
+          set -euo pipefail
+          clang-format --version
+          clang-format --dry-run --Werror \
+            include/avm/*.h \
+            test/link_store_test.cpp \
+            test/relations_model_test.cpp \
+            test/executor_test.cpp
 
-      - name: Configure CMake
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release
+  core:
+    name: Core C++20 / warnings-as-errors
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure core-only build
+        run: >-
+          cmake -S . -B build-core
+          -DCMAKE_BUILD_TYPE=Release
+          -DAVM_BUILD_LEGACY=OFF
+          -DAVM_BUILD_CORE_TESTS=ON
+          -DAVM_WARNINGS_AS_ERRORS=ON
+
+      - name: Build core tests
+        run: cmake --build build-core --target avm_core_tests --parallel
+
+      - name: Run core tests
+        run: ctest --test-dir build-core --output-on-failure
+
+  sanitizers:
+    name: Core ASan + UBSan
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure sanitizer build
+        run: >-
+          cmake -S . -B build-sanitizers
+          -DCMAKE_BUILD_TYPE=Debug
+          -DAVM_BUILD_LEGACY=OFF
+          -DAVM_BUILD_CORE_TESTS=ON
+          -DAVM_WARNINGS_AS_ERRORS=ON
+          -DAVM_ENABLE_SANITIZERS=ON
+
+      - name: Build sanitizer tests
+        run: cmake --build build-sanitizers --target avm_core_tests --parallel
+
+      - name: Run sanitizer tests
+        env:
+          ASAN_OPTIONS: detect_leaks=1:halt_on_error=1
+          UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1
+        run: ctest --test-dir build-sanitizers --output-on-failure
+
+  portable:
+    name: Portable / ${{ matrix.os }}
+    needs: quality
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure full compatibility build
+        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DAVM_BUILD_LEGACY=ON -DAVM_BUILD_CORE_TESTS=ON
 
       - name: Build
-        run: cmake --build build --config Release
+        run: cmake --build build --config Release --parallel
 
-      - name: Run tests
-        working-directory: build
-        run: ctest -C Release --output-on-failure
+      - name: Run all tests
+        run: ctest --test-dir build -C Release --output-on-failure
+
+  release-artifact:
+    name: Tagged Linux artifact
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [core, sanitizers]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure release build
+        run: cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DAVM_BUILD_LEGACY=ON
+
+      - name: Build AVM executable
+        run: cmake --build build-release --target avm --parallel
+
+      - name: Upload tagged executable
+        uses: actions/upload-artifact@v4
+        with:
+          name: avm-${{ github.ref_name }}-linux-x86_64
+          path: build-release/avm
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-format
+
       - name: Check source file sizes
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,132 +1,153 @@
-# Require CMAKE 3.20 or higher
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
-message( "Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
+message("Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_PROJECT_VERSION 0.0.5 )
+set(CMAKE_PROJECT_VERSION 0.0.5)
 
-# Project name
-project( avm
-         VERSION ${CMAKE_PROJECT_VERSION}
-         DESCRIPTION "Associative virtual machine"
-         LANGUAGES CXX )
+project(avm
+    VERSION ${CMAKE_PROJECT_VERSION}
+    DESCRIPTION "Associative virtual machine"
+    LANGUAGES CXX)
 
 enable_testing()
 
-# name template
-set( TARGET_NAME avm )
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-# Build for C++20
-set( CMAKE_CXX_STANDARD 20 )
-set( CMAKE_CXX_STANDARD_REQUIRED ON )
-set( CMAKE_CXX_EXTENSIONS OFF )
+option(AVM_BUILD_LEGACY "Build the legacy JSON compatibility executable and tests" ON)
+option(AVM_BUILD_CORE_TESTS "Build AVM 1.0 core tests" ON)
+option(AVM_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
+option(AVM_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
-# Name of executable
-add_executable( ${TARGET_NAME} )
-
-# Adding build-requirements
-target_include_directories( ${TARGET_NAME} PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${CMAKE_CURRENT_SOURCE_DIR}/3p" )
-
-target_sources( ${TARGET_NAME} PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/avm.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/3p/UnitedMemoryLinks.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp" )
-
-if( WIN32 )
-    add_definitions(-DUNICODE -D_UNICODE)
-    link_directories(
-        "${CMAKE_CURRENT_SOURCE_DIR}/3p" )
-    target_link_libraries(${PROJECT_NAME} PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/3p/doublets_ffi.dll.lib" )
-    # Increase stack size to 8MB on Windows (default 1MB causes stack overflow
-    # with deeply recursive export_json on large inputs like text2.json)
-    if( MSVC )
-        target_link_options(${TARGET_NAME} PRIVATE /STACK:8388608)
+function(avm_apply_quality target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /W4)
+        if(AVM_WARNINGS_AS_ERRORS)
+            target_compile_options(${target} PRIVATE /WX)
+        endif()
     else()
-        target_link_options(${TARGET_NAME} PRIVATE -Wl,--stack,8388608)
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+        if(AVM_WARNINGS_AS_ERRORS)
+            target_compile_options(${target} PRIVATE -Werror)
+        endif()
+
+        if(AVM_ENABLE_SANITIZERS)
+            target_compile_options(${target} PRIVATE
+                -fsanitize=address,undefined
+                -fno-omit-frame-pointer)
+            target_link_options(${target} PRIVATE
+                -fsanitize=address,undefined)
+        endif()
     endif()
+endfunction()
+
+if(AVM_BUILD_LEGACY)
+    set(TARGET_NAME avm)
+
+    add_executable(${TARGET_NAME})
+
+    target_include_directories(${TARGET_NAME} PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+
+    target_sources(${TARGET_NAME} PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/avm.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p/UnitedMemoryLinks.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp")
+
+    if(WIN32)
+        add_definitions(-DUNICODE -D_UNICODE)
+        link_directories("${CMAKE_CURRENT_SOURCE_DIR}/3p")
+        target_link_libraries(${PROJECT_NAME} PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/3p/doublets_ffi.dll.lib")
+
+        if(MSVC)
+            target_link_options(${TARGET_NAME} PRIVATE /STACK:8388608)
+        else()
+            target_link_options(${TARGET_NAME} PRIVATE -Wl,--stack,8388608)
+        endif()
+    endif()
+
+    set(TEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test")
+    set(TEST_FILES
+        true.json
+        false.json
+        null.json
+        "[true].json"
+        "[false].json"
+        "[null].json"
+        array.json
+        number.json
+        unsigned.json
+        text.json
+        text2.json
+        strings.json
+        nulls.json
+        empty_array.json
+        empty_object.json
+        root.json)
+
+    add_executable(avm_unit_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/unit_test.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
+        "${CMAKE_CURRENT_SOURCE_DIR}/include/avm.h"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p/UnitedMemoryLinks.h")
+
+    target_include_directories(avm_unit_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+
+    target_compile_definitions(avm_unit_test PRIVATE AVM_NO_MAIN)
+
+    if(WIN32)
+        target_link_libraries(avm_unit_test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/3p/doublets_ffi.dll.lib")
+        if(MSVC)
+            target_link_options(avm_unit_test PRIVATE /STACK:8388608)
+        else()
+            target_link_options(avm_unit_test PRIVATE -Wl,--stack,8388608)
+        endif()
+    endif()
+
+    add_test(NAME unit_tests COMMAND avm_unit_test)
+
+    foreach(TEST_FILE ${TEST_FILES})
+        add_test(
+            NAME "json_roundtrip_${TEST_FILE}"
+            COMMAND ${CMAKE_COMMAND}
+                -DAVM_EXECUTABLE=$<TARGET_FILE:${TARGET_NAME}>
+                -DTEST_FILE=${TEST_DIR}/${TEST_FILE}
+                -DTEST_DIR=${TEST_DIR}
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.cmake")
+    endforeach()
 endif()
 
-# Add tests: for each test JSON file, run avm and compare output with expected
-set( TEST_DIR "${CMAKE_CURRENT_SOURCE_DIR}/test" )
-set( TEST_FILES
-    true.json
-    false.json
-    null.json
-    "[true].json"
-    "[false].json"
-    "[null].json"
-    array.json
-    number.json
-    unsigned.json
-    text.json
-    text2.json
-    strings.json
-    nulls.json
-    empty_array.json
-    empty_object.json
-    root.json
-)
+if(AVM_BUILD_CORE_TESTS)
+    function(avm_add_core_test target source test_name)
+        add_executable(${target} "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
+        target_include_directories(${target} PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/include")
+        avm_apply_quality(${target})
+        add_test(NAME ${test_name} COMMAND ${target})
+    endfunction()
 
-# Unit test executable
-add_executable( avm_unit_test
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/unit_test.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/include/avm.h"
-    "${CMAKE_CURRENT_SOURCE_DIR}/3p/UnitedMemoryLinks.h" )
+    avm_add_core_test(
+        avm_link_store_test
+        test/link_store_test.cpp
+        link_store_tests)
 
-target_include_directories( avm_unit_test PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include"
-    "${CMAKE_CURRENT_SOURCE_DIR}/3p" )
+    avm_add_core_test(
+        avm_relations_model_test
+        test/relations_model_test.cpp
+        relations_model_tests)
 
-target_compile_definitions( avm_unit_test PRIVATE AVM_NO_MAIN )
+    avm_add_core_test(
+        avm_executor_test
+        test/executor_test.cpp
+        executor_tests)
 
-if( WIN32 )
-    target_link_libraries( avm_unit_test PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/3p/doublets_ffi.dll.lib" )
-    if( MSVC )
-        target_link_options(avm_unit_test PRIVATE /STACK:8388608)
-    else()
-        target_link_options(avm_unit_test PRIVATE -Wl,--stack,8388608)
-    endif()
+    add_custom_target(avm_core_tests DEPENDS
+        avm_link_store_test
+        avm_relations_model_test
+        avm_executor_test)
 endif()
-
-add_test( NAME unit_tests COMMAND avm_unit_test )
-
-# The AVM 1.0 core is tested independently from the legacy JSON interpreter
-# and from the optional Windows LinksPlatform DLL.
-add_executable( avm_link_store_test
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/link_store_test.cpp" )
-
-target_include_directories( avm_link_store_test PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test( NAME link_store_tests COMMAND avm_link_store_test )
-
-add_executable( avm_relations_model_test
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/relations_model_test.cpp" )
-
-target_include_directories( avm_relations_model_test PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test( NAME relations_model_tests COMMAND avm_relations_model_test )
-
-add_executable( avm_executor_test
-    "${CMAKE_CURRENT_SOURCE_DIR}/test/executor_test.cpp" )
-
-target_include_directories( avm_executor_test PRIVATE
-    "${CMAKE_CURRENT_SOURCE_DIR}/include" )
-
-add_test( NAME executor_tests COMMAND avm_executor_test )
-
-foreach( TEST_FILE ${TEST_FILES} )
-    add_test(
-        NAME "json_roundtrip_${TEST_FILE}"
-        COMMAND ${CMAKE_COMMAND}
-            -DAVM_EXECUTABLE=$<TARGET_FILE:${TARGET_NAME}>
-            -DTEST_FILE=${TEST_DIR}/${TEST_FILE}
-            -DTEST_DIR=${TEST_DIR}
-            -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.cmake"
-    )
-endforeach()

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,59 @@
+# AVM CI/CD policy
+
+The AVM 1.0 core is intentionally testable without the legacy JSON interpreter or the optional LinksPlatform dependency.
+
+## CMake switches
+
+- `AVM_BUILD_LEGACY=ON|OFF` — build the historical JSON-facing executable and compatibility tests.
+- `AVM_BUILD_CORE_TESTS=ON|OFF` — build the link-native AVM 1.0 test suites.
+- `AVM_WARNINGS_AS_ERRORS=ON|OFF` — enable strict compiler diagnostics for targets using the core quality profile.
+- `AVM_ENABLE_SANITIZERS=ON|OFF` — enable AddressSanitizer and UndefinedBehaviorSanitizer on supported non-MSVC toolchains.
+
+The fast validation command is:
+
+```bash
+cmake -S . -B build-core \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DAVM_BUILD_LEGACY=OFF \
+  -DAVM_BUILD_CORE_TESTS=ON \
+  -DAVM_WARNINGS_AS_ERRORS=ON
+cmake --build build-core --target avm_core_tests --parallel
+ctest --test-dir build-core --output-on-failure
+```
+
+## Pull-request gates
+
+The `CI` workflow has four independent concerns:
+
+1. `Quality gates` — source-size policy and strict clang-format verification for the AVM 1.0 core files.
+2. `Core C++20 / warnings-as-errors` — Linux core-only build with strict warnings and CTest.
+3. `Core ASan + UBSan` — Debug core-only build under AddressSanitizer and UndefinedBehaviorSanitizer.
+4. `Portable / <os>` — full compatibility build and test matrix on Linux, Windows and macOS.
+
+Recommended branch-protection required checks for `main` are:
+
+- `Quality gates`;
+- `Core C++20 / warnings-as-errors`;
+- `Core ASan + UBSan`.
+
+The portable matrix should also stay green, but the three fast core gates are the minimum architectural merge barrier. This separation keeps the new link-native core independently verifiable even if a legacy/platform-specific dependency is temporarily unavailable.
+
+## Test-suite growth rule
+
+Every new AVM 1.0 semantic layer must add a separately named CTest suite and be included in the `avm_core_tests` aggregate target. The intended progression is:
+
+- `link_store_tests`;
+- `relations_model_tests`;
+- `executor_tests`;
+- program-model tests;
+- Boolean/If runtime tests;
+- function/frame/recursion tests;
+- JSON compatibility/conformance tests during the migration phase.
+
+Tests should prefer explicit invariants over broad end-to-end snapshots: canonical identity reuse, non-mutating lookup, malformed-link rejection, lazy branch behavior, frame materialization and recursion bounds should each be asserted directly.
+
+## Tagged delivery
+
+A push of a tag matching `v*` builds the Linux `avm` executable and uploads it as a workflow artifact named `avm-<tag>-linux-x86_64` after the core and sanitizer gates pass.
+
+This is deliberately a minimal CD step. Publishing a GitHub Release, binary signing and a multi-platform release bundle should be enabled only after the versioning/signing policy and the legacy-to-AVM-1.0 executable transition are settled.

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -49,7 +49,7 @@ public:
         if (!handler)
             throw std::invalid_argument("native relation handler is empty");
 
-        const auto [it, inserted] = native_handlers_.emplace(relation, std::move(handler));
+        const bool inserted = native_handlers_.emplace(relation, std::move(handler)).second;
         if (!inserted)
             throw std::logic_error("native relation handler is already registered");
     }


### PR DESCRIPTION
Closes #39.

## What changed
- split CMake into independently selectable legacy and AVM 1.0 core targets;
- added `AVM_WARNINGS_AS_ERRORS` and `AVM_ENABLE_SANITIZERS` quality switches;
- added `avm_core_tests` aggregate target;
- made core compiler warnings strict and fixed the existing unused structured binding in `Executor`;
- replaced the single CI matrix with explicit quality, core, sanitizer and portable lanes;
- added a minimal tagged Linux artifact delivery step for `v*` tags;
- documented required checks and test-suite growth policy.

## Why
The new link-native core must remain independently verifiable while the historical JSON/LinksPlatform path is still being migrated. This also gives #35–#38 a fast test lane that does not require legacy dependencies.

## Validation
Locally validated the C++20 core profile with `-Wall -Wextra -Wpedantic -Werror`: LinkStore, Relations Model and Executor tests pass 3/3. The same three tests also pass under ASan + UBSan.

GitHub-hosted job execution remains dependent on runner availability; the workflow is intentionally split so branch protection can require the fast `Quality gates`, `Core C++20 / warnings-as-errors`, and `Core ASan + UBSan` checks.