### PR TITLE
CI: keep test assertions active in every build type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           clang-format --version
           clang-format --dry-run --Werror \
             include/avm/*.h \
+            test/assertions_enabled_test.cpp \
             test/link_store_test.cpp \
             test/relations_model_test.cpp \
             test/executor_test.cpp \
@@ -80,7 +81,7 @@ jobs:
       - name: Configure core-only build
         run: >-
           cmake -S . -B build-core
-          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_BUILD_TYPE=Debug
           -DAVM_BUILD_LEGACY=OFF
           -DAVM_BUILD_CORE_TESTS=ON
           -DAVM_WARNINGS_AS_ERRORS=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,14 @@ function(avm_apply_quality target)
     endif()
 endfunction()
 
+function(avm_enable_test_assertions target)
+    if(MSVC)
+        target_compile_options(${target} PRIVATE /UNDEBUG)
+    else()
+        target_compile_options(${target} PRIVATE -UNDEBUG)
+    endif()
+endfunction()
+
 if(AVM_BUILD_LEGACY)
     set(TARGET_NAME avm)
 
@@ -98,6 +106,7 @@ if(AVM_BUILD_LEGACY)
         "${CMAKE_CURRENT_SOURCE_DIR}/3p")
 
     target_compile_definitions(avm_unit_test PRIVATE AVM_NO_MAIN)
+    avm_enable_test_assertions(avm_unit_test)
 
     if(WIN32)
         target_link_libraries(avm_unit_test PRIVATE
@@ -128,8 +137,14 @@ if(AVM_BUILD_CORE_TESTS)
         target_include_directories(${target} PRIVATE
             "${CMAKE_CURRENT_SOURCE_DIR}/include")
         avm_apply_quality(${target})
+        avm_enable_test_assertions(${target})
         add_test(NAME ${test_name} COMMAND ${target})
     endfunction()
+
+    avm_add_core_test(
+        avm_assertions_enabled_test
+        test/assertions_enabled_test.cpp
+        assertions_enabled_tests)
 
     avm_add_core_test(
         avm_link_store_test
@@ -157,6 +172,7 @@ if(AVM_BUILD_CORE_TESTS)
         boolean_runtime_tests)
 
     add_custom_target(avm_core_tests DEPENDS
+        avm_assertions_enabled_test
         avm_link_store_test
         avm_relations_model_test
         avm_executor_test

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -13,7 +13,7 @@ The fast validation command is:
 
 ```bash
 cmake -S . -B build-core \
-  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_BUILD_TYPE=Debug \
   -DAVM_BUILD_LEGACY=OFF \
   -DAVM_BUILD_CORE_TESTS=ON \
   -DAVM_WARNINGS_AS_ERRORS=ON
@@ -21,14 +21,20 @@ cmake --build build-core --target avm_core_tests --parallel
 ctest --test-dir build-core --output-on-failure
 ```
 
+## Assertions are part of the test contract
+
+The current C++ suites use `assert(...)` for invariant checks. CMake Release configurations normally define `NDEBUG`, which would compile those checks out. Therefore every C++ test target explicitly undefines `NDEBUG` (`-UNDEBUG` or `/UNDEBUG`) regardless of build type.
+
+`assertions_enabled_tests` additionally fails at compile time if `NDEBUG` reaches a core test target and verifies at runtime that an assertion expression is actually evaluated. The strict core lane uses Debug to maximize diagnostic visibility; the portable matrix still exercises Release builds with assertions forced active in test executables.
+
 ## Pull-request gates
 
 The `CI` workflow has four independent concerns:
 
 1. `Quality gates` — source-size policy and strict clang-format verification for the AVM 1.0 core files.
-2. `Core C++20 / warnings-as-errors` — Linux core-only build with strict warnings and CTest.
+2. `Core C++20 / warnings-as-errors` — Linux Debug core-only build with strict warnings and CTest.
 3. `Core ASan + UBSan` — Debug core-only build under AddressSanitizer and UndefinedBehaviorSanitizer.
-4. `Portable / <os>` — full compatibility build and test matrix on Linux, Windows and macOS.
+4. `Portable / <os>` — full compatibility Release build and test matrix on Linux, Windows and macOS.
 
 Recommended branch-protection required checks for `main` are:
 
@@ -42,6 +48,7 @@ The portable matrix should also stay green, but the three fast core gates are th
 
 Every new AVM 1.0 semantic layer must add a separately named CTest suite and be included in the `avm_core_tests` aggregate target. The intended progression is:
 
+- `assertions_enabled_tests`;
 - `link_store_tests`;
 - `relations_model_tests`;
 - `executor_tests`;

--- a/test/assertions_enabled_test.cpp
+++ b/test/assertions_enabled_test.cpp
@@ -1,0 +1,12 @@
+#include <cassert>
+
+#ifdef NDEBUG
+#error "AVM test targets must be compiled with assertions enabled"
+#endif
+
+int main()
+{
+    bool assertion_expression_evaluated = false;
+    assert((assertion_expression_evaluated = true));
+    return assertion_expression_evaluated ? 0 : 1;
+}


### PR DESCRIPTION
Closes #43. Follow-up to #39.

## Root cause
The core CI lane configured `Release`, while the C++ suites use `assert(...)`. Standard Release flags define `NDEBUG`, so the checks themselves could be compiled out; variables used only by assertions then also became `unused` under `-Werror`.

## Changes
- explicitly undefine `NDEBUG` for every C++ test target on MSVC/GCC/Clang;
- add `assertions_enabled_tests`, which fails compilation if `NDEBUG` leaks into the target and verifies assertion-expression evaluation at runtime;
- run the strict warnings-as-errors core lane as Debug;
- preserve portable Release coverage with assertions still forced active;
- document assertions as part of the test contract.

## Validation
Locally:
- Debug + `-Wall -Wextra -Wpedantic -Werror`: 6/6 core suites pass;
- Debug + ASan/UBSan + warnings-as-errors: 6/6 pass;
- Release: 6/6 pass with the assertion regression suite proving assertions remain active.