### PR TITLE
AVM 1.0: add link-native bootstrap program model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,8 @@ jobs:
             include/avm/*.h \
             test/link_store_test.cpp \
             test/relations_model_test.cpp \
-            test/executor_test.cpp
+            test/executor_test.cpp \
+            test/program_model_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,8 +146,14 @@ if(AVM_BUILD_CORE_TESTS)
         test/executor_test.cpp
         executor_tests)
 
+    avm_add_core_test(
+        avm_program_model_test
+        test/program_model_test.cpp
+        program_model_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_link_store_test
         avm_relations_model_test
-        avm_executor_test)
+        avm_executor_test
+        avm_program_model_test)
 endif()

--- a/docs/program-model.md
+++ b/docs/program-model.md
@@ -1,0 +1,90 @@
+# AVM 1.0 link-native program model
+
+This document defines the first bootstrap program representation for AVM 1.0. It is an engineering protocol built on the canonical `LinkStore` and Relations Model codec. It is not declared to be a fundamental MTS vocabulary.
+
+## Core invariant
+
+After projection/import, executable program structure lives in the same link store as data:
+
+```text
+program representation ∈ LinkStore
+```
+
+The executor must not require operator names, JSON nodes, C++ function-definition maps or parameter-name maps to understand the structure.
+
+## Bootstrap vocabulary
+
+`BootstrapVocabulary` materializes opaque LinkId identities for:
+
+- `unit` — marker used as the subject of executable expression entities;
+- `nil` — terminator for link-list chains;
+- Boolean values `true_value` and `false_value`;
+- expression relations: quote, parameter, sequence, NOT, AND, OR, IF and CALL;
+- runtime structure relations: function, binding and frame.
+
+The IDs are deliberately opaque. Textual names are projection-level labels and do not participate in core identity or dispatch.
+
+## Expression shape
+
+Executable expression nodes are Relations Model entities:
+
+```text
+Expression(relation, payload)
+    = (relation, unit, payload)
+    = Link(relation, Link(unit, payload))
+```
+
+Examples:
+
+```text
+Literal(value)     = (quote, unit, value)
+Parameter(formal)  = (parameter, unit, formal)
+NOT(arg)           = (not, unit, List(arg))
+AND(a,b)           = (and, unit, List(a,b))
+OR(a,b)            = (or, unit, List(a,b))
+IF(c,t,e)          = (if, unit, List(c,t,e))
+Sequence(e...)     = (sequence, unit, List(e...))
+```
+
+Repeated materialization of the same immutable structure reuses the canonical LinkId because all constituent dyads are interned.
+
+## Lists
+
+Argument, parameter and sequence collections use a canonical dyad chain:
+
+```text
+List()      = nil
+List(a,b,c) = Link(a, Link(b, Link(c, nil)))
+```
+
+`decode_link_list` detects cycles, missing LinkIds and a configurable maximum item count. List decoding therefore does not rely on recursion or on JSON arrays.
+
+## Functions
+
+A function handle is an independently created point. This indirection is important: the body may reference the handle before the immutable function definition is materialized, which makes recursive program graphs representable without mutable link identities.
+
+A definition is:
+
+```text
+params = List(formal1, formal2, ...)
+payload = Link(params, bodyRoot)
+definition = (function, handle, payload)
+```
+
+A handle has at most one definition. Repeating an identical definition is idempotent; attempting to attach a different definition to the same handle is an error.
+
+A call expression is:
+
+```text
+args = List(actualExpr1, actualExpr2, ...)
+payload = Link(functionHandle, args)
+call = (call, unit, payload)
+```
+
+At this stage the model only represents calls. Frame materialization, binding lookup and recursion semantics are implemented in the next runtime gate (#37).
+
+## Boundary with JSON and Anum
+
+This layer does not parse JSON and does not parse Anum/abits. A projection layer may map external names and syntax to vocabulary LinkIds and construct this graph, but execution receives only LinkIds and runtime vocabulary.
+
+That boundary is intentional: AVM storage/execution semantics must not become another parser implementation, and future Anum integration should connect through the projection/load/find/realize boundary described by #26.

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -1,0 +1,273 @@
+#pragma once
+
+#include "avm/relations_model.h"
+
+#include <cstddef>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+struct BootstrapVocabulary
+{
+    LinkId unit;
+    LinkId nil;
+    LinkId true_value;
+    LinkId false_value;
+    LinkId quote_relation;
+    LinkId parameter_relation;
+    LinkId sequence_relation;
+    LinkId not_relation;
+    LinkId and_relation;
+    LinkId or_relation;
+    LinkId if_relation;
+    LinkId function_relation;
+    LinkId call_relation;
+    LinkId binding_relation;
+    LinkId frame_relation;
+
+    static BootstrapVocabulary create(LinkStore &store)
+    {
+        return BootstrapVocabulary{
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+            store.create_point(),
+        };
+    }
+};
+
+inline LinkId encode_link_list(LinkStore &store, LinkId nil, const std::vector<LinkId> &items)
+{
+    if (!store.contains(nil))
+        throw std::invalid_argument("list nil identity is not present in LinkStore");
+
+    LinkId tail = nil;
+    for (auto it = items.rbegin(); it != items.rend(); ++it)
+    {
+        if (!store.contains(*it))
+            throw std::invalid_argument("list item is not present in LinkStore");
+        tail = store.intern(*it, tail);
+    }
+    return tail;
+}
+
+inline std::vector<LinkId> decode_link_list(
+    const LinkStore &store, LinkId nil, LinkId head, std::size_t max_items = 100000)
+{
+    if (!store.contains(nil))
+        throw std::invalid_argument("list nil identity is not present in LinkStore");
+    if (!store.contains(head))
+        throw std::invalid_argument("list head is not present in LinkStore");
+
+    std::vector<LinkId> result;
+    std::set<LinkId> visited;
+    LinkId cursor = head;
+
+    while (cursor != nil)
+    {
+        if (!visited.insert(cursor).second)
+            throw std::runtime_error("cycle detected in link list");
+        if (result.size() >= max_items)
+            throw std::runtime_error("link list exceeds configured limit");
+
+        const Link cell = store.get(cursor);
+        result.push_back(cell.begin);
+        cursor = cell.end;
+
+        if (!store.contains(cursor))
+            throw std::runtime_error("link list tail references an unknown LinkId");
+    }
+
+    return result;
+}
+
+struct FunctionDefinition
+{
+    LinkId entity;
+    LinkId handle;
+    std::vector<LinkId> parameters;
+    LinkId body;
+};
+
+inline std::optional<FunctionDefinition> find_function_definition(
+    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId handle)
+{
+    if (!store.contains(handle))
+        return std::nullopt;
+
+    std::optional<FunctionDefinition> found;
+    for (const LinkId candidate : store.outgoing(vocabulary.function_relation))
+    {
+        const RelationEntity decoded = decode_relation_entity(store, candidate);
+        if (decoded.relation != vocabulary.function_relation || decoded.subject != handle)
+            continue;
+
+        const Link payload = store.get(decoded.object);
+        FunctionDefinition definition{
+            candidate,
+            handle,
+            decode_link_list(store, vocabulary.nil, payload.begin),
+            payload.end,
+        };
+
+        if (found)
+            throw std::logic_error("multiple function definitions for one handle");
+        found = std::move(definition);
+    }
+    return found;
+}
+
+struct CallExpression
+{
+    LinkId function;
+    std::vector<LinkId> arguments;
+};
+
+inline CallExpression decode_call_expression(
+    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId entity)
+{
+    const RelationEntity decoded = decode_relation_entity(store, entity);
+    if (decoded.relation != vocabulary.call_relation || decoded.subject != vocabulary.unit)
+        throw std::invalid_argument("entity is not an AVM call expression");
+
+    const Link payload = store.get(decoded.object);
+    return CallExpression{
+        payload.begin,
+        decode_link_list(store, vocabulary.nil, payload.end),
+    };
+}
+
+class ProgramBuilder
+{
+public:
+    ProgramBuilder(LinkStore &store, const BootstrapVocabulary &vocabulary)
+        : store_(store)
+        , vocabulary_(vocabulary)
+    {
+    }
+
+    LinkId literal(LinkId value)
+    {
+        require(value, "literal value");
+        return expression(vocabulary_.quote_relation, value);
+    }
+
+    LinkId parameter(LinkId formal)
+    {
+        require(formal, "formal parameter");
+        return expression(vocabulary_.parameter_relation, formal);
+    }
+
+    LinkId logical_not(LinkId argument)
+    {
+        require(argument, "NOT argument");
+        return expression(vocabulary_.not_relation, encode_link_list(store_, vocabulary_.nil, {argument}));
+    }
+
+    LinkId logical_and(LinkId left, LinkId right)
+    {
+        return binary(vocabulary_.and_relation, left, right);
+    }
+
+    LinkId logical_or(LinkId left, LinkId right)
+    {
+        return binary(vocabulary_.or_relation, left, right);
+    }
+
+    LinkId conditional(LinkId condition, LinkId then_branch, LinkId else_branch)
+    {
+        require(condition, "If condition");
+        require(then_branch, "If then branch");
+        require(else_branch, "If else branch");
+        return expression(
+            vocabulary_.if_relation,
+            encode_link_list(store_, vocabulary_.nil, {condition, then_branch, else_branch}));
+    }
+
+    LinkId sequence(const std::vector<LinkId> &expressions)
+    {
+        return expression(
+            vocabulary_.sequence_relation,
+            encode_link_list(store_, vocabulary_.nil, expressions));
+    }
+
+    LinkId create_function_handle()
+    {
+        return store_.create_point();
+    }
+
+    LinkId define_function(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
+    {
+        require(handle, "function handle");
+        require(body, "function body");
+        for (const LinkId parameter_id : parameters)
+            require(parameter_id, "formal parameter");
+
+        const LinkId parameter_list = encode_link_list(store_, vocabulary_.nil, parameters);
+        const LinkId payload = store_.intern(parameter_list, body);
+        const RelationEntity source{vocabulary_.function_relation, handle, payload};
+
+        if (const auto existing = find_function_definition(store_, vocabulary_, handle))
+        {
+            if (existing->parameters == parameters && existing->body == body)
+                return existing->entity;
+            throw std::logic_error("function handle already has a different definition");
+        }
+
+        return encode_relation_entity(store_, source);
+    }
+
+    LinkId call(LinkId function, const std::vector<LinkId> &arguments)
+    {
+        require(function, "function handle");
+        const LinkId argument_list = encode_link_list(store_, vocabulary_.nil, arguments);
+        const LinkId payload = store_.intern(function, argument_list);
+        return expression(vocabulary_.call_relation, payload);
+    }
+
+private:
+    LinkId expression(LinkId relation, LinkId object)
+    {
+        require(relation, "expression relation");
+        require(object, "expression object");
+        return encode_relation_entity(
+            store_, RelationEntity{relation, vocabulary_.unit, object});
+    }
+
+    LinkId binary(LinkId relation, LinkId left, LinkId right)
+    {
+        require(left, "left argument");
+        require(right, "right argument");
+        return expression(
+            relation,
+            encode_link_list(store_, vocabulary_.nil, {left, right}));
+    }
+
+    void require(LinkId id, const char *what) const
+    {
+        if (!store_.contains(id))
+            throw std::invalid_argument(std::string(what) + " is not present in LinkStore");
+    }
+
+    LinkStore &store_;
+    const BootstrapVocabulary &vocabulary_;
+};
+
+} // namespace avm

--- a/test/program_model_test.cpp
+++ b/test/program_model_test.cpp
@@ -1,0 +1,133 @@
+#include "avm/program_model.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+    const avm::BootstrapVocabulary vocabulary = avm::BootstrapVocabulary::create(store);
+    avm::ProgramBuilder builder(store, vocabulary);
+
+    const std::vector<avm::LinkId> vocabulary_ids{
+        vocabulary.unit,
+        vocabulary.nil,
+        vocabulary.true_value,
+        vocabulary.false_value,
+        vocabulary.quote_relation,
+        vocabulary.parameter_relation,
+        vocabulary.sequence_relation,
+        vocabulary.not_relation,
+        vocabulary.and_relation,
+        vocabulary.or_relation,
+        vocabulary.if_relation,
+        vocabulary.function_relation,
+        vocabulary.call_relation,
+        vocabulary.binding_relation,
+        vocabulary.frame_relation,
+    };
+    for (const avm::LinkId id : vocabulary_ids)
+    {
+        assert(store.contains(id));
+        assert(store.get(id) == (avm::Link{id, id}));
+    }
+
+    assert(avm::encode_link_list(store, vocabulary.nil, {}) == vocabulary.nil);
+    assert(avm::decode_link_list(store, vocabulary.nil, vocabulary.nil).empty());
+
+    const avm::LinkId a = store.create_point();
+    const avm::LinkId b = store.create_point();
+    const avm::LinkId c = store.create_point();
+    const std::vector<avm::LinkId> abc{a, b, c};
+    const avm::LinkId abc_list = avm::encode_link_list(store, vocabulary.nil, abc);
+    assert(avm::decode_link_list(store, vocabulary.nil, abc_list) == abc);
+    const std::size_t before_list_reencode = store.size();
+    assert(avm::encode_link_list(store, vocabulary.nil, abc) == abc_list);
+    assert(store.size() == before_list_reencode);
+
+    bool cycle_rejected = false;
+    try
+    {
+        static_cast<void>(avm::decode_link_list(store, vocabulary.nil, a));
+    }
+    catch (const std::runtime_error &)
+    {
+        cycle_rejected = true;
+    }
+    assert(cycle_rejected);
+
+    const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+    const std::size_t before_literal_rebuild = store.size();
+    assert(builder.literal(vocabulary.true_value) == true_literal);
+    assert(store.size() == before_literal_rebuild);
+    assert(avm::decode_relation_entity(store, true_literal) ==
+           (avm::RelationEntity{vocabulary.quote_relation, vocabulary.unit, vocabulary.true_value}));
+
+    const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
+    const avm::LinkId nested = builder.logical_not(builder.logical_and(true_literal, false_literal));
+    const avm::RelationEntity nested_decoded = avm::decode_relation_entity(store, nested);
+    assert(nested_decoded.relation == vocabulary.not_relation);
+    assert(nested_decoded.subject == vocabulary.unit);
+    const auto nested_args = avm::decode_link_list(store, vocabulary.nil, nested_decoded.object);
+    assert(nested_args.size() == 1);
+
+    const avm::LinkId if_expression = builder.conditional(true_literal, nested, false_literal);
+    const auto if_decoded = avm::decode_relation_entity(store, if_expression);
+    assert(if_decoded.relation == vocabulary.if_relation);
+    assert(avm::decode_link_list(store, vocabulary.nil, if_decoded.object) ==
+           (std::vector<avm::LinkId>{true_literal, nested, false_literal}));
+
+    const avm::LinkId formal = store.create_point();
+    const avm::LinkId parameter_expression = builder.parameter(formal);
+    assert(avm::decode_relation_entity(store, parameter_expression) ==
+           (avm::RelationEntity{vocabulary.parameter_relation, vocabulary.unit, formal}));
+
+    const avm::LinkId function = builder.create_function_handle();
+    const avm::LinkId definition = builder.define_function(function, {formal}, parameter_expression);
+    const auto found = avm::find_function_definition(store, vocabulary, function);
+    assert(found.has_value());
+    assert(found->entity == definition);
+    assert(found->handle == function);
+    assert(found->parameters == (std::vector<avm::LinkId>{formal}));
+    assert(found->body == parameter_expression);
+
+    const std::size_t before_definition_rebuild = store.size();
+    assert(builder.define_function(function, {formal}, parameter_expression) == definition);
+    assert(store.size() == before_definition_rebuild);
+
+    bool conflicting_definition_rejected = false;
+    try
+    {
+        static_cast<void>(builder.define_function(function, {}, false_literal));
+    }
+    catch (const std::logic_error &)
+    {
+        conflicting_definition_rejected = true;
+    }
+    assert(conflicting_definition_rejected);
+
+    const avm::LinkId call = builder.call(function, {true_literal});
+    const avm::CallExpression decoded_call = avm::decode_call_expression(store, vocabulary, call);
+    assert(decoded_call.function == function);
+    assert(decoded_call.arguments == (std::vector<avm::LinkId>{true_literal}));
+
+    const avm::LinkId sequence = builder.sequence({definition, call});
+    const avm::RelationEntity sequence_decoded = avm::decode_relation_entity(store, sequence);
+    assert(sequence_decoded.relation == vocabulary.sequence_relation);
+    assert(avm::decode_link_list(store, vocabulary.nil, sequence_decoded.object) ==
+           (std::vector<avm::LinkId>{definition, call}));
+
+    bool unknown_value_rejected = false;
+    try
+    {
+        static_cast<void>(builder.literal(999999));
+    }
+    catch (const std::invalid_argument &)
+    {
+        unknown_value_rejected = true;
+    }
+    assert(unknown_value_rejected);
+
+    return 0;
+}


### PR DESCRIPTION
Closes #35. Parent #25 / Epic #31.

## What changed
- added `BootstrapVocabulary` with opaque LinkId identities for program/runtime primitives;
- added canonical dyad-chain lists with cycle and size-limit validation;
- added link-native literals, parameter references, Boolean/If/sequence expression encoding;
- added function handles and immutable function-definition records;
- added call-expression representation without string names or JSON nodes;
- documented the bootstrap vocabulary and projection boundary;
- added `program_model_tests` to the core CMake aggregate and CI formatting gate.

## Architectural result
After construction, the full minimal program graph is stored in `LinkStore`; textual names are not part of core identity. Function handles provide the indirection needed for recursive program graphs before runtime frame semantics are added in #37.

## Tests
Locally validated 4/4 core suites under C++20 with `-Wall -Wextra -Wpedantic -Werror`:
- LinkStore;
- Relations Model;
- Executor;
- Program Model.

The same 4/4 suites pass under ASan + UBSan.