### PR TITLE
AVM 1.0: execute associative Boolean tables and lazy If

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,8 @@ jobs:
             test/link_store_test.cpp \
             test/relations_model_test.cpp \
             test/executor_test.cpp \
-            test/program_model_test.cpp
+            test/program_model_test.cpp \
+            test/boolean_runtime_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,9 +151,15 @@ if(AVM_BUILD_CORE_TESTS)
         test/program_model_test.cpp
         program_model_tests)
 
+    avm_add_core_test(
+        avm_boolean_runtime_test
+        test/boolean_runtime_test.cpp
+        boolean_runtime_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_link_store_test
         avm_relations_model_test
         avm_executor_test
-        avm_program_model_test)
+        avm_program_model_test
+        avm_boolean_runtime_test)
 endif()

--- a/docs/boolean-runtime.md
+++ b/docs/boolean-runtime.md
@@ -1,0 +1,66 @@
+# AVM 1.0 associative Boolean runtime
+
+The bootstrap runtime executes the first link-native AVM program subset without JSON semantics or string operator dispatch.
+
+## Truth tables are data
+
+Boolean semantics are materialized in `LinkStore` as Relations Model entities. Native C++ handlers do not encode the truth table with `if`/`switch` statements; they evaluate arguments and perform associative lookup.
+
+Unary NOT rows are represented as:
+
+```text
+(not, true,  false)
+(not, false, true)
+```
+
+Binary functions use a canonical argument-pair LinkId as the subject:
+
+```text
+key = Link(left, right)
+(and, key, result)
+(or,  key, result)
+```
+
+The lookup path uses `LinkStore::find(left, right)` and therefore does not materialize missing argument keys while evaluating a query.
+
+## Executable expressions
+
+Program expressions keep the #35 shape:
+
+```text
+(relation, unit, payload)
+```
+
+The bootstrap handlers currently cover:
+
+- quote/literal;
+- sequence;
+- NOT;
+- AND;
+- OR;
+- IF.
+
+Expression handlers reject Relations Model rows whose subject is not the `unit` execution marker. This keeps truth-table data and executable application nodes in the same relation namespace without conflating their roles.
+
+## Lazy IF
+
+`IF` uses two associative condition rows:
+
+```text
+(if, true,  true)
+(if, false, false)
+```
+
+Execution is:
+
+1. evaluate only the condition expression;
+2. resolve its Boolean selector through the stored relation;
+3. execute exactly one selected branch.
+
+The test suite proves laziness by placing an entity with an unregistered relation in the unselected branch. The expression succeeds while the same entity fails when moved into the selected branch.
+
+## Mutation rule
+
+All truth-table rows are materialized during `BootstrapRuntime` construction. Executing an already constructed Boolean program performs read-only table lookup; tests assert that `LinkStore::size()` does not change for nested Boolean evaluation or invalid Boolean lookup.
+
+Runtime frame/binding materialization is intentionally not part of this gate. Calls and parameters are implemented by #37.

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -1,0 +1,235 @@
+#pragma once
+
+#include "avm/executor.h"
+#include "avm/program_model.h"
+
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace avm
+{
+
+inline std::optional<LinkId> lookup_relation_value(
+    const LinkStore &store, LinkId relation, LinkId subject)
+{
+    std::optional<LinkId> result;
+    for (const LinkId candidate : store.outgoing(relation))
+    {
+        const RelationEntity decoded = decode_relation_entity(store, candidate);
+        if (decoded.relation != relation || decoded.subject != subject)
+            continue;
+
+        if (result && *result != decoded.object)
+            throw std::logic_error("relation lookup is not functional for the requested subject");
+        result = decoded.object;
+    }
+    return result;
+}
+
+inline std::optional<LinkId> lookup_binary_relation_value(
+    const LinkStore &store, LinkId relation, LinkId left, LinkId right)
+{
+    const auto pair = store.find(left, right);
+    if (!pair)
+        return std::nullopt;
+    return lookup_relation_value(store, relation, *pair);
+}
+
+class BootstrapRuntime
+{
+public:
+    explicit BootstrapRuntime(LinkStore &store)
+        : store_(store)
+        , vocabulary_(BootstrapVocabulary::create(store))
+        , executor_(store)
+    {
+        materialize_truth_tables();
+        register_handlers();
+    }
+
+    const BootstrapVocabulary &vocabulary() const
+    {
+        return vocabulary_;
+    }
+
+    ProgramBuilder builder()
+    {
+        return ProgramBuilder(store_, vocabulary_);
+    }
+
+    Executor &executor()
+    {
+        return executor_;
+    }
+
+    const Executor &executor() const
+    {
+        return executor_;
+    }
+
+    LinkId execute(LinkId root)
+    {
+        return executor_.execute(root);
+    }
+
+private:
+    static void require_expression_subject(const ExecutionContext &context, LinkId unit)
+    {
+        if (context.subject != unit)
+            throw std::runtime_error("runtime relation entity is not an executable expression");
+    }
+
+    std::vector<LinkId> expression_arguments(const ExecutionContext &context, std::size_t expected) const
+    {
+        require_expression_subject(context, vocabulary_.unit);
+        std::vector<LinkId> arguments = decode_link_list(store_, vocabulary_.nil, context.object);
+        if (arguments.size() != expected)
+            throw std::runtime_error("expression has unexpected argument count");
+        return arguments;
+    }
+
+    LinkId require_lookup(const std::optional<LinkId> &value, const char *message) const
+    {
+        if (!value)
+            throw std::runtime_error(message);
+        return *value;
+    }
+
+    void materialize_truth_tables()
+    {
+        encode_relation_entity(
+            store_, RelationEntity{vocabulary_.not_relation, vocabulary_.true_value, vocabulary_.false_value});
+        encode_relation_entity(
+            store_, RelationEntity{vocabulary_.not_relation, vocabulary_.false_value, vocabulary_.true_value});
+
+        const auto add_binary_row = [this](LinkId relation, LinkId left, LinkId right, LinkId result) {
+            const LinkId key = store_.intern(left, right);
+            encode_relation_entity(store_, RelationEntity{relation, key, result});
+        };
+
+        add_binary_row(
+            vocabulary_.and_relation,
+            vocabulary_.false_value,
+            vocabulary_.false_value,
+            vocabulary_.false_value);
+        add_binary_row(
+            vocabulary_.and_relation,
+            vocabulary_.false_value,
+            vocabulary_.true_value,
+            vocabulary_.false_value);
+        add_binary_row(
+            vocabulary_.and_relation,
+            vocabulary_.true_value,
+            vocabulary_.false_value,
+            vocabulary_.false_value);
+        add_binary_row(
+            vocabulary_.and_relation,
+            vocabulary_.true_value,
+            vocabulary_.true_value,
+            vocabulary_.true_value);
+
+        add_binary_row(
+            vocabulary_.or_relation,
+            vocabulary_.false_value,
+            vocabulary_.false_value,
+            vocabulary_.false_value);
+        add_binary_row(
+            vocabulary_.or_relation,
+            vocabulary_.false_value,
+            vocabulary_.true_value,
+            vocabulary_.true_value);
+        add_binary_row(
+            vocabulary_.or_relation,
+            vocabulary_.true_value,
+            vocabulary_.false_value,
+            vocabulary_.true_value);
+        add_binary_row(
+            vocabulary_.or_relation,
+            vocabulary_.true_value,
+            vocabulary_.true_value,
+            vocabulary_.true_value);
+
+        encode_relation_entity(
+            store_, RelationEntity{vocabulary_.if_relation, vocabulary_.true_value, vocabulary_.true_value});
+        encode_relation_entity(
+            store_, RelationEntity{vocabulary_.if_relation, vocabulary_.false_value, vocabulary_.false_value});
+    }
+
+    void register_handlers()
+    {
+        executor_.register_native(
+            vocabulary_.quote_relation,
+            [this](const ExecutionContext &context, Executor &) {
+                require_expression_subject(context, vocabulary_.unit);
+                return context.object;
+            });
+
+        executor_.register_native(
+            vocabulary_.sequence_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                require_expression_subject(context, vocabulary_.unit);
+                const std::vector<LinkId> expressions =
+                    decode_link_list(store_, vocabulary_.nil, context.object);
+
+                LinkId result = vocabulary_.nil;
+                for (const LinkId expression : expressions)
+                    result = executor.execute(expression, context.entity);
+                return result;
+            });
+
+        executor_.register_native(
+            vocabulary_.not_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                const std::vector<LinkId> arguments = expression_arguments(context, 1);
+                const LinkId value = executor.execute(arguments[0], context.entity);
+                return require_lookup(
+                    lookup_relation_value(store_, vocabulary_.not_relation, value),
+                    "NOT operand is not a Boolean value");
+            });
+
+        executor_.register_native(
+            vocabulary_.and_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                const std::vector<LinkId> arguments = expression_arguments(context, 2);
+                const LinkId left = executor.execute(arguments[0], context.entity);
+                const LinkId right = executor.execute(arguments[1], context.entity);
+                return require_lookup(
+                    lookup_binary_relation_value(store_, vocabulary_.and_relation, left, right),
+                    "AND operands are not Boolean values");
+            });
+
+        executor_.register_native(
+            vocabulary_.or_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                const std::vector<LinkId> arguments = expression_arguments(context, 2);
+                const LinkId left = executor.execute(arguments[0], context.entity);
+                const LinkId right = executor.execute(arguments[1], context.entity);
+                return require_lookup(
+                    lookup_binary_relation_value(store_, vocabulary_.or_relation, left, right),
+                    "OR operands are not Boolean values");
+            });
+
+        executor_.register_native(
+            vocabulary_.if_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                const std::vector<LinkId> arguments = expression_arguments(context, 3);
+                const LinkId condition = executor.execute(arguments[0], context.entity);
+                const LinkId selected = require_lookup(
+                    lookup_relation_value(store_, vocabulary_.if_relation, condition),
+                    "If condition is not a Boolean value");
+
+                if (selected == vocabulary_.true_value)
+                    return executor.execute(arguments[1], context.entity);
+                if (selected == vocabulary_.false_value)
+                    return executor.execute(arguments[2], context.entity);
+                throw std::logic_error("If truth table returned a non-Boolean selector");
+            });
+    }
+
+    LinkStore &store_;
+    BootstrapVocabulary vocabulary_;
+    Executor executor_;
+};
+
+} // namespace avm

--- a/test/boolean_runtime_test.cpp
+++ b/test/boolean_runtime_test.cpp
@@ -1,0 +1,103 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+    avm::BootstrapRuntime runtime(store);
+    avm::ProgramBuilder builder = runtime.builder();
+    const avm::BootstrapVocabulary &v = runtime.vocabulary();
+
+    const avm::LinkId t = builder.literal(v.true_value);
+    const avm::LinkId f = builder.literal(v.false_value);
+    assert(runtime.execute(t) == v.true_value);
+    assert(runtime.execute(f) == v.false_value);
+
+    assert(runtime.execute(builder.logical_not(t)) == v.false_value);
+    assert(runtime.execute(builder.logical_not(f)) == v.true_value);
+
+    assert(runtime.execute(builder.logical_and(f, f)) == v.false_value);
+    assert(runtime.execute(builder.logical_and(f, t)) == v.false_value);
+    assert(runtime.execute(builder.logical_and(t, f)) == v.false_value);
+    assert(runtime.execute(builder.logical_and(t, t)) == v.true_value);
+
+    assert(runtime.execute(builder.logical_or(f, f)) == v.false_value);
+    assert(runtime.execute(builder.logical_or(f, t)) == v.true_value);
+    assert(runtime.execute(builder.logical_or(t, f)) == v.true_value);
+    assert(runtime.execute(builder.logical_or(t, t)) == v.true_value);
+
+    const avm::LinkId nested = builder.logical_not(builder.logical_and(t, f));
+    const std::size_t before_nested_execute = store.size();
+    assert(runtime.execute(nested) == v.true_value);
+    assert(store.size() == before_nested_execute);
+
+    const avm::LinkId arbitrary_value = store.create_point();
+    const avm::LinkId invalid_not = builder.logical_not(builder.literal(arbitrary_value));
+    const std::size_t before_invalid_not = store.size();
+    bool invalid_boolean_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(invalid_not));
+    }
+    catch (const std::runtime_error &)
+    {
+        invalid_boolean_rejected = true;
+    }
+    assert(invalid_boolean_rejected);
+    assert(store.size() == before_invalid_not);
+
+    const avm::LinkId unknown_relation = store.create_point();
+    const avm::LinkId failing_branch = avm::encode_relation_entity(
+        store, avm::RelationEntity{unknown_relation, v.unit, v.false_value});
+
+    const avm::LinkId lazy_true = builder.conditional(t, f, failing_branch);
+    assert(runtime.execute(lazy_true) == v.false_value);
+
+    const avm::LinkId lazy_false = builder.conditional(f, failing_branch, t);
+    assert(runtime.execute(lazy_false) == v.true_value);
+
+    const avm::LinkId selected_failure = builder.conditional(t, failing_branch, f);
+    bool selected_branch_executed = false;
+    try
+    {
+        static_cast<void>(runtime.execute(selected_failure));
+    }
+    catch (const std::runtime_error &)
+    {
+        selected_branch_executed = true;
+    }
+    assert(selected_branch_executed);
+
+    const avm::LinkId invalid_condition = builder.conditional(builder.literal(arbitrary_value), t, f);
+    bool invalid_condition_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(invalid_condition));
+    }
+    catch (const std::runtime_error &)
+    {
+        invalid_condition_rejected = true;
+    }
+    assert(invalid_condition_rejected);
+
+    const avm::LinkId sequence = builder.sequence({t, f, nested});
+    assert(runtime.execute(sequence) == v.true_value);
+    assert(runtime.execute(builder.sequence({})) == v.nil);
+
+    const avm::LinkId malformed_not = avm::encode_relation_entity(
+        store, avm::RelationEntity{v.not_relation, v.unit, v.nil});
+    bool arity_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(malformed_not));
+    }
+    catch (const std::runtime_error &)
+    {
+        arity_rejected = true;
+    }
+    assert(arity_rejected);
+
+    return 0;
+}


### PR DESCRIPTION
Closes #36. Parent #25 / Epic #31.

## What changed
- added `BootstrapRuntime` on top of `Executor` and the link-native program model;
- materialized NOT/AND/OR truth tables as Relations Model entities in `LinkStore`;
- binary lookup uses canonical argument-pair LinkIds and non-mutating `find`;
- added quote and sequence execution;
- implemented lazy `If` that evaluates exactly one selected branch;
- documented the runtime/data distinction;
- added `boolean_runtime_tests` to core CMake and CI quality gates.

## Tests
Locally validated 5/5 core suites with C++20, `-Wall -Wextra -Wpedantic -Werror`, and again under ASan + UBSan.

Boolean coverage includes the complete NOT/AND/OR truth tables, nested execution, invalid Boolean operands, zero-argument malformed expressions, sequence semantics, store-size non-mutation for lookup, and lazy If with an intentionally unregistered relation in the unselected branch.