### PR TITLE
AVM 1.0: store function bindings and call frames in links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   quality:
     name: Quality gates
@@ -35,8 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -60,36 +55,11 @@ jobs:
             exit 1
           fi
 
-      - name: One-time format AVM 1.0 core
-        if: github.head_ref == 'agent/function-frames'
-        shell: bash
-        run: |
-          set -euo pipefail
-          clang-format --version
-          clang-format -i \
-            include/avm/*.h \
-            test/assertions_enabled_test.cpp \
-            test/link_store_test.cpp \
-            test/relations_model_test.cpp \
-            test/executor_test.cpp \
-            test/program_model_test.cpp \
-            test/boolean_runtime_test.cpp \
-            test/function_runtime_test.cpp \
-            test/frame_runtime_test.cpp
-          if git diff --quiet; then
-            echo "Core files already formatted"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add include/avm test/*.cpp
-          git commit -m "style: clang-format AVM 1.0 core"
-          git push origin HEAD:${{ github.head_ref }}
-
       - name: Check AVM 1.0 core formatting
         shell: bash
         run: |
           set -euo pipefail
+          clang-format --version
           clang-format --dry-run --Werror \
             include/avm/*.h \
             test/assertions_enabled_test.cpp \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   quality:
     name: Quality gates
@@ -32,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -55,11 +60,36 @@ jobs:
             exit 1
           fi
 
-      - name: Check AVM 1.0 core formatting
+      - name: One-time format AVM 1.0 core
+        if: github.head_ref == 'agent/function-frames'
         shell: bash
         run: |
           set -euo pipefail
           clang-format --version
+          clang-format -i \
+            include/avm/*.h \
+            test/assertions_enabled_test.cpp \
+            test/link_store_test.cpp \
+            test/relations_model_test.cpp \
+            test/executor_test.cpp \
+            test/program_model_test.cpp \
+            test/boolean_runtime_test.cpp \
+            test/function_runtime_test.cpp \
+            test/frame_runtime_test.cpp
+          if git diff --quiet; then
+            echo "Core files already formatted"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add include/avm test/*.cpp
+          git commit -m "style: clang-format AVM 1.0 core"
+          git push origin HEAD:${{ github.head_ref }}
+
+      - name: Check AVM 1.0 core formatting
+        shell: bash
+        run: |
+          set -euo pipefail
           clang-format --dry-run --Werror \
             include/avm/*.h \
             test/assertions_enabled_test.cpp \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
             test/relations_model_test.cpp \
             test/executor_test.cpp \
             test/program_model_test.cpp \
-            test/boolean_runtime_test.cpp
+            test/boolean_runtime_test.cpp \
+            test/function_runtime_test.cpp \
+            test/frame_runtime_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,11 +171,23 @@ if(AVM_BUILD_CORE_TESTS)
         test/boolean_runtime_test.cpp
         boolean_runtime_tests)
 
+    avm_add_core_test(
+        avm_function_runtime_test
+        test/function_runtime_test.cpp
+        function_runtime_tests)
+
+    avm_add_core_test(
+        avm_frame_runtime_test
+        test/frame_runtime_test.cpp
+        frame_runtime_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
         avm_relations_model_test
         avm_executor_test
         avm_program_model_test
-        avm_boolean_runtime_test)
+        avm_boolean_runtime_test
+        avm_function_runtime_test
+        avm_frame_runtime_test)
 endif()

--- a/docs/functions-and-frames.md
+++ b/docs/functions-and-frames.md
@@ -1,0 +1,89 @@
+# AVM 1.0 functions, bindings and call frames
+
+This layer moves function runtime state out of the legacy C++ `func_env` / `param_stack` side channel and into the same `LinkStore` used by program and data entities.
+
+## Function definitions
+
+A function still uses the program-model encoding introduced by #35:
+
+```text
+parameters = List(formal1, formal2, ...)
+payload    = Link(parameters, bodyRoot)
+definition = (function, handle, payload)
+```
+
+The handle is an independently created LinkId, so a recursive body can refer to its own function before the immutable definition entity is materialized.
+
+Executing a definition validates the stored shape and returns `nil`. Definition availability itself is structural: a link-native call references the handle directly. A future JSON compatibility importer is responsible for preserving textual declaration order while resolving names to handles.
+
+## Bindings
+
+Each evaluated actual argument is bound to its formal parameter with a Relations Model entity:
+
+```text
+(binding, formal, actualValue)
+```
+
+There is no `map<string, value>` in the new runtime. Formal identity is a LinkId and actual values are LinkIds.
+
+## Call frames
+
+Bindings are collected into a canonical link list and attached to an immutable call frame:
+
+```text
+bindings = List(binding1, binding2, ...)
+payload  = Link(functionHandle, bindings)
+frame    = (frame, parentFrameOrNil, payload)
+```
+
+`ExecutionContext` carries the current frame LinkId. Every recursive execution of a child expression preserves that frame unless a function call deliberately creates a child frame.
+
+Nested calls therefore form a parent-frame chain entirely in the associative store. Parameter resolution walks the chain from the current frame toward `nil`, validating that every referenced binding really has `binding_relation`.
+
+## Call execution
+
+For `(call, unit, payload)` the runtime performs:
+
+1. decode function handle and argument-expression list;
+2. locate the immutable function definition;
+3. verify arity;
+4. verify the current frame depth against the configured recursion limit;
+5. evaluate actual arguments in the caller frame;
+6. materialize binding entities;
+7. materialize a child frame linked to the caller frame;
+8. execute the function body with the child frame.
+
+This preserves lexical parameter identity without a global C++ stack. Recursive calls work because the function body already contains the same handle LinkId.
+
+## Recursion guard
+
+`BootstrapRuntime` accepts a maximum call depth, defaulting to 1000. Depth is derived by traversing parent-frame links rather than by reading a C++ container size. Malformed frame chains, non-frame parents and invalid frame payloads fail explicitly.
+
+The frame vocabulary identity itself is a self-link, like all bootstrap identities. It must not be confused with a frame instance; `decode_call_frame` rejects it explicitly. This invariant is covered by tests because the relation identity naturally appears in `LinkStore::outgoing(frame_relation)`.
+
+## Test coverage
+
+`function_runtime_tests` covers:
+
+- one- and two-parameter functions;
+- Boolean expressions inside a function body;
+- nested calls;
+- finite recursion;
+- unbounded recursion hitting the depth guard;
+- arity mismatch;
+- undefined functions;
+- unbound parameters;
+- malformed frames and definitions;
+- physical presence of binding/frame entities in `LinkStore`.
+
+`frame_runtime_tests` separately covers:
+
+- decoded root-frame structure;
+- formal→actual binding rows;
+- executing a parameter against an explicit frame LinkId;
+- parent/child frame linkage for nested calls;
+- rejection of the frame vocabulary self-link;
+- rejection of non-binding entries and invalid parent frames;
+- rejection of a zero recursion-depth configuration.
+
+Together with the existing suites, this keeps function semantics independently testable without JSON or the legacy LinksPlatform path.

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -4,7 +4,9 @@
 #include "avm/program_model.h"
 
 #include <optional>
+#include <set>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace avm
@@ -36,14 +38,44 @@ inline std::optional<LinkId> lookup_binary_relation_value(
     return lookup_relation_value(store, relation, *pair);
 }
 
+struct DecodedCallFrame
+{
+    LinkId entity;
+    LinkId parent;
+    LinkId function;
+    std::vector<LinkId> bindings;
+};
+
+inline DecodedCallFrame decode_call_frame(
+    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId frame)
+{
+    if (frame == vocabulary.frame_relation)
+        throw std::runtime_error("frame vocabulary identity is not a call frame");
+
+    const RelationEntity decoded = decode_relation_entity(store, frame);
+    if (decoded.relation != vocabulary.frame_relation)
+        throw std::runtime_error("LinkId is not an AVM call frame");
+
+    const Link payload = store.get(decoded.object);
+    return DecodedCallFrame{
+        frame,
+        decoded.subject,
+        payload.begin,
+        decode_link_list(store, vocabulary.nil, payload.end),
+    };
+}
+
 class BootstrapRuntime
 {
 public:
-    explicit BootstrapRuntime(LinkStore &store)
+    explicit BootstrapRuntime(LinkStore &store, std::size_t max_call_depth = 1000)
         : store_(store)
         , vocabulary_(BootstrapVocabulary::create(store))
         , executor_(store)
+        , max_call_depth_(max_call_depth)
     {
+        if (max_call_depth_ == 0)
+            throw std::invalid_argument("maximum call depth must be greater than zero");
         materialize_truth_tables();
         register_handlers();
     }
@@ -94,6 +126,76 @@ private:
         if (!value)
             throw std::runtime_error(message);
         return *value;
+    }
+
+    std::size_t frame_depth(std::optional<LinkId> frame) const
+    {
+        std::size_t depth = 0;
+        std::set<LinkId> visited;
+        LinkId cursor = frame.value_or(vocabulary_.nil);
+        while (cursor != vocabulary_.nil)
+        {
+            if (!visited.insert(cursor).second)
+                throw std::runtime_error("cycle detected in call-frame chain");
+
+            const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
+            cursor = decoded.parent;
+            ++depth;
+            if (depth > max_call_depth_)
+                throw std::runtime_error("call-frame chain exceeds maximum depth");
+        }
+        return depth;
+    }
+
+    std::optional<LinkId> resolve_parameter(std::optional<LinkId> frame, LinkId formal) const
+    {
+        std::set<LinkId> visited;
+        LinkId cursor = frame.value_or(vocabulary_.nil);
+        while (cursor != vocabulary_.nil)
+        {
+            if (!visited.insert(cursor).second)
+                throw std::runtime_error("cycle detected in call-frame chain");
+
+            const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
+            for (const LinkId binding : decoded.bindings)
+            {
+                const RelationEntity row = decode_relation_entity(store_, binding);
+                if (row.relation != vocabulary_.binding_relation)
+                    throw std::runtime_error("call frame contains a non-binding entity");
+                if (row.subject == formal)
+                    return row.object;
+            }
+            cursor = decoded.parent;
+        }
+        return std::nullopt;
+    }
+
+    LinkId materialize_frame(
+        std::optional<LinkId> parent,
+        LinkId function,
+        const std::vector<LinkId> &formals,
+        const std::vector<LinkId> &actuals)
+    {
+        if (formals.size() != actuals.size())
+            throw std::logic_error("cannot materialize frame with mismatched binding counts");
+
+        std::vector<LinkId> bindings;
+        bindings.reserve(formals.size());
+        for (std::size_t i = 0; i < formals.size(); ++i)
+        {
+            bindings.push_back(encode_relation_entity(
+                store_, RelationEntity{vocabulary_.binding_relation, formals[i], actuals[i]}));
+        }
+
+        const LinkId binding_list = encode_link_list(store_, vocabulary_.nil, bindings);
+        const LinkId payload = store_.intern(function, binding_list);
+        return encode_relation_entity(
+            store_,
+            RelationEntity{
+                vocabulary_.frame_relation,
+                parent.value_or(vocabulary_.nil),
+                payload,
+            });
     }
 
     void materialize_truth_tables()
@@ -174,7 +276,7 @@ private:
 
                 LinkId result = vocabulary_.nil;
                 for (const LinkId expression : expressions)
-                    result = executor.execute(expression, context.entity);
+                    result = executor.execute(expression, context.entity, context.frame);
                 return result;
             });
 
@@ -182,7 +284,7 @@ private:
             vocabulary_.not_relation,
             [this](const ExecutionContext &context, Executor &executor) {
                 const std::vector<LinkId> arguments = expression_arguments(context, 1);
-                const LinkId value = executor.execute(arguments[0], context.entity);
+                const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
                 return require_lookup(
                     lookup_relation_value(store_, vocabulary_.not_relation, value),
                     "NOT operand is not a Boolean value");
@@ -192,8 +294,8 @@ private:
             vocabulary_.and_relation,
             [this](const ExecutionContext &context, Executor &executor) {
                 const std::vector<LinkId> arguments = expression_arguments(context, 2);
-                const LinkId left = executor.execute(arguments[0], context.entity);
-                const LinkId right = executor.execute(arguments[1], context.entity);
+                const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+                const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
                 return require_lookup(
                     lookup_binary_relation_value(store_, vocabulary_.and_relation, left, right),
                     "AND operands are not Boolean values");
@@ -203,8 +305,8 @@ private:
             vocabulary_.or_relation,
             [this](const ExecutionContext &context, Executor &executor) {
                 const std::vector<LinkId> arguments = expression_arguments(context, 2);
-                const LinkId left = executor.execute(arguments[0], context.entity);
-                const LinkId right = executor.execute(arguments[1], context.entity);
+                const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+                const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
                 return require_lookup(
                     lookup_binary_relation_value(store_, vocabulary_.or_relation, left, right),
                     "OR operands are not Boolean values");
@@ -214,22 +316,67 @@ private:
             vocabulary_.if_relation,
             [this](const ExecutionContext &context, Executor &executor) {
                 const std::vector<LinkId> arguments = expression_arguments(context, 3);
-                const LinkId condition = executor.execute(arguments[0], context.entity);
+                const LinkId condition = executor.execute(arguments[0], context.entity, context.frame);
                 const LinkId selected = require_lookup(
                     lookup_relation_value(store_, vocabulary_.if_relation, condition),
                     "If condition is not a Boolean value");
 
                 if (selected == vocabulary_.true_value)
-                    return executor.execute(arguments[1], context.entity);
+                    return executor.execute(arguments[1], context.entity, context.frame);
                 if (selected == vocabulary_.false_value)
-                    return executor.execute(arguments[2], context.entity);
+                    return executor.execute(arguments[2], context.entity, context.frame);
                 throw std::logic_error("If truth table returned a non-Boolean selector");
+            });
+
+        executor_.register_native(
+            vocabulary_.function_relation,
+            [this](const ExecutionContext &context, Executor &) {
+                if (context.subject == vocabulary_.function_relation)
+                    throw std::runtime_error("function vocabulary identity is not executable");
+                static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
+                return context.subject;
+            });
+
+        executor_.register_native(
+            vocabulary_.parameter_relation,
+            [this](const ExecutionContext &context, Executor &) {
+                require_expression_subject(context, vocabulary_.unit);
+                return require_lookup(
+                    resolve_parameter(context.frame, context.object),
+                    "parameter is not bound in the current call-frame chain");
+            });
+
+        executor_.register_native(
+            vocabulary_.call_relation,
+            [this](const ExecutionContext &context, Executor &executor) {
+                require_expression_subject(context, vocabulary_.unit);
+                const CallExpression call = decode_call_expression(store_, vocabulary_, context.entity);
+                const auto definition = find_function_definition(store_, vocabulary_, call.function);
+                if (!definition)
+                    throw std::runtime_error("call references an undefined function handle");
+                if (definition->parameters.size() != call.arguments.size())
+                    throw std::runtime_error("function call arity mismatch");
+                if (frame_depth(context.frame) >= max_call_depth_)
+                    throw std::runtime_error("maximum function call depth exceeded");
+
+                std::vector<LinkId> actuals;
+                actuals.reserve(call.arguments.size());
+                for (const LinkId argument : call.arguments)
+                    actuals.push_back(executor.execute(argument, context.entity, context.frame));
+
+                const LinkId frame = materialize_frame(
+                    context.frame,
+                    call.function,
+                    definition->parameters,
+                    actuals);
+                return executor.execute(definition->body, context.entity, frame);
             });
     }
 
     LinkStore &store_;
     BootstrapVocabulary vocabulary_;
     Executor executor_;
+    std::size_t max_call_depth_;
 };
 
 } // namespace avm

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -12,371 +12,320 @@
 namespace avm
 {
 
-inline std::optional<LinkId> lookup_relation_value(
-    const LinkStore &store, LinkId relation, LinkId subject)
+inline std::optional<LinkId> lookup_relation_value(const LinkStore &store, LinkId relation, LinkId subject)
 {
-    std::optional<LinkId> result;
-    for (const LinkId candidate : store.outgoing(relation))
-    {
-        const RelationEntity decoded = decode_relation_entity(store, candidate);
-        if (decoded.relation != relation || decoded.subject != subject)
-            continue;
+	std::optional<LinkId> result;
+	for (const LinkId candidate : store.outgoing(relation))
+	{
+		const RelationEntity decoded = decode_relation_entity(store, candidate);
+		if (decoded.relation != relation || decoded.subject != subject)
+			continue;
 
-        if (result && *result != decoded.object)
-            throw std::logic_error("relation lookup is not functional for the requested subject");
-        result = decoded.object;
-    }
-    return result;
+		if (result && *result != decoded.object)
+			throw std::logic_error("relation lookup is not functional for the requested subject");
+		result = decoded.object;
+	}
+	return result;
 }
 
-inline std::optional<LinkId> lookup_binary_relation_value(
-    const LinkStore &store, LinkId relation, LinkId left, LinkId right)
+inline std::optional<LinkId> lookup_binary_relation_value(const LinkStore &store, LinkId relation, LinkId left,
+                                                          LinkId right)
 {
-    const auto pair = store.find(left, right);
-    if (!pair)
-        return std::nullopt;
-    return lookup_relation_value(store, relation, *pair);
+	const auto pair = store.find(left, right);
+	if (!pair)
+		return std::nullopt;
+	return lookup_relation_value(store, relation, *pair);
 }
 
 struct DecodedCallFrame
 {
-    LinkId entity;
-    LinkId parent;
-    LinkId function;
-    std::vector<LinkId> bindings;
+	LinkId entity;
+	LinkId parent;
+	LinkId function;
+	std::vector<LinkId> bindings;
 };
 
-inline DecodedCallFrame decode_call_frame(
-    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId frame)
+inline DecodedCallFrame decode_call_frame(const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId frame)
 {
-    if (frame == vocabulary.frame_relation)
-        throw std::runtime_error("frame vocabulary identity is not a call frame");
+	if (frame == vocabulary.frame_relation)
+		throw std::runtime_error("frame vocabulary identity is not a call frame");
 
-    const RelationEntity decoded = decode_relation_entity(store, frame);
-    if (decoded.relation != vocabulary.frame_relation)
-        throw std::runtime_error("LinkId is not an AVM call frame");
+	const RelationEntity decoded = decode_relation_entity(store, frame);
+	if (decoded.relation != vocabulary.frame_relation)
+		throw std::runtime_error("LinkId is not an AVM call frame");
 
-    const Link payload = store.get(decoded.object);
-    return DecodedCallFrame{
-        frame,
-        decoded.subject,
-        payload.begin,
-        decode_link_list(store, vocabulary.nil, payload.end),
-    };
+	const Link payload = store.get(decoded.object);
+	return DecodedCallFrame{
+	    frame,
+	    decoded.subject,
+	    payload.begin,
+	    decode_link_list(store, vocabulary.nil, payload.end),
+	};
 }
 
 class BootstrapRuntime
 {
 public:
-    explicit BootstrapRuntime(LinkStore &store, std::size_t max_call_depth = 1000)
-        : store_(store)
-        , vocabulary_(BootstrapVocabulary::create(store))
-        , executor_(store)
-        , max_call_depth_(max_call_depth)
-    {
-        if (max_call_depth_ == 0)
-            throw std::invalid_argument("maximum call depth must be greater than zero");
-        materialize_truth_tables();
-        register_handlers();
-    }
+	explicit BootstrapRuntime(LinkStore &store, std::size_t max_call_depth = 1000)
+	    : store_(store), vocabulary_(BootstrapVocabulary::create(store)), executor_(store),
+	      max_call_depth_(max_call_depth)
+	{
+		if (max_call_depth_ == 0)
+			throw std::invalid_argument("maximum call depth must be greater than zero");
+		materialize_truth_tables();
+		register_handlers();
+	}
 
-    const BootstrapVocabulary &vocabulary() const
-    {
-        return vocabulary_;
-    }
+	const BootstrapVocabulary &vocabulary() const { return vocabulary_; }
 
-    ProgramBuilder builder()
-    {
-        return ProgramBuilder(store_, vocabulary_);
-    }
+	ProgramBuilder builder() { return ProgramBuilder(store_, vocabulary_); }
 
-    Executor &executor()
-    {
-        return executor_;
-    }
+	Executor &executor() { return executor_; }
 
-    const Executor &executor() const
-    {
-        return executor_;
-    }
+	const Executor &executor() const { return executor_; }
 
-    LinkId execute(LinkId root)
-    {
-        return executor_.execute(root);
-    }
+	LinkId execute(LinkId root) { return executor_.execute(root); }
 
 private:
-    static void require_expression_subject(const ExecutionContext &context, LinkId unit)
-    {
-        if (context.subject != unit)
-            throw std::runtime_error("runtime relation entity is not an executable expression");
-    }
+	static void require_expression_subject(const ExecutionContext &context, LinkId unit)
+	{
+		if (context.subject != unit)
+			throw std::runtime_error("runtime relation entity is not an executable expression");
+	}
 
-    std::vector<LinkId> expression_arguments(const ExecutionContext &context, std::size_t expected) const
-    {
-        require_expression_subject(context, vocabulary_.unit);
-        std::vector<LinkId> arguments = decode_link_list(store_, vocabulary_.nil, context.object);
-        if (arguments.size() != expected)
-            throw std::runtime_error("expression has unexpected argument count");
-        return arguments;
-    }
+	std::vector<LinkId> expression_arguments(const ExecutionContext &context, std::size_t expected) const
+	{
+		require_expression_subject(context, vocabulary_.unit);
+		std::vector<LinkId> arguments = decode_link_list(store_, vocabulary_.nil, context.object);
+		if (arguments.size() != expected)
+			throw std::runtime_error("expression has unexpected argument count");
+		return arguments;
+	}
 
-    LinkId require_lookup(const std::optional<LinkId> &value, const char *message) const
-    {
-        if (!value)
-            throw std::runtime_error(message);
-        return *value;
-    }
+	LinkId require_lookup(const std::optional<LinkId> &value, const char *message) const
+	{
+		if (!value)
+			throw std::runtime_error(message);
+		return *value;
+	}
 
-    std::size_t frame_depth(std::optional<LinkId> frame) const
-    {
-        std::size_t depth = 0;
-        std::set<LinkId> visited;
-        LinkId cursor = frame.value_or(vocabulary_.nil);
-        while (cursor != vocabulary_.nil)
-        {
-            if (!visited.insert(cursor).second)
-                throw std::runtime_error("cycle detected in call-frame chain");
+	std::size_t frame_depth(std::optional<LinkId> frame) const
+	{
+		std::size_t depth = 0;
+		std::set<LinkId> visited;
+		LinkId cursor = frame.value_or(vocabulary_.nil);
+		while (cursor != vocabulary_.nil)
+		{
+			if (!visited.insert(cursor).second)
+				throw std::runtime_error("cycle detected in call-frame chain");
 
-            const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
-            cursor = decoded.parent;
-            ++depth;
-            if (depth > max_call_depth_)
-                throw std::runtime_error("call-frame chain exceeds maximum depth");
-        }
-        return depth;
-    }
+			const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
+			cursor = decoded.parent;
+			++depth;
+			if (depth > max_call_depth_)
+				throw std::runtime_error("call-frame chain exceeds maximum depth");
+		}
+		return depth;
+	}
 
-    std::optional<LinkId> resolve_parameter(std::optional<LinkId> frame, LinkId formal) const
-    {
-        std::set<LinkId> visited;
-        LinkId cursor = frame.value_or(vocabulary_.nil);
-        while (cursor != vocabulary_.nil)
-        {
-            if (!visited.insert(cursor).second)
-                throw std::runtime_error("cycle detected in call-frame chain");
+	std::optional<LinkId> resolve_parameter(std::optional<LinkId> frame, LinkId formal) const
+	{
+		std::set<LinkId> visited;
+		LinkId cursor = frame.value_or(vocabulary_.nil);
+		while (cursor != vocabulary_.nil)
+		{
+			if (!visited.insert(cursor).second)
+				throw std::runtime_error("cycle detected in call-frame chain");
 
-            const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
-            for (const LinkId binding : decoded.bindings)
-            {
-                const RelationEntity row = decode_relation_entity(store_, binding);
-                if (row.relation != vocabulary_.binding_relation)
-                    throw std::runtime_error("call frame contains a non-binding entity");
-                if (row.subject == formal)
-                    return row.object;
-            }
-            cursor = decoded.parent;
-        }
-        return std::nullopt;
-    }
+			const DecodedCallFrame decoded = decode_call_frame(store_, vocabulary_, cursor);
+			for (const LinkId binding : decoded.bindings)
+			{
+				const RelationEntity row = decode_relation_entity(store_, binding);
+				if (row.relation != vocabulary_.binding_relation)
+					throw std::runtime_error("call frame contains a non-binding entity");
+				if (row.subject == formal)
+					return row.object;
+			}
+			cursor = decoded.parent;
+		}
+		return std::nullopt;
+	}
 
-    LinkId materialize_frame(
-        std::optional<LinkId> parent,
-        LinkId function,
-        const std::vector<LinkId> &formals,
-        const std::vector<LinkId> &actuals)
-    {
-        if (formals.size() != actuals.size())
-            throw std::logic_error("cannot materialize frame with mismatched binding counts");
+	LinkId materialize_frame(std::optional<LinkId> parent, LinkId function, const std::vector<LinkId> &formals,
+	                         const std::vector<LinkId> &actuals)
+	{
+		if (formals.size() != actuals.size())
+			throw std::logic_error("cannot materialize frame with mismatched binding counts");
 
-        std::vector<LinkId> bindings;
-        bindings.reserve(formals.size());
-        for (std::size_t i = 0; i < formals.size(); ++i)
-        {
-            bindings.push_back(encode_relation_entity(
-                store_, RelationEntity{vocabulary_.binding_relation, formals[i], actuals[i]}));
-        }
+		std::vector<LinkId> bindings;
+		bindings.reserve(formals.size());
+		for (std::size_t i = 0; i < formals.size(); ++i)
+		{
+			bindings.push_back(
+			    encode_relation_entity(store_, RelationEntity{vocabulary_.binding_relation, formals[i], actuals[i]}));
+		}
 
-        const LinkId binding_list = encode_link_list(store_, vocabulary_.nil, bindings);
-        const LinkId payload = store_.intern(function, binding_list);
-        return encode_relation_entity(
-            store_,
-            RelationEntity{
-                vocabulary_.frame_relation,
-                parent.value_or(vocabulary_.nil),
-                payload,
-            });
-    }
+		const LinkId binding_list = encode_link_list(store_, vocabulary_.nil, bindings);
+		const LinkId payload = store_.intern(function, binding_list);
+		return encode_relation_entity(store_, RelationEntity{
+		                                          vocabulary_.frame_relation,
+		                                          parent.value_or(vocabulary_.nil),
+		                                          payload,
+		                                      });
+	}
 
-    void materialize_truth_tables()
-    {
-        encode_relation_entity(
-            store_, RelationEntity{vocabulary_.not_relation, vocabulary_.true_value, vocabulary_.false_value});
-        encode_relation_entity(
-            store_, RelationEntity{vocabulary_.not_relation, vocabulary_.false_value, vocabulary_.true_value});
+	void materialize_truth_tables()
+	{
+		encode_relation_entity(
+		    store_, RelationEntity{vocabulary_.not_relation, vocabulary_.true_value, vocabulary_.false_value});
+		encode_relation_entity(
+		    store_, RelationEntity{vocabulary_.not_relation, vocabulary_.false_value, vocabulary_.true_value});
 
-        const auto add_binary_row = [this](LinkId relation, LinkId left, LinkId right, LinkId result) {
-            const LinkId key = store_.intern(left, right);
-            encode_relation_entity(store_, RelationEntity{relation, key, result});
-        };
+		const auto add_binary_row = [this](LinkId relation, LinkId left, LinkId right, LinkId result)
+		{
+			const LinkId key = store_.intern(left, right);
+			encode_relation_entity(store_, RelationEntity{relation, key, result});
+		};
 
-        add_binary_row(
-            vocabulary_.and_relation,
-            vocabulary_.false_value,
-            vocabulary_.false_value,
-            vocabulary_.false_value);
-        add_binary_row(
-            vocabulary_.and_relation,
-            vocabulary_.false_value,
-            vocabulary_.true_value,
-            vocabulary_.false_value);
-        add_binary_row(
-            vocabulary_.and_relation,
-            vocabulary_.true_value,
-            vocabulary_.false_value,
-            vocabulary_.false_value);
-        add_binary_row(
-            vocabulary_.and_relation,
-            vocabulary_.true_value,
-            vocabulary_.true_value,
-            vocabulary_.true_value);
+		add_binary_row(vocabulary_.and_relation, vocabulary_.false_value, vocabulary_.false_value,
+		               vocabulary_.false_value);
+		add_binary_row(vocabulary_.and_relation, vocabulary_.false_value, vocabulary_.true_value,
+		               vocabulary_.false_value);
+		add_binary_row(vocabulary_.and_relation, vocabulary_.true_value, vocabulary_.false_value,
+		               vocabulary_.false_value);
+		add_binary_row(vocabulary_.and_relation, vocabulary_.true_value, vocabulary_.true_value,
+		               vocabulary_.true_value);
 
-        add_binary_row(
-            vocabulary_.or_relation,
-            vocabulary_.false_value,
-            vocabulary_.false_value,
-            vocabulary_.false_value);
-        add_binary_row(
-            vocabulary_.or_relation,
-            vocabulary_.false_value,
-            vocabulary_.true_value,
-            vocabulary_.true_value);
-        add_binary_row(
-            vocabulary_.or_relation,
-            vocabulary_.true_value,
-            vocabulary_.false_value,
-            vocabulary_.true_value);
-        add_binary_row(
-            vocabulary_.or_relation,
-            vocabulary_.true_value,
-            vocabulary_.true_value,
-            vocabulary_.true_value);
+		add_binary_row(vocabulary_.or_relation, vocabulary_.false_value, vocabulary_.false_value,
+		               vocabulary_.false_value);
+		add_binary_row(vocabulary_.or_relation, vocabulary_.false_value, vocabulary_.true_value,
+		               vocabulary_.true_value);
+		add_binary_row(vocabulary_.or_relation, vocabulary_.true_value, vocabulary_.false_value,
+		               vocabulary_.true_value);
+		add_binary_row(vocabulary_.or_relation, vocabulary_.true_value, vocabulary_.true_value, vocabulary_.true_value);
 
-        encode_relation_entity(
-            store_, RelationEntity{vocabulary_.if_relation, vocabulary_.true_value, vocabulary_.true_value});
-        encode_relation_entity(
-            store_, RelationEntity{vocabulary_.if_relation, vocabulary_.false_value, vocabulary_.false_value});
-    }
+		encode_relation_entity(store_,
+		                       RelationEntity{vocabulary_.if_relation, vocabulary_.true_value, vocabulary_.true_value});
+		encode_relation_entity(
+		    store_, RelationEntity{vocabulary_.if_relation, vocabulary_.false_value, vocabulary_.false_value});
+	}
 
-    void register_handlers()
-    {
-        executor_.register_native(
-            vocabulary_.quote_relation,
-            [this](const ExecutionContext &context, Executor &) {
-                require_expression_subject(context, vocabulary_.unit);
-                return context.object;
-            });
+	void register_handlers()
+	{
+		executor_.register_native(vocabulary_.quote_relation,
+		                          [this](const ExecutionContext &context, Executor &)
+		                          {
+			                          require_expression_subject(context, vocabulary_.unit);
+			                          return context.object;
+		                          });
 
-        executor_.register_native(
-            vocabulary_.sequence_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                require_expression_subject(context, vocabulary_.unit);
-                const std::vector<LinkId> expressions =
-                    decode_link_list(store_, vocabulary_.nil, context.object);
+		executor_.register_native(vocabulary_.sequence_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          require_expression_subject(context, vocabulary_.unit);
+			                          const std::vector<LinkId> expressions =
+			                              decode_link_list(store_, vocabulary_.nil, context.object);
 
-                LinkId result = vocabulary_.nil;
-                for (const LinkId expression : expressions)
-                    result = executor.execute(expression, context.entity, context.frame);
-                return result;
-            });
+			                          LinkId result = vocabulary_.nil;
+			                          for (const LinkId expression : expressions)
+				                          result = executor.execute(expression, context.entity, context.frame);
+			                          return result;
+		                          });
 
-        executor_.register_native(
-            vocabulary_.not_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                const std::vector<LinkId> arguments = expression_arguments(context, 1);
-                const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
-                return require_lookup(
-                    lookup_relation_value(store_, vocabulary_.not_relation, value),
-                    "NOT operand is not a Boolean value");
-            });
+		executor_.register_native(
+		    vocabulary_.not_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 1);
+			    const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
+			    return require_lookup(lookup_relation_value(store_, vocabulary_.not_relation, value),
+			                          "NOT operand is not a Boolean value");
+		    });
 
-        executor_.register_native(
-            vocabulary_.and_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                const std::vector<LinkId> arguments = expression_arguments(context, 2);
-                const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
-                const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
-                return require_lookup(
-                    lookup_binary_relation_value(store_, vocabulary_.and_relation, left, right),
-                    "AND operands are not Boolean values");
-            });
+		executor_.register_native(
+		    vocabulary_.and_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			    const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+			    const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
+			    return require_lookup(lookup_binary_relation_value(store_, vocabulary_.and_relation, left, right),
+			                          "AND operands are not Boolean values");
+		    });
 
-        executor_.register_native(
-            vocabulary_.or_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                const std::vector<LinkId> arguments = expression_arguments(context, 2);
-                const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
-                const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
-                return require_lookup(
-                    lookup_binary_relation_value(store_, vocabulary_.or_relation, left, right),
-                    "OR operands are not Boolean values");
-            });
+		executor_.register_native(
+		    vocabulary_.or_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			    const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+			    const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
+			    return require_lookup(lookup_binary_relation_value(store_, vocabulary_.or_relation, left, right),
+			                          "OR operands are not Boolean values");
+		    });
 
-        executor_.register_native(
-            vocabulary_.if_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                const std::vector<LinkId> arguments = expression_arguments(context, 3);
-                const LinkId condition = executor.execute(arguments[0], context.entity, context.frame);
-                const LinkId selected = require_lookup(
-                    lookup_relation_value(store_, vocabulary_.if_relation, condition),
-                    "If condition is not a Boolean value");
+		executor_.register_native(vocabulary_.if_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 3);
+			                          const LinkId condition =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId selected = require_lookup(
+			                              lookup_relation_value(store_, vocabulary_.if_relation, condition),
+			                              "If condition is not a Boolean value");
 
-                if (selected == vocabulary_.true_value)
-                    return executor.execute(arguments[1], context.entity, context.frame);
-                if (selected == vocabulary_.false_value)
-                    return executor.execute(arguments[2], context.entity, context.frame);
-                throw std::logic_error("If truth table returned a non-Boolean selector");
-            });
+			                          if (selected == vocabulary_.true_value)
+				                          return executor.execute(arguments[1], context.entity, context.frame);
+			                          if (selected == vocabulary_.false_value)
+				                          return executor.execute(arguments[2], context.entity, context.frame);
+			                          throw std::logic_error("If truth table returned a non-Boolean selector");
+		                          });
 
-        executor_.register_native(
-            vocabulary_.function_relation,
-            [this](const ExecutionContext &context, Executor &) {
-                if (context.subject == vocabulary_.function_relation)
-                    throw std::runtime_error("function vocabulary identity is not executable");
-                static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
-                return vocabulary_.nil;
-            });
+		executor_.register_native(vocabulary_.function_relation,
+		                          [this](const ExecutionContext &context, Executor &)
+		                          {
+			                          if (context.subject == vocabulary_.function_relation)
+				                          throw std::runtime_error("function vocabulary identity is not executable");
+			                          static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
+			                          return vocabulary_.nil;
+		                          });
 
-        executor_.register_native(
-            vocabulary_.parameter_relation,
-            [this](const ExecutionContext &context, Executor &) {
-                require_expression_subject(context, vocabulary_.unit);
-                return require_lookup(
-                    resolve_parameter(context.frame, context.object),
-                    "parameter is not bound in the current call-frame chain");
-            });
+		executor_.register_native(vocabulary_.parameter_relation,
+		                          [this](const ExecutionContext &context, Executor &)
+		                          {
+			                          require_expression_subject(context, vocabulary_.unit);
+			                          return require_lookup(resolve_parameter(context.frame, context.object),
+			                                                "parameter is not bound in the current call-frame chain");
+		                          });
 
-        executor_.register_native(
-            vocabulary_.call_relation,
-            [this](const ExecutionContext &context, Executor &executor) {
-                require_expression_subject(context, vocabulary_.unit);
-                const CallExpression call = decode_call_expression(store_, vocabulary_, context.entity);
-                const auto definition = find_function_definition(store_, vocabulary_, call.function);
-                if (!definition)
-                    throw std::runtime_error("call references an undefined function handle");
-                if (definition->parameters.size() != call.arguments.size())
-                    throw std::runtime_error("function call arity mismatch");
-                if (frame_depth(context.frame) >= max_call_depth_)
-                    throw std::runtime_error("maximum function call depth exceeded");
+		executor_.register_native(
+		    vocabulary_.call_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    require_expression_subject(context, vocabulary_.unit);
+			    const CallExpression call = decode_call_expression(store_, vocabulary_, context.entity);
+			    const auto definition = find_function_definition(store_, vocabulary_, call.function);
+			    if (!definition)
+				    throw std::runtime_error("call references an undefined function handle");
+			    if (definition->parameters.size() != call.arguments.size())
+				    throw std::runtime_error("function call arity mismatch");
+			    if (frame_depth(context.frame) >= max_call_depth_)
+				    throw std::runtime_error("maximum function call depth exceeded");
 
-                std::vector<LinkId> actuals;
-                actuals.reserve(call.arguments.size());
-                for (const LinkId argument : call.arguments)
-                    actuals.push_back(executor.execute(argument, context.entity, context.frame));
+			    std::vector<LinkId> actuals;
+			    actuals.reserve(call.arguments.size());
+			    for (const LinkId argument : call.arguments)
+				    actuals.push_back(executor.execute(argument, context.entity, context.frame));
 
-                const LinkId frame = materialize_frame(
-                    context.frame,
-                    call.function,
-                    definition->parameters,
-                    actuals);
-                return executor.execute(definition->body, context.entity, frame);
-            });
-    }
+			    const LinkId frame = materialize_frame(context.frame, call.function, definition->parameters, actuals);
+			    return executor.execute(definition->body, context.entity, frame);
+		    });
+	}
 
-    LinkStore &store_;
-    BootstrapVocabulary vocabulary_;
-    Executor executor_;
-    std::size_t max_call_depth_;
+	LinkStore &store_;
+	BootstrapVocabulary vocabulary_;
+	Executor executor_;
+	std::size_t max_call_depth_;
 };
 
 } // namespace avm

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -334,7 +334,7 @@ private:
                 if (context.subject == vocabulary_.function_relation)
                     throw std::runtime_error("function vocabulary identity is not executable");
                 static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
-                return context.subject;
+                return vocabulary_.nil;
             });
 
         executor_.register_native(

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -19,6 +19,7 @@ struct ExecutionContext
     LinkId subject;
     LinkId object;
     std::optional<LinkId> parent;
+    std::optional<LinkId> frame;
 };
 
 class Executor;
@@ -59,7 +60,10 @@ public:
         return native_handlers_.contains(relation);
     }
 
-    LinkId execute(LinkId entity, std::optional<LinkId> parent = std::nullopt)
+    LinkId execute(
+        LinkId entity,
+        std::optional<LinkId> parent = std::nullopt,
+        std::optional<LinkId> frame = std::nullopt)
     {
         if (!store_.contains(entity))
             throw std::invalid_argument("execution entity is not present in LinkStore");
@@ -71,6 +75,7 @@ public:
             decoded.subject,
             decoded.object,
             parent,
+            frame,
         };
 
         const auto handler = native_handlers_.find(context.relation);

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -14,12 +14,12 @@ namespace avm
 
 struct ExecutionContext
 {
-    LinkId entity;
-    LinkId relation;
-    LinkId subject;
-    LinkId object;
-    std::optional<LinkId> parent;
-    std::optional<LinkId> frame;
+	LinkId entity;
+	LinkId relation;
+	LinkId subject;
+	LinkId object;
+	std::optional<LinkId> parent;
+	std::optional<LinkId> frame;
 };
 
 class Executor;
@@ -28,70 +28,51 @@ using NativeRelationHandler = std::function<LinkId(const ExecutionContext &, Exe
 class Executor
 {
 public:
-    explicit Executor(LinkStore &store)
-        : store_(store)
-    {
-    }
+	explicit Executor(LinkStore &store) : store_(store) {}
 
-    LinkStore &store()
-    {
-        return store_;
-    }
+	LinkStore &store() { return store_; }
 
-    const LinkStore &store() const
-    {
-        return store_;
-    }
+	const LinkStore &store() const { return store_; }
 
-    void register_native(LinkId relation, NativeRelationHandler handler)
-    {
-        if (!store_.contains(relation))
-            throw std::invalid_argument("native relation is not present in LinkStore");
-        if (!handler)
-            throw std::invalid_argument("native relation handler is empty");
+	void register_native(LinkId relation, NativeRelationHandler handler)
+	{
+		if (!store_.contains(relation))
+			throw std::invalid_argument("native relation is not present in LinkStore");
+		if (!handler)
+			throw std::invalid_argument("native relation handler is empty");
 
-        const bool inserted = native_handlers_.emplace(relation, std::move(handler)).second;
-        if (!inserted)
-            throw std::logic_error("native relation handler is already registered");
-    }
+		const bool inserted = native_handlers_.emplace(relation, std::move(handler)).second;
+		if (!inserted)
+			throw std::logic_error("native relation handler is already registered");
+	}
 
-    bool has_native(LinkId relation) const
-    {
-        return native_handlers_.contains(relation);
-    }
+	bool has_native(LinkId relation) const { return native_handlers_.contains(relation); }
 
-    LinkId execute(
-        LinkId entity,
-        std::optional<LinkId> parent = std::nullopt,
-        std::optional<LinkId> frame = std::nullopt)
-    {
-        if (!store_.contains(entity))
-            throw std::invalid_argument("execution entity is not present in LinkStore");
+	LinkId execute(LinkId entity, std::optional<LinkId> parent = std::nullopt,
+	               std::optional<LinkId> frame = std::nullopt)
+	{
+		if (!store_.contains(entity))
+			throw std::invalid_argument("execution entity is not present in LinkStore");
 
-        const RelationEntity decoded = decode_relation_entity(store_, entity);
-        const ExecutionContext context{
-            entity,
-            decoded.relation,
-            decoded.subject,
-            decoded.object,
-            parent,
-            frame,
-        };
+		const RelationEntity decoded = decode_relation_entity(store_, entity);
+		const ExecutionContext context{
+		    entity, decoded.relation, decoded.subject, decoded.object, parent, frame,
+		};
 
-        const auto handler = native_handlers_.find(context.relation);
-        if (handler == native_handlers_.end())
-            throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
+		const auto handler = native_handlers_.find(context.relation);
+		if (handler == native_handlers_.end())
+			throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
 
-        const LinkId result = handler->second(context, *this);
-        if (!store_.contains(result))
-            throw std::runtime_error("native relation returned an unknown LinkId");
+		const LinkId result = handler->second(context, *this);
+		if (!store_.contains(result))
+			throw std::runtime_error("native relation returned an unknown LinkId");
 
-        return result;
-    }
+		return result;
+	}
 
 private:
-    LinkStore &store_;
-    std::map<LinkId, NativeRelationHandler> native_handlers_;
+	LinkStore &store_;
+	std::map<LinkId, NativeRelationHandler> native_handlers_;
 };
 
 } // namespace avm

--- a/include/avm/link_store.h
+++ b/include/avm/link_store.h
@@ -18,131 +18,125 @@ inline constexpr LinkId invalid_link_id = 0;
 
 struct Link
 {
-    LinkId begin;
-    LinkId end;
+	LinkId begin;
+	LinkId end;
 
-    bool operator==(const Link &) const = default;
+	bool operator==(const Link &) const = default;
 };
 
 class LinkStore
 {
 public:
-    virtual ~LinkStore() = default;
+	virtual ~LinkStore() = default;
 
-    // A point is a self-link. It is the only bootstrap operation needed to
-    // introduce a new independent identity into an otherwise link-only store.
-    virtual LinkId create_point() = 0;
+	// A point is a self-link. It is the only bootstrap operation needed to
+	// introduce a new independent identity into an otherwise link-only store.
+	virtual LinkId create_point() = 0;
 
-    // Return the canonical identity of (begin, end), creating it if necessary.
-    virtual LinkId intern(LinkId begin, LinkId end) = 0;
+	// Return the canonical identity of (begin, end), creating it if necessary.
+	virtual LinkId intern(LinkId begin, LinkId end) = 0;
 
-    // Read operations never materialize missing links.
-    virtual std::optional<LinkId> find(LinkId begin, LinkId end) const = 0;
-    virtual Link get(LinkId id) const = 0;
-    virtual std::vector<LinkId> outgoing(LinkId begin) const = 0;
-    virtual std::vector<LinkId> incoming(LinkId end) const = 0;
-    virtual bool contains(LinkId id) const = 0;
-    virtual std::size_t size() const = 0;
+	// Read operations never materialize missing links.
+	virtual std::optional<LinkId> find(LinkId begin, LinkId end) const = 0;
+	virtual Link get(LinkId id) const = 0;
+	virtual std::vector<LinkId> outgoing(LinkId begin) const = 0;
+	virtual std::vector<LinkId> incoming(LinkId end) const = 0;
+	virtual bool contains(LinkId id) const = 0;
+	virtual std::size_t size() const = 0;
 };
 
 class InMemoryLinkStore final : public LinkStore
 {
 public:
-    LinkId create_point() override
-    {
-        const LinkId id = allocate_id();
-        insert_link(id, Link{id, id});
-        return id;
-    }
+	LinkId create_point() override
+	{
+		const LinkId id = allocate_id();
+		insert_link(id, Link{id, id});
+		return id;
+	}
 
-    LinkId intern(LinkId begin, LinkId end) override
-    {
-        require_existing_endpoint(begin, "begin");
-        require_existing_endpoint(end, "end");
+	LinkId intern(LinkId begin, LinkId end) override
+	{
+		require_existing_endpoint(begin, "begin");
+		require_existing_endpoint(end, "end");
 
-        if (const auto existing = find(begin, end))
-            return *existing;
+		if (const auto existing = find(begin, end))
+			return *existing;
 
-        const LinkId id = allocate_id();
-        insert_link(id, Link{begin, end});
-        return id;
-    }
+		const LinkId id = allocate_id();
+		insert_link(id, Link{begin, end});
+		return id;
+	}
 
-    std::optional<LinkId> find(LinkId begin, LinkId end) const override
-    {
-        const auto it = exact_.find({begin, end});
-        if (it == exact_.end())
-            return std::nullopt;
-        return it->second;
-    }
+	std::optional<LinkId> find(LinkId begin, LinkId end) const override
+	{
+		const auto it = exact_.find({begin, end});
+		if (it == exact_.end())
+			return std::nullopt;
+		return it->second;
+	}
 
-    Link get(LinkId id) const override
-    {
-        const auto it = links_.find(id);
-        if (it == links_.end())
-            throw std::out_of_range("unknown LinkId");
-        return it->second;
-    }
+	Link get(LinkId id) const override
+	{
+		const auto it = links_.find(id);
+		if (it == links_.end())
+			throw std::out_of_range("unknown LinkId");
+		return it->second;
+	}
 
-    std::vector<LinkId> outgoing(LinkId begin) const override
-    {
-        const auto it = outgoing_.find(begin);
-        if (it == outgoing_.end())
-            return {};
-        return it->second;
-    }
+	std::vector<LinkId> outgoing(LinkId begin) const override
+	{
+		const auto it = outgoing_.find(begin);
+		if (it == outgoing_.end())
+			return {};
+		return it->second;
+	}
 
-    std::vector<LinkId> incoming(LinkId end) const override
-    {
-        const auto it = incoming_.find(end);
-        if (it == incoming_.end())
-            return {};
-        return it->second;
-    }
+	std::vector<LinkId> incoming(LinkId end) const override
+	{
+		const auto it = incoming_.find(end);
+		if (it == incoming_.end())
+			return {};
+		return it->second;
+	}
 
-    bool contains(LinkId id) const override
-    {
-        return links_.contains(id);
-    }
+	bool contains(LinkId id) const override { return links_.contains(id); }
 
-    std::size_t size() const override
-    {
-        return links_.size();
-    }
+	std::size_t size() const override { return links_.size(); }
 
 private:
-    using Pair = std::pair<LinkId, LinkId>;
+	using Pair = std::pair<LinkId, LinkId>;
 
-    LinkId allocate_id()
-    {
-        if (next_id_ == invalid_link_id || next_id_ == std::numeric_limits<LinkId>::max())
-            throw std::overflow_error("LinkId space exhausted");
-        return next_id_++;
-    }
+	LinkId allocate_id()
+	{
+		if (next_id_ == invalid_link_id || next_id_ == std::numeric_limits<LinkId>::max())
+			throw std::overflow_error("LinkId space exhausted");
+		return next_id_++;
+	}
 
-    void require_existing_endpoint(LinkId id, const char *role) const
-    {
-        if (!contains(id))
-            throw std::invalid_argument(std::string("unknown ") + role + " LinkId");
-    }
+	void require_existing_endpoint(LinkId id, const char *role) const
+	{
+		if (!contains(id))
+			throw std::invalid_argument(std::string("unknown ") + role + " LinkId");
+	}
 
-    void insert_link(LinkId id, Link link)
-    {
-        const Pair pair{link.begin, link.end};
-        if (exact_.contains(pair))
-            throw std::logic_error("attempt to insert duplicate canonical link");
+	void insert_link(LinkId id, Link link)
+	{
+		const Pair pair{link.begin, link.end};
+		if (exact_.contains(pair))
+			throw std::logic_error("attempt to insert duplicate canonical link");
 
-        links_.emplace(id, link);
-        exact_.emplace(pair, id);
-        outgoing_[link.begin].push_back(id);
-        incoming_[link.end].push_back(id);
-    }
+		links_.emplace(id, link);
+		exact_.emplace(pair, id);
+		outgoing_[link.begin].push_back(id);
+		incoming_[link.end].push_back(id);
+	}
 
-    LinkId next_id_{1};
-    std::map<LinkId, Link> links_;
-    std::map<Pair, LinkId> exact_;
-    std::map<LinkId, std::vector<LinkId>> outgoing_;
-    std::map<LinkId, std::vector<LinkId>> incoming_;
+	LinkId next_id_{1};
+	std::map<LinkId, Link> links_;
+	std::map<Pair, LinkId> exact_;
+	std::map<LinkId, std::vector<LinkId>> outgoing_;
+	std::map<LinkId, std::vector<LinkId>> incoming_;
 };
 
 } // namespace avm

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -15,259 +15,229 @@ namespace avm
 
 struct BootstrapVocabulary
 {
-    LinkId unit;
-    LinkId nil;
-    LinkId true_value;
-    LinkId false_value;
-    LinkId quote_relation;
-    LinkId parameter_relation;
-    LinkId sequence_relation;
-    LinkId not_relation;
-    LinkId and_relation;
-    LinkId or_relation;
-    LinkId if_relation;
-    LinkId function_relation;
-    LinkId call_relation;
-    LinkId binding_relation;
-    LinkId frame_relation;
+	LinkId unit;
+	LinkId nil;
+	LinkId true_value;
+	LinkId false_value;
+	LinkId quote_relation;
+	LinkId parameter_relation;
+	LinkId sequence_relation;
+	LinkId not_relation;
+	LinkId and_relation;
+	LinkId or_relation;
+	LinkId if_relation;
+	LinkId function_relation;
+	LinkId call_relation;
+	LinkId binding_relation;
+	LinkId frame_relation;
 
-    static BootstrapVocabulary create(LinkStore &store)
-    {
-        return BootstrapVocabulary{
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-            store.create_point(),
-        };
-    }
+	static BootstrapVocabulary create(LinkStore &store)
+	{
+		return BootstrapVocabulary{
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(), store.create_point(), store.create_point(),
+		};
+	}
 };
 
 inline LinkId encode_link_list(LinkStore &store, LinkId nil, const std::vector<LinkId> &items)
 {
-    if (!store.contains(nil))
-        throw std::invalid_argument("list nil identity is not present in LinkStore");
+	if (!store.contains(nil))
+		throw std::invalid_argument("list nil identity is not present in LinkStore");
 
-    LinkId tail = nil;
-    for (auto it = items.rbegin(); it != items.rend(); ++it)
-    {
-        if (!store.contains(*it))
-            throw std::invalid_argument("list item is not present in LinkStore");
-        tail = store.intern(*it, tail);
-    }
-    return tail;
+	LinkId tail = nil;
+	for (auto it = items.rbegin(); it != items.rend(); ++it)
+	{
+		if (!store.contains(*it))
+			throw std::invalid_argument("list item is not present in LinkStore");
+		tail = store.intern(*it, tail);
+	}
+	return tail;
 }
 
-inline std::vector<LinkId> decode_link_list(
-    const LinkStore &store, LinkId nil, LinkId head, std::size_t max_items = 100000)
+inline std::vector<LinkId> decode_link_list(const LinkStore &store, LinkId nil, LinkId head,
+                                            std::size_t max_items = 100000)
 {
-    if (!store.contains(nil))
-        throw std::invalid_argument("list nil identity is not present in LinkStore");
-    if (!store.contains(head))
-        throw std::invalid_argument("list head is not present in LinkStore");
+	if (!store.contains(nil))
+		throw std::invalid_argument("list nil identity is not present in LinkStore");
+	if (!store.contains(head))
+		throw std::invalid_argument("list head is not present in LinkStore");
 
-    std::vector<LinkId> result;
-    std::set<LinkId> visited;
-    LinkId cursor = head;
+	std::vector<LinkId> result;
+	std::set<LinkId> visited;
+	LinkId cursor = head;
 
-    while (cursor != nil)
-    {
-        if (!visited.insert(cursor).second)
-            throw std::runtime_error("cycle detected in link list");
-        if (result.size() >= max_items)
-            throw std::runtime_error("link list exceeds configured limit");
+	while (cursor != nil)
+	{
+		if (!visited.insert(cursor).second)
+			throw std::runtime_error("cycle detected in link list");
+		if (result.size() >= max_items)
+			throw std::runtime_error("link list exceeds configured limit");
 
-        const Link cell = store.get(cursor);
-        result.push_back(cell.begin);
-        cursor = cell.end;
+		const Link cell = store.get(cursor);
+		result.push_back(cell.begin);
+		cursor = cell.end;
 
-        if (!store.contains(cursor))
-            throw std::runtime_error("link list tail references an unknown LinkId");
-    }
+		if (!store.contains(cursor))
+			throw std::runtime_error("link list tail references an unknown LinkId");
+	}
 
-    return result;
+	return result;
 }
 
 struct FunctionDefinition
 {
-    LinkId entity;
-    LinkId handle;
-    std::vector<LinkId> parameters;
-    LinkId body;
+	LinkId entity;
+	LinkId handle;
+	std::vector<LinkId> parameters;
+	LinkId body;
 };
 
-inline std::optional<FunctionDefinition> find_function_definition(
-    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId handle)
+inline std::optional<FunctionDefinition> find_function_definition(const LinkStore &store,
+                                                                  const BootstrapVocabulary &vocabulary, LinkId handle)
 {
-    if (!store.contains(handle))
-        return std::nullopt;
+	if (!store.contains(handle))
+		return std::nullopt;
 
-    std::optional<FunctionDefinition> found;
-    for (const LinkId candidate : store.outgoing(vocabulary.function_relation))
-    {
-        const RelationEntity decoded = decode_relation_entity(store, candidate);
-        if (decoded.relation != vocabulary.function_relation || decoded.subject != handle)
-            continue;
+	std::optional<FunctionDefinition> found;
+	for (const LinkId candidate : store.outgoing(vocabulary.function_relation))
+	{
+		const RelationEntity decoded = decode_relation_entity(store, candidate);
+		if (decoded.relation != vocabulary.function_relation || decoded.subject != handle)
+			continue;
 
-        const Link payload = store.get(decoded.object);
-        FunctionDefinition definition{
-            candidate,
-            handle,
-            decode_link_list(store, vocabulary.nil, payload.begin),
-            payload.end,
-        };
+		const Link payload = store.get(decoded.object);
+		FunctionDefinition definition{
+		    candidate,
+		    handle,
+		    decode_link_list(store, vocabulary.nil, payload.begin),
+		    payload.end,
+		};
 
-        if (found)
-            throw std::logic_error("multiple function definitions for one handle");
-        found = std::move(definition);
-    }
-    return found;
+		if (found)
+			throw std::logic_error("multiple function definitions for one handle");
+		found = std::move(definition);
+	}
+	return found;
 }
 
 struct CallExpression
 {
-    LinkId function;
-    std::vector<LinkId> arguments;
+	LinkId function;
+	std::vector<LinkId> arguments;
 };
 
-inline CallExpression decode_call_expression(
-    const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId entity)
+inline CallExpression decode_call_expression(const LinkStore &store, const BootstrapVocabulary &vocabulary,
+                                             LinkId entity)
 {
-    const RelationEntity decoded = decode_relation_entity(store, entity);
-    if (decoded.relation != vocabulary.call_relation || decoded.subject != vocabulary.unit)
-        throw std::invalid_argument("entity is not an AVM call expression");
+	const RelationEntity decoded = decode_relation_entity(store, entity);
+	if (decoded.relation != vocabulary.call_relation || decoded.subject != vocabulary.unit)
+		throw std::invalid_argument("entity is not an AVM call expression");
 
-    const Link payload = store.get(decoded.object);
-    return CallExpression{
-        payload.begin,
-        decode_link_list(store, vocabulary.nil, payload.end),
-    };
+	const Link payload = store.get(decoded.object);
+	return CallExpression{
+	    payload.begin,
+	    decode_link_list(store, vocabulary.nil, payload.end),
+	};
 }
 
 class ProgramBuilder
 {
 public:
-    ProgramBuilder(LinkStore &store, const BootstrapVocabulary &vocabulary)
-        : store_(store)
-        , vocabulary_(vocabulary)
-    {
-    }
+	ProgramBuilder(LinkStore &store, const BootstrapVocabulary &vocabulary) : store_(store), vocabulary_(vocabulary) {}
 
-    LinkId literal(LinkId value)
-    {
-        require(value, "literal value");
-        return expression(vocabulary_.quote_relation, value);
-    }
+	LinkId literal(LinkId value)
+	{
+		require(value, "literal value");
+		return expression(vocabulary_.quote_relation, value);
+	}
 
-    LinkId parameter(LinkId formal)
-    {
-        require(formal, "formal parameter");
-        return expression(vocabulary_.parameter_relation, formal);
-    }
+	LinkId parameter(LinkId formal)
+	{
+		require(formal, "formal parameter");
+		return expression(vocabulary_.parameter_relation, formal);
+	}
 
-    LinkId logical_not(LinkId argument)
-    {
-        require(argument, "NOT argument");
-        return expression(vocabulary_.not_relation, encode_link_list(store_, vocabulary_.nil, {argument}));
-    }
+	LinkId logical_not(LinkId argument)
+	{
+		require(argument, "NOT argument");
+		return expression(vocabulary_.not_relation, encode_link_list(store_, vocabulary_.nil, {argument}));
+	}
 
-    LinkId logical_and(LinkId left, LinkId right)
-    {
-        return binary(vocabulary_.and_relation, left, right);
-    }
+	LinkId logical_and(LinkId left, LinkId right) { return binary(vocabulary_.and_relation, left, right); }
 
-    LinkId logical_or(LinkId left, LinkId right)
-    {
-        return binary(vocabulary_.or_relation, left, right);
-    }
+	LinkId logical_or(LinkId left, LinkId right) { return binary(vocabulary_.or_relation, left, right); }
 
-    LinkId conditional(LinkId condition, LinkId then_branch, LinkId else_branch)
-    {
-        require(condition, "If condition");
-        require(then_branch, "If then branch");
-        require(else_branch, "If else branch");
-        return expression(
-            vocabulary_.if_relation,
-            encode_link_list(store_, vocabulary_.nil, {condition, then_branch, else_branch}));
-    }
+	LinkId conditional(LinkId condition, LinkId then_branch, LinkId else_branch)
+	{
+		require(condition, "If condition");
+		require(then_branch, "If then branch");
+		require(else_branch, "If else branch");
+		return expression(vocabulary_.if_relation,
+		                  encode_link_list(store_, vocabulary_.nil, {condition, then_branch, else_branch}));
+	}
 
-    LinkId sequence(const std::vector<LinkId> &expressions)
-    {
-        return expression(
-            vocabulary_.sequence_relation,
-            encode_link_list(store_, vocabulary_.nil, expressions));
-    }
+	LinkId sequence(const std::vector<LinkId> &expressions)
+	{
+		return expression(vocabulary_.sequence_relation, encode_link_list(store_, vocabulary_.nil, expressions));
+	}
 
-    LinkId create_function_handle()
-    {
-        return store_.create_point();
-    }
+	LinkId create_function_handle() { return store_.create_point(); }
 
-    LinkId define_function(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
-    {
-        require(handle, "function handle");
-        require(body, "function body");
-        for (const LinkId parameter_id : parameters)
-            require(parameter_id, "formal parameter");
+	LinkId define_function(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
+	{
+		require(handle, "function handle");
+		require(body, "function body");
+		for (const LinkId parameter_id : parameters)
+			require(parameter_id, "formal parameter");
 
-        const LinkId parameter_list = encode_link_list(store_, vocabulary_.nil, parameters);
-        const LinkId payload = store_.intern(parameter_list, body);
-        const RelationEntity source{vocabulary_.function_relation, handle, payload};
+		const LinkId parameter_list = encode_link_list(store_, vocabulary_.nil, parameters);
+		const LinkId payload = store_.intern(parameter_list, body);
+		const RelationEntity source{vocabulary_.function_relation, handle, payload};
 
-        if (const auto existing = find_function_definition(store_, vocabulary_, handle))
-        {
-            if (existing->parameters == parameters && existing->body == body)
-                return existing->entity;
-            throw std::logic_error("function handle already has a different definition");
-        }
+		if (const auto existing = find_function_definition(store_, vocabulary_, handle))
+		{
+			if (existing->parameters == parameters && existing->body == body)
+				return existing->entity;
+			throw std::logic_error("function handle already has a different definition");
+		}
 
-        return encode_relation_entity(store_, source);
-    }
+		return encode_relation_entity(store_, source);
+	}
 
-    LinkId call(LinkId function, const std::vector<LinkId> &arguments)
-    {
-        require(function, "function handle");
-        const LinkId argument_list = encode_link_list(store_, vocabulary_.nil, arguments);
-        const LinkId payload = store_.intern(function, argument_list);
-        return expression(vocabulary_.call_relation, payload);
-    }
+	LinkId call(LinkId function, const std::vector<LinkId> &arguments)
+	{
+		require(function, "function handle");
+		const LinkId argument_list = encode_link_list(store_, vocabulary_.nil, arguments);
+		const LinkId payload = store_.intern(function, argument_list);
+		return expression(vocabulary_.call_relation, payload);
+	}
 
 private:
-    LinkId expression(LinkId relation, LinkId object)
-    {
-        require(relation, "expression relation");
-        require(object, "expression object");
-        return encode_relation_entity(
-            store_, RelationEntity{relation, vocabulary_.unit, object});
-    }
+	LinkId expression(LinkId relation, LinkId object)
+	{
+		require(relation, "expression relation");
+		require(object, "expression object");
+		return encode_relation_entity(store_, RelationEntity{relation, vocabulary_.unit, object});
+	}
 
-    LinkId binary(LinkId relation, LinkId left, LinkId right)
-    {
-        require(left, "left argument");
-        require(right, "right argument");
-        return expression(
-            relation,
-            encode_link_list(store_, vocabulary_.nil, {left, right}));
-    }
+	LinkId binary(LinkId relation, LinkId left, LinkId right)
+	{
+		require(left, "left argument");
+		require(right, "right argument");
+		return expression(relation, encode_link_list(store_, vocabulary_.nil, {left, right}));
+	}
 
-    void require(LinkId id, const char *what) const
-    {
-        if (!store_.contains(id))
-            throw std::invalid_argument(std::string(what) + " is not present in LinkStore");
-    }
+	void require(LinkId id, const char *what) const
+	{
+		if (!store_.contains(id))
+			throw std::invalid_argument(std::string(what) + " is not present in LinkStore");
+	}
 
-    LinkStore &store_;
-    const BootstrapVocabulary &vocabulary_;
+	LinkStore &store_;
+	const BootstrapVocabulary &vocabulary_;
 };
 
 } // namespace avm

--- a/include/avm/relations_model.h
+++ b/include/avm/relations_model.h
@@ -9,11 +9,11 @@ namespace avm
 
 struct RelationEntity
 {
-    LinkId relation;
-    LinkId subject;
-    LinkId object;
+	LinkId relation;
+	LinkId subject;
+	LinkId object;
 
-    bool operator==(const RelationEntity &) const = default;
+	bool operator==(const RelationEntity &) const = default;
 };
 
 // Canonical Relations Model projection:
@@ -25,27 +25,27 @@ struct RelationEntity
 // so repeated encoding reuses the same canonical LinkIds.
 inline LinkId encode_relation_entity(LinkStore &store, const RelationEntity &entity)
 {
-    const LinkId subject_object = store.intern(entity.subject, entity.object);
-    return store.intern(entity.relation, subject_object);
+	const LinkId subject_object = store.intern(entity.subject, entity.object);
+	return store.intern(entity.relation, subject_object);
 }
 
 // Look up an already materialized Relations Model entity without creating the
 // inner subject-object dyad or the outer entity dyad.
 inline std::optional<LinkId> find_relation_entity(const LinkStore &store, const RelationEntity &entity)
 {
-    const auto subject_object = store.find(entity.subject, entity.object);
-    if (!subject_object)
-        return std::nullopt;
+	const auto subject_object = store.find(entity.subject, entity.object);
+	if (!subject_object)
+		return std::nullopt;
 
-    return store.find(entity.relation, *subject_object);
+	return store.find(entity.relation, *subject_object);
 }
 
 inline RelationEntity decode_relation_entity(const LinkStore &store, LinkId entity)
 {
-    const Link outer = store.get(entity);
-    const Link subject_object = store.get(outer.end);
+	const Link outer = store.get(entity);
+	const Link subject_object = store.get(outer.end);
 
-    return RelationEntity{outer.begin, subject_object.begin, subject_object.end};
+	return RelationEntity{outer.begin, subject_object.begin, subject_object.end};
 }
 
 } // namespace avm

--- a/test/assertions_enabled_test.cpp
+++ b/test/assertions_enabled_test.cpp
@@ -6,7 +6,7 @@
 
 int main()
 {
-    bool assertion_expression_evaluated = false;
-    assert((assertion_expression_evaluated = true));
-    return assertion_expression_evaluated ? 0 : 1;
+	bool assertion_expression_evaluated = false;
+	assert((assertion_expression_evaluated = true));
+	return assertion_expression_evaluated ? 0 : 1;
 }

--- a/test/boolean_runtime_test.cpp
+++ b/test/boolean_runtime_test.cpp
@@ -5,99 +5,99 @@
 
 int main()
 {
-    avm::InMemoryLinkStore store;
-    avm::BootstrapRuntime runtime(store);
-    avm::ProgramBuilder builder = runtime.builder();
-    const avm::BootstrapVocabulary &v = runtime.vocabulary();
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &v = runtime.vocabulary();
 
-    const avm::LinkId t = builder.literal(v.true_value);
-    const avm::LinkId f = builder.literal(v.false_value);
-    assert(runtime.execute(t) == v.true_value);
-    assert(runtime.execute(f) == v.false_value);
+	const avm::LinkId t = builder.literal(v.true_value);
+	const avm::LinkId f = builder.literal(v.false_value);
+	assert(runtime.execute(t) == v.true_value);
+	assert(runtime.execute(f) == v.false_value);
 
-    assert(runtime.execute(builder.logical_not(t)) == v.false_value);
-    assert(runtime.execute(builder.logical_not(f)) == v.true_value);
+	assert(runtime.execute(builder.logical_not(t)) == v.false_value);
+	assert(runtime.execute(builder.logical_not(f)) == v.true_value);
 
-    assert(runtime.execute(builder.logical_and(f, f)) == v.false_value);
-    assert(runtime.execute(builder.logical_and(f, t)) == v.false_value);
-    assert(runtime.execute(builder.logical_and(t, f)) == v.false_value);
-    assert(runtime.execute(builder.logical_and(t, t)) == v.true_value);
+	assert(runtime.execute(builder.logical_and(f, f)) == v.false_value);
+	assert(runtime.execute(builder.logical_and(f, t)) == v.false_value);
+	assert(runtime.execute(builder.logical_and(t, f)) == v.false_value);
+	assert(runtime.execute(builder.logical_and(t, t)) == v.true_value);
 
-    assert(runtime.execute(builder.logical_or(f, f)) == v.false_value);
-    assert(runtime.execute(builder.logical_or(f, t)) == v.true_value);
-    assert(runtime.execute(builder.logical_or(t, f)) == v.true_value);
-    assert(runtime.execute(builder.logical_or(t, t)) == v.true_value);
+	assert(runtime.execute(builder.logical_or(f, f)) == v.false_value);
+	assert(runtime.execute(builder.logical_or(f, t)) == v.true_value);
+	assert(runtime.execute(builder.logical_or(t, f)) == v.true_value);
+	assert(runtime.execute(builder.logical_or(t, t)) == v.true_value);
 
-    const avm::LinkId nested = builder.logical_not(builder.logical_and(t, f));
-    const std::size_t before_nested_execute = store.size();
-    assert(runtime.execute(nested) == v.true_value);
-    assert(store.size() == before_nested_execute);
+	const avm::LinkId nested = builder.logical_not(builder.logical_and(t, f));
+	const std::size_t before_nested_execute = store.size();
+	assert(runtime.execute(nested) == v.true_value);
+	assert(store.size() == before_nested_execute);
 
-    const avm::LinkId arbitrary_value = store.create_point();
-    const avm::LinkId invalid_not = builder.logical_not(builder.literal(arbitrary_value));
-    const std::size_t before_invalid_not = store.size();
-    bool invalid_boolean_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(invalid_not));
-    }
-    catch (const std::runtime_error &)
-    {
-        invalid_boolean_rejected = true;
-    }
-    assert(invalid_boolean_rejected);
-    assert(store.size() == before_invalid_not);
+	const avm::LinkId arbitrary_value = store.create_point();
+	const avm::LinkId invalid_not = builder.logical_not(builder.literal(arbitrary_value));
+	const std::size_t before_invalid_not = store.size();
+	bool invalid_boolean_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(invalid_not));
+	}
+	catch (const std::runtime_error &)
+	{
+		invalid_boolean_rejected = true;
+	}
+	assert(invalid_boolean_rejected);
+	assert(store.size() == before_invalid_not);
 
-    const avm::LinkId unknown_relation = store.create_point();
-    const avm::LinkId failing_branch = avm::encode_relation_entity(
-        store, avm::RelationEntity{unknown_relation, v.unit, v.false_value});
+	const avm::LinkId unknown_relation = store.create_point();
+	const avm::LinkId failing_branch =
+	    avm::encode_relation_entity(store, avm::RelationEntity{unknown_relation, v.unit, v.false_value});
 
-    const avm::LinkId lazy_true = builder.conditional(t, f, failing_branch);
-    assert(runtime.execute(lazy_true) == v.false_value);
+	const avm::LinkId lazy_true = builder.conditional(t, f, failing_branch);
+	assert(runtime.execute(lazy_true) == v.false_value);
 
-    const avm::LinkId lazy_false = builder.conditional(f, failing_branch, t);
-    assert(runtime.execute(lazy_false) == v.true_value);
+	const avm::LinkId lazy_false = builder.conditional(f, failing_branch, t);
+	assert(runtime.execute(lazy_false) == v.true_value);
 
-    const avm::LinkId selected_failure = builder.conditional(t, failing_branch, f);
-    bool selected_branch_executed = false;
-    try
-    {
-        static_cast<void>(runtime.execute(selected_failure));
-    }
-    catch (const std::runtime_error &)
-    {
-        selected_branch_executed = true;
-    }
-    assert(selected_branch_executed);
+	const avm::LinkId selected_failure = builder.conditional(t, failing_branch, f);
+	bool selected_branch_executed = false;
+	try
+	{
+		static_cast<void>(runtime.execute(selected_failure));
+	}
+	catch (const std::runtime_error &)
+	{
+		selected_branch_executed = true;
+	}
+	assert(selected_branch_executed);
 
-    const avm::LinkId invalid_condition = builder.conditional(builder.literal(arbitrary_value), t, f);
-    bool invalid_condition_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(invalid_condition));
-    }
-    catch (const std::runtime_error &)
-    {
-        invalid_condition_rejected = true;
-    }
-    assert(invalid_condition_rejected);
+	const avm::LinkId invalid_condition = builder.conditional(builder.literal(arbitrary_value), t, f);
+	bool invalid_condition_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(invalid_condition));
+	}
+	catch (const std::runtime_error &)
+	{
+		invalid_condition_rejected = true;
+	}
+	assert(invalid_condition_rejected);
 
-    const avm::LinkId sequence = builder.sequence({t, f, nested});
-    assert(runtime.execute(sequence) == v.true_value);
-    assert(runtime.execute(builder.sequence({})) == v.nil);
+	const avm::LinkId sequence = builder.sequence({t, f, nested});
+	assert(runtime.execute(sequence) == v.true_value);
+	assert(runtime.execute(builder.sequence({})) == v.nil);
 
-    const avm::LinkId malformed_not = avm::encode_relation_entity(
-        store, avm::RelationEntity{v.not_relation, v.unit, v.nil});
-    bool arity_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(malformed_not));
-    }
-    catch (const std::runtime_error &)
-    {
-        arity_rejected = true;
-    }
-    assert(arity_rejected);
+	const avm::LinkId malformed_not =
+	    avm::encode_relation_entity(store, avm::RelationEntity{v.not_relation, v.unit, v.nil});
+	bool arity_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(malformed_not));
+	}
+	catch (const std::runtime_error &)
+	{
+		arity_rejected = true;
+	}
+	assert(arity_rejected);
 
-    return 0;
+	return 0;
 }

--- a/test/executor_test.cpp
+++ b/test/executor_test.cpp
@@ -6,115 +6,106 @@
 
 int main()
 {
-    avm::InMemoryLinkStore store;
+	avm::InMemoryLinkStore store;
 
-    const avm::LinkId identity_relation = store.create_point();
-    const avm::LinkId subject_relation = store.create_point();
-    const avm::LinkId unknown_relation = store.create_point();
-    const avm::LinkId subject = store.create_point();
-    const avm::LinkId object = store.create_point();
+	const avm::LinkId identity_relation = store.create_point();
+	const avm::LinkId subject_relation = store.create_point();
+	const avm::LinkId unknown_relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
 
-    avm::Executor executor(store);
+	avm::Executor executor(store);
 
-    executor.register_native(
-        identity_relation,
-        [](const avm::ExecutionContext &context, avm::Executor &) {
-            return context.object;
-        });
+	executor.register_native(identity_relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &) { return context.object; });
 
-    executor.register_native(
-        subject_relation,
-        [subject](const avm::ExecutionContext &context, avm::Executor &) {
-            assert(context.subject == subject);
-            return context.subject;
-        });
+	executor.register_native(subject_relation,
+	                         [subject](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         assert(context.subject == subject);
+		                         return context.subject;
+	                         });
 
-    const avm::LinkId identity_entity = avm::encode_relation_entity(
-        store, avm::RelationEntity{identity_relation, subject, object});
+	const avm::LinkId identity_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{identity_relation, subject, object});
 
-    assert(executor.execute(identity_entity) == object);
+	assert(executor.execute(identity_entity) == object);
 
-    std::optional<avm::ExecutionContext> captured_context;
-    const avm::LinkId parent_relation = store.create_point();
-    executor.register_native(
-        parent_relation,
-        [&captured_context](const avm::ExecutionContext &context, avm::Executor &) {
-            captured_context = context;
-            return context.object;
-        });
+	std::optional<avm::ExecutionContext> captured_context;
+	const avm::LinkId parent_relation = store.create_point();
+	executor.register_native(parent_relation,
+	                         [&captured_context](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         captured_context = context;
+		                         return context.object;
+	                         });
 
-    const avm::LinkId parent_entity = avm::encode_relation_entity(
-        store, avm::RelationEntity{parent_relation, subject, object});
+	const avm::LinkId parent_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{parent_relation, subject, object});
 
-    assert(executor.execute(parent_entity, identity_entity) == object);
-    assert(captured_context.has_value());
-    assert(captured_context->entity == parent_entity);
-    assert(captured_context->relation == parent_relation);
-    assert(captured_context->subject == subject);
-    assert(captured_context->object == object);
-    assert(captured_context->parent == identity_entity);
-    assert(!captured_context->frame.has_value());
+	assert(executor.execute(parent_entity, identity_entity) == object);
+	assert(captured_context.has_value());
+	assert(captured_context->entity == parent_entity);
+	assert(captured_context->relation == parent_relation);
+	assert(captured_context->subject == subject);
+	assert(captured_context->object == object);
+	assert(captured_context->parent == identity_entity);
+	assert(!captured_context->frame.has_value());
 
-    const avm::LinkId frame = store.create_point();
-    assert(executor.execute(parent_entity, identity_entity, frame) == object);
-    assert(captured_context.has_value());
-    assert(captured_context->parent == identity_entity);
-    assert(captured_context->frame == frame);
+	const avm::LinkId frame = store.create_point();
+	assert(executor.execute(parent_entity, identity_entity, frame) == object);
+	assert(captured_context.has_value());
+	assert(captured_context->parent == identity_entity);
+	assert(captured_context->frame == frame);
 
-    const avm::LinkId subject_entity = avm::encode_relation_entity(
-        store, avm::RelationEntity{subject_relation, subject, object});
-    assert(executor.execute(subject_entity) == subject);
+	const avm::LinkId subject_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{subject_relation, subject, object});
+	assert(executor.execute(subject_entity) == subject);
 
-    const avm::LinkId unknown_entity = avm::encode_relation_entity(
-        store, avm::RelationEntity{unknown_relation, subject, object});
-    const std::size_t before_unknown_execute = store.size();
+	const avm::LinkId unknown_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{unknown_relation, subject, object});
+	const std::size_t before_unknown_execute = store.size();
 
-    bool unknown_rejected = false;
-    try
-    {
-        static_cast<void>(executor.execute(unknown_entity));
-    }
-    catch (const std::runtime_error &)
-    {
-        unknown_rejected = true;
-    }
-    assert(unknown_rejected);
-    assert(store.size() == before_unknown_execute);
+	bool unknown_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(unknown_entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		unknown_rejected = true;
+	}
+	assert(unknown_rejected);
+	assert(store.size() == before_unknown_execute);
 
-    bool duplicate_handler_rejected = false;
-    try
-    {
-        executor.register_native(
-            identity_relation,
-            [](const avm::ExecutionContext &context, avm::Executor &) {
-                return context.object;
-            });
-    }
-    catch (const std::logic_error &)
-    {
-        duplicate_handler_rejected = true;
-    }
-    assert(duplicate_handler_rejected);
+	bool duplicate_handler_rejected = false;
+	try
+	{
+		executor.register_native(identity_relation,
+		                         [](const avm::ExecutionContext &context, avm::Executor &) { return context.object; });
+	}
+	catch (const std::logic_error &)
+	{
+		duplicate_handler_rejected = true;
+	}
+	assert(duplicate_handler_rejected);
 
-    const avm::LinkId invalid_result_relation = store.create_point();
-    executor.register_native(
-        invalid_result_relation,
-        [](const avm::ExecutionContext &, avm::Executor &) {
-            return static_cast<avm::LinkId>(999999);
-        });
-    const avm::LinkId invalid_result_entity = avm::encode_relation_entity(
-        store, avm::RelationEntity{invalid_result_relation, subject, object});
+	const avm::LinkId invalid_result_relation = store.create_point();
+	executor.register_native(invalid_result_relation, [](const avm::ExecutionContext &, avm::Executor &)
+	                         { return static_cast<avm::LinkId>(999999); });
+	const avm::LinkId invalid_result_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{invalid_result_relation, subject, object});
 
-    bool invalid_result_rejected = false;
-    try
-    {
-        static_cast<void>(executor.execute(invalid_result_entity));
-    }
-    catch (const std::runtime_error &)
-    {
-        invalid_result_rejected = true;
-    }
-    assert(invalid_result_rejected);
+	bool invalid_result_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(invalid_result_entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		invalid_result_rejected = true;
+	}
+	assert(invalid_result_rejected);
 
-    return 0;
+	return 0;
 }

--- a/test/executor_test.cpp
+++ b/test/executor_test.cpp
@@ -53,6 +53,13 @@ int main()
     assert(captured_context->subject == subject);
     assert(captured_context->object == object);
     assert(captured_context->parent == identity_entity);
+    assert(!captured_context->frame.has_value());
+
+    const avm::LinkId frame = store.create_point();
+    assert(executor.execute(parent_entity, identity_entity, frame) == object);
+    assert(captured_context.has_value());
+    assert(captured_context->parent == identity_entity);
+    assert(captured_context->frame == frame);
 
     const avm::LinkId subject_entity = avm::encode_relation_entity(
         store, avm::RelationEntity{subject_relation, subject, object});

--- a/test/frame_runtime_test.cpp
+++ b/test/frame_runtime_test.cpp
@@ -6,133 +6,127 @@
 namespace
 {
 
-avm::LinkId find_frame_for_function(
-    const avm::LinkStore &store,
-    const avm::BootstrapVocabulary &vocabulary,
-    avm::LinkId function,
-    bool require_parent)
+avm::LinkId find_frame_for_function(const avm::LinkStore &store, const avm::BootstrapVocabulary &vocabulary,
+                                    avm::LinkId function, bool require_parent)
 {
-    for (const avm::LinkId candidate : store.outgoing(vocabulary.frame_relation))
-    {
-        if (candidate == vocabulary.frame_relation)
-            continue;
+	for (const avm::LinkId candidate : store.outgoing(vocabulary.frame_relation))
+	{
+		if (candidate == vocabulary.frame_relation)
+			continue;
 
-        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
-        if (row.relation != vocabulary.frame_relation)
-            continue;
+		const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+		if (row.relation != vocabulary.frame_relation)
+			continue;
 
-        const avm::DecodedCallFrame frame = avm::decode_call_frame(store, vocabulary, candidate);
-        if (frame.function != function)
-            continue;
-        if (require_parent && frame.parent == vocabulary.nil)
-            continue;
-        return candidate;
-    }
-    return avm::invalid_link_id;
+		const avm::DecodedCallFrame frame = avm::decode_call_frame(store, vocabulary, candidate);
+		if (frame.function != function)
+			continue;
+		if (require_parent && frame.parent == vocabulary.nil)
+			continue;
+		return candidate;
+	}
+	return avm::invalid_link_id;
 }
 
 } // namespace
 
 int main()
 {
-    avm::InMemoryLinkStore store;
-    avm::BootstrapRuntime runtime(store, 16);
-    avm::ProgramBuilder builder = runtime.builder();
-    const avm::BootstrapVocabulary &v = runtime.vocabulary();
-    const avm::LinkId t = builder.literal(v.true_value);
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store, 16);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &v = runtime.vocabulary();
+	const avm::LinkId t = builder.literal(v.true_value);
 
-    const avm::LinkId formal = store.create_point();
-    const avm::LinkId identity = builder.create_function_handle();
-    const avm::LinkId parameter = builder.parameter(formal);
-    builder.define_function(identity, {formal}, parameter);
-    assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId identity = builder.create_function_handle();
+	const avm::LinkId parameter = builder.parameter(formal);
+	builder.define_function(identity, {formal}, parameter);
+	assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
 
-    const avm::LinkId identity_frame_id = find_frame_for_function(store, v, identity, false);
-    assert(identity_frame_id != avm::invalid_link_id);
-    const avm::DecodedCallFrame identity_frame = avm::decode_call_frame(store, v, identity_frame_id);
-    assert(identity_frame.parent == v.nil);
-    assert(identity_frame.function == identity);
-    assert(identity_frame.bindings.size() == 1);
+	const avm::LinkId identity_frame_id = find_frame_for_function(store, v, identity, false);
+	assert(identity_frame_id != avm::invalid_link_id);
+	const avm::DecodedCallFrame identity_frame = avm::decode_call_frame(store, v, identity_frame_id);
+	assert(identity_frame.parent == v.nil);
+	assert(identity_frame.function == identity);
+	assert(identity_frame.bindings.size() == 1);
 
-    const avm::RelationEntity binding = avm::decode_relation_entity(store, identity_frame.bindings[0]);
-    assert(binding.relation == v.binding_relation);
-    assert(binding.subject == formal);
-    assert(binding.object == v.true_value);
-    assert(runtime.executor().execute(parameter, std::nullopt, identity_frame_id) == v.true_value);
+	const avm::RelationEntity binding = avm::decode_relation_entity(store, identity_frame.bindings[0]);
+	assert(binding.relation == v.binding_relation);
+	assert(binding.subject == formal);
+	assert(binding.object == v.true_value);
+	assert(runtime.executor().execute(parameter, std::nullopt, identity_frame_id) == v.true_value);
 
-    const avm::LinkId outer_formal = store.create_point();
-    const avm::LinkId inner_formal = store.create_point();
-    const avm::LinkId inner = builder.create_function_handle();
-    builder.define_function(inner, {inner_formal}, builder.parameter(inner_formal));
+	const avm::LinkId outer_formal = store.create_point();
+	const avm::LinkId inner_formal = store.create_point();
+	const avm::LinkId inner = builder.create_function_handle();
+	builder.define_function(inner, {inner_formal}, builder.parameter(inner_formal));
 
-    const avm::LinkId outer = builder.create_function_handle();
-    builder.define_function(
-        outer,
-        {outer_formal},
-        builder.call(inner, {builder.parameter(outer_formal)}));
-    assert(runtime.execute(builder.call(outer, {t})) == v.true_value);
+	const avm::LinkId outer = builder.create_function_handle();
+	builder.define_function(outer, {outer_formal}, builder.call(inner, {builder.parameter(outer_formal)}));
+	assert(runtime.execute(builder.call(outer, {t})) == v.true_value);
 
-    const avm::LinkId nested_frame_id = find_frame_for_function(store, v, inner, true);
-    assert(nested_frame_id != avm::invalid_link_id);
-    const avm::DecodedCallFrame nested_frame = avm::decode_call_frame(store, v, nested_frame_id);
-    assert(nested_frame.parent != v.nil);
-    const avm::DecodedCallFrame parent_frame = avm::decode_call_frame(store, v, nested_frame.parent);
-    assert(parent_frame.function == outer);
+	const avm::LinkId nested_frame_id = find_frame_for_function(store, v, inner, true);
+	assert(nested_frame_id != avm::invalid_link_id);
+	const avm::DecodedCallFrame nested_frame = avm::decode_call_frame(store, v, nested_frame_id);
+	assert(nested_frame.parent != v.nil);
+	const avm::DecodedCallFrame parent_frame = avm::decode_call_frame(store, v, nested_frame.parent);
+	assert(parent_frame.function == outer);
 
-    bool vocabulary_point_rejected = false;
-    try
-    {
-        static_cast<void>(avm::decode_call_frame(store, v, v.frame_relation));
-    }
-    catch (const std::runtime_error &)
-    {
-        vocabulary_point_rejected = true;
-    }
-    assert(vocabulary_point_rejected);
+	bool vocabulary_point_rejected = false;
+	try
+	{
+		static_cast<void>(avm::decode_call_frame(store, v, v.frame_relation));
+	}
+	catch (const std::runtime_error &)
+	{
+		vocabulary_point_rejected = true;
+	}
+	assert(vocabulary_point_rejected);
 
-    const avm::LinkId fake_binding = store.create_point();
-    const avm::LinkId bad_binding_list = avm::encode_link_list(store, v.nil, {fake_binding});
-    const avm::LinkId bad_binding_payload = store.intern(identity, bad_binding_list);
-    const avm::LinkId bad_binding_frame = avm::encode_relation_entity(
-        store, avm::RelationEntity{v.frame_relation, v.nil, bad_binding_payload});
-    bool non_binding_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.executor().execute(parameter, std::nullopt, bad_binding_frame));
-    }
-    catch (const std::runtime_error &)
-    {
-        non_binding_rejected = true;
-    }
-    assert(non_binding_rejected);
+	const avm::LinkId fake_binding = store.create_point();
+	const avm::LinkId bad_binding_list = avm::encode_link_list(store, v.nil, {fake_binding});
+	const avm::LinkId bad_binding_payload = store.intern(identity, bad_binding_list);
+	const avm::LinkId bad_binding_frame =
+	    avm::encode_relation_entity(store, avm::RelationEntity{v.frame_relation, v.nil, bad_binding_payload});
+	bool non_binding_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.executor().execute(parameter, std::nullopt, bad_binding_frame));
+	}
+	catch (const std::runtime_error &)
+	{
+		non_binding_rejected = true;
+	}
+	assert(non_binding_rejected);
 
-    const avm::LinkId invalid_parent = store.create_point();
-    const avm::LinkId empty_payload = store.intern(identity, v.nil);
-    const avm::LinkId invalid_parent_frame = avm::encode_relation_entity(
-        store, avm::RelationEntity{v.frame_relation, invalid_parent, empty_payload});
-    bool invalid_parent_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.executor().execute(parameter, std::nullopt, invalid_parent_frame));
-    }
-    catch (const std::runtime_error &)
-    {
-        invalid_parent_rejected = true;
-    }
-    assert(invalid_parent_rejected);
+	const avm::LinkId invalid_parent = store.create_point();
+	const avm::LinkId empty_payload = store.intern(identity, v.nil);
+	const avm::LinkId invalid_parent_frame =
+	    avm::encode_relation_entity(store, avm::RelationEntity{v.frame_relation, invalid_parent, empty_payload});
+	bool invalid_parent_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.executor().execute(parameter, std::nullopt, invalid_parent_frame));
+	}
+	catch (const std::runtime_error &)
+	{
+		invalid_parent_rejected = true;
+	}
+	assert(invalid_parent_rejected);
 
-    bool zero_depth_rejected = false;
-    try
-    {
-        avm::InMemoryLinkStore another_store;
-        avm::BootstrapRuntime invalid_runtime(another_store, 0);
-        static_cast<void>(invalid_runtime);
-    }
-    catch (const std::invalid_argument &)
-    {
-        zero_depth_rejected = true;
-    }
-    assert(zero_depth_rejected);
+	bool zero_depth_rejected = false;
+	try
+	{
+		avm::InMemoryLinkStore another_store;
+		avm::BootstrapRuntime invalid_runtime(another_store, 0);
+		static_cast<void>(invalid_runtime);
+	}
+	catch (const std::invalid_argument &)
+	{
+		zero_depth_rejected = true;
+	}
+	assert(zero_depth_rejected);
 
-    return 0;
+	return 0;
 }

--- a/test/frame_runtime_test.cpp
+++ b/test/frame_runtime_test.cpp
@@ -1,0 +1,138 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace
+{
+
+avm::LinkId find_frame_for_function(
+    const avm::LinkStore &store,
+    const avm::BootstrapVocabulary &vocabulary,
+    avm::LinkId function,
+    bool require_parent)
+{
+    for (const avm::LinkId candidate : store.outgoing(vocabulary.frame_relation))
+    {
+        if (candidate == vocabulary.frame_relation)
+            continue;
+
+        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+        if (row.relation != vocabulary.frame_relation)
+            continue;
+
+        const avm::DecodedCallFrame frame = avm::decode_call_frame(store, vocabulary, candidate);
+        if (frame.function != function)
+            continue;
+        if (require_parent && frame.parent == vocabulary.nil)
+            continue;
+        return candidate;
+    }
+    return avm::invalid_link_id;
+}
+
+} // namespace
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+    avm::BootstrapRuntime runtime(store, 16);
+    avm::ProgramBuilder builder = runtime.builder();
+    const avm::BootstrapVocabulary &v = runtime.vocabulary();
+    const avm::LinkId t = builder.literal(v.true_value);
+
+    const avm::LinkId formal = store.create_point();
+    const avm::LinkId identity = builder.create_function_handle();
+    const avm::LinkId parameter = builder.parameter(formal);
+    builder.define_function(identity, {formal}, parameter);
+    assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
+
+    const avm::LinkId identity_frame_id = find_frame_for_function(store, v, identity, false);
+    assert(identity_frame_id != avm::invalid_link_id);
+    const avm::DecodedCallFrame identity_frame = avm::decode_call_frame(store, v, identity_frame_id);
+    assert(identity_frame.parent == v.nil);
+    assert(identity_frame.function == identity);
+    assert(identity_frame.bindings.size() == 1);
+
+    const avm::RelationEntity binding = avm::decode_relation_entity(store, identity_frame.bindings[0]);
+    assert(binding.relation == v.binding_relation);
+    assert(binding.subject == formal);
+    assert(binding.object == v.true_value);
+    assert(runtime.executor().execute(parameter, std::nullopt, identity_frame_id) == v.true_value);
+
+    const avm::LinkId outer_formal = store.create_point();
+    const avm::LinkId inner_formal = store.create_point();
+    const avm::LinkId inner = builder.create_function_handle();
+    builder.define_function(inner, {inner_formal}, builder.parameter(inner_formal));
+
+    const avm::LinkId outer = builder.create_function_handle();
+    builder.define_function(
+        outer,
+        {outer_formal},
+        builder.call(inner, {builder.parameter(outer_formal)}));
+    assert(runtime.execute(builder.call(outer, {t})) == v.true_value);
+
+    const avm::LinkId nested_frame_id = find_frame_for_function(store, v, inner, true);
+    assert(nested_frame_id != avm::invalid_link_id);
+    const avm::DecodedCallFrame nested_frame = avm::decode_call_frame(store, v, nested_frame_id);
+    assert(nested_frame.parent != v.nil);
+    const avm::DecodedCallFrame parent_frame = avm::decode_call_frame(store, v, nested_frame.parent);
+    assert(parent_frame.function == outer);
+
+    bool vocabulary_point_rejected = false;
+    try
+    {
+        static_cast<void>(avm::decode_call_frame(store, v, v.frame_relation));
+    }
+    catch (const std::runtime_error &)
+    {
+        vocabulary_point_rejected = true;
+    }
+    assert(vocabulary_point_rejected);
+
+    const avm::LinkId fake_binding = store.create_point();
+    const avm::LinkId bad_binding_list = avm::encode_link_list(store, v.nil, {fake_binding});
+    const avm::LinkId bad_binding_payload = store.intern(identity, bad_binding_list);
+    const avm::LinkId bad_binding_frame = avm::encode_relation_entity(
+        store, avm::RelationEntity{v.frame_relation, v.nil, bad_binding_payload});
+    bool non_binding_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.executor().execute(parameter, std::nullopt, bad_binding_frame));
+    }
+    catch (const std::runtime_error &)
+    {
+        non_binding_rejected = true;
+    }
+    assert(non_binding_rejected);
+
+    const avm::LinkId invalid_parent = store.create_point();
+    const avm::LinkId empty_payload = store.intern(identity, v.nil);
+    const avm::LinkId invalid_parent_frame = avm::encode_relation_entity(
+        store, avm::RelationEntity{v.frame_relation, invalid_parent, empty_payload});
+    bool invalid_parent_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.executor().execute(parameter, std::nullopt, invalid_parent_frame));
+    }
+    catch (const std::runtime_error &)
+    {
+        invalid_parent_rejected = true;
+    }
+    assert(invalid_parent_rejected);
+
+    bool zero_depth_rejected = false;
+    try
+    {
+        avm::InMemoryLinkStore another_store;
+        avm::BootstrapRuntime invalid_runtime(another_store, 0);
+        static_cast<void>(invalid_runtime);
+    }
+    catch (const std::invalid_argument &)
+    {
+        zero_depth_rejected = true;
+    }
+    assert(zero_depth_rejected);
+
+    return 0;
+}

--- a/test/function_runtime_test.cpp
+++ b/test/function_runtime_test.cpp
@@ -39,6 +39,16 @@ int main()
     builder.define_function(outer, {outer_x}, builder.call(inner, {t}));
     assert(runtime.execute(builder.call(outer, {f})) == v.true_value);
 
+    const avm::LinkId shared_formal = store.create_point();
+    const avm::LinkId shadow_inner = builder.create_function_handle();
+    builder.define_function(shadow_inner, {shared_formal}, builder.parameter(shared_formal));
+    const avm::LinkId shadow_outer = builder.create_function_handle();
+    builder.define_function(
+        shadow_outer,
+        {shared_formal},
+        builder.call(shadow_inner, {f}));
+    assert(runtime.execute(builder.call(shadow_outer, {t})) == v.false_value);
+
     const avm::LinkId recurse_flag = store.create_point();
     const avm::LinkId finite_recursive = builder.create_function_handle();
     const avm::LinkId finite_body = builder.conditional(

--- a/test/function_runtime_test.cpp
+++ b/test/function_runtime_test.cpp
@@ -5,164 +5,155 @@
 
 int main()
 {
-    avm::InMemoryLinkStore store;
-    avm::BootstrapRuntime runtime(store, 8);
-    avm::ProgramBuilder builder = runtime.builder();
-    const avm::BootstrapVocabulary &v = runtime.vocabulary();
-    const avm::LinkId t = builder.literal(v.true_value);
-    const avm::LinkId f = builder.literal(v.false_value);
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store, 8);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &v = runtime.vocabulary();
+	const avm::LinkId t = builder.literal(v.true_value);
+	const avm::LinkId f = builder.literal(v.false_value);
 
-    const avm::LinkId x = store.create_point();
-    const avm::LinkId identity = builder.create_function_handle();
-    const avm::LinkId identity_body = builder.parameter(x);
-    const avm::LinkId identity_definition = builder.define_function(identity, {x}, identity_body);
-    assert(runtime.execute(identity_definition) == v.nil);
-    assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
-    assert(runtime.execute(builder.call(identity, {f})) == v.false_value);
+	const avm::LinkId x = store.create_point();
+	const avm::LinkId identity = builder.create_function_handle();
+	const avm::LinkId identity_body = builder.parameter(x);
+	const avm::LinkId identity_definition = builder.define_function(identity, {x}, identity_body);
+	assert(runtime.execute(identity_definition) == v.nil);
+	assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
+	assert(runtime.execute(builder.call(identity, {f})) == v.false_value);
 
-    const avm::LinkId a = store.create_point();
-    const avm::LinkId b = store.create_point();
-    const avm::LinkId conjunction = builder.create_function_handle();
-    builder.define_function(
-        conjunction,
-        {a, b},
-        builder.logical_and(builder.parameter(a), builder.parameter(b)));
-    assert(runtime.execute(builder.call(conjunction, {t, t})) == v.true_value);
-    assert(runtime.execute(builder.call(conjunction, {t, f})) == v.false_value);
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
+	const avm::LinkId conjunction = builder.create_function_handle();
+	builder.define_function(conjunction, {a, b}, builder.logical_and(builder.parameter(a), builder.parameter(b)));
+	assert(runtime.execute(builder.call(conjunction, {t, t})) == v.true_value);
+	assert(runtime.execute(builder.call(conjunction, {t, f})) == v.false_value);
 
-    const avm::LinkId inner_x = store.create_point();
-    const avm::LinkId inner = builder.create_function_handle();
-    builder.define_function(inner, {inner_x}, builder.parameter(inner_x));
+	const avm::LinkId inner_x = store.create_point();
+	const avm::LinkId inner = builder.create_function_handle();
+	builder.define_function(inner, {inner_x}, builder.parameter(inner_x));
 
-    const avm::LinkId outer_x = store.create_point();
-    const avm::LinkId outer = builder.create_function_handle();
-    builder.define_function(outer, {outer_x}, builder.call(inner, {t}));
-    assert(runtime.execute(builder.call(outer, {f})) == v.true_value);
+	const avm::LinkId outer_x = store.create_point();
+	const avm::LinkId outer = builder.create_function_handle();
+	builder.define_function(outer, {outer_x}, builder.call(inner, {t}));
+	assert(runtime.execute(builder.call(outer, {f})) == v.true_value);
 
-    const avm::LinkId shared_formal = store.create_point();
-    const avm::LinkId shadow_inner = builder.create_function_handle();
-    builder.define_function(shadow_inner, {shared_formal}, builder.parameter(shared_formal));
-    const avm::LinkId shadow_outer = builder.create_function_handle();
-    builder.define_function(
-        shadow_outer,
-        {shared_formal},
-        builder.call(shadow_inner, {f}));
-    assert(runtime.execute(builder.call(shadow_outer, {t})) == v.false_value);
+	const avm::LinkId shared_formal = store.create_point();
+	const avm::LinkId shadow_inner = builder.create_function_handle();
+	builder.define_function(shadow_inner, {shared_formal}, builder.parameter(shared_formal));
+	const avm::LinkId shadow_outer = builder.create_function_handle();
+	builder.define_function(shadow_outer, {shared_formal}, builder.call(shadow_inner, {f}));
+	assert(runtime.execute(builder.call(shadow_outer, {t})) == v.false_value);
 
-    const avm::LinkId recurse_flag = store.create_point();
-    const avm::LinkId finite_recursive = builder.create_function_handle();
-    const avm::LinkId finite_body = builder.conditional(
-        builder.parameter(recurse_flag),
-        builder.call(finite_recursive, {f}),
-        t);
-    builder.define_function(finite_recursive, {recurse_flag}, finite_body);
-    assert(runtime.execute(builder.call(finite_recursive, {t})) == v.true_value);
+	const avm::LinkId recurse_flag = store.create_point();
+	const avm::LinkId finite_recursive = builder.create_function_handle();
+	const avm::LinkId finite_body =
+	    builder.conditional(builder.parameter(recurse_flag), builder.call(finite_recursive, {f}), t);
+	builder.define_function(finite_recursive, {recurse_flag}, finite_body);
+	assert(runtime.execute(builder.call(finite_recursive, {t})) == v.true_value);
 
-    const avm::LinkId infinite_param = store.create_point();
-    const avm::LinkId infinite = builder.create_function_handle();
-    const avm::LinkId infinite_body = builder.call(infinite, {t});
-    builder.define_function(infinite, {infinite_param}, infinite_body);
-    bool depth_guard_triggered = false;
-    try
-    {
-        static_cast<void>(runtime.execute(builder.call(infinite, {t})));
-    }
-    catch (const std::runtime_error &)
-    {
-        depth_guard_triggered = true;
-    }
-    assert(depth_guard_triggered);
+	const avm::LinkId infinite_param = store.create_point();
+	const avm::LinkId infinite = builder.create_function_handle();
+	const avm::LinkId infinite_body = builder.call(infinite, {t});
+	builder.define_function(infinite, {infinite_param}, infinite_body);
+	bool depth_guard_triggered = false;
+	try
+	{
+		static_cast<void>(runtime.execute(builder.call(infinite, {t})));
+	}
+	catch (const std::runtime_error &)
+	{
+		depth_guard_triggered = true;
+	}
+	assert(depth_guard_triggered);
 
-    bool arity_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(builder.call(identity, {})));
-    }
-    catch (const std::runtime_error &)
-    {
-        arity_rejected = true;
-    }
-    assert(arity_rejected);
+	bool arity_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(builder.call(identity, {})));
+	}
+	catch (const std::runtime_error &)
+	{
+		arity_rejected = true;
+	}
+	assert(arity_rejected);
 
-    const avm::LinkId undefined_function = builder.create_function_handle();
-    bool undefined_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(builder.call(undefined_function, {t})));
-    }
-    catch (const std::runtime_error &)
-    {
-        undefined_rejected = true;
-    }
-    assert(undefined_rejected);
+	const avm::LinkId undefined_function = builder.create_function_handle();
+	bool undefined_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(builder.call(undefined_function, {t})));
+	}
+	catch (const std::runtime_error &)
+	{
+		undefined_rejected = true;
+	}
+	assert(undefined_rejected);
 
-    const avm::LinkId unbound_formal = store.create_point();
-    const avm::LinkId unbound_parameter = builder.parameter(unbound_formal);
-    bool unbound_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(unbound_parameter));
-    }
-    catch (const std::runtime_error &)
-    {
-        unbound_rejected = true;
-    }
-    assert(unbound_rejected);
+	const avm::LinkId unbound_formal = store.create_point();
+	const avm::LinkId unbound_parameter = builder.parameter(unbound_formal);
+	bool unbound_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(unbound_parameter));
+	}
+	catch (const std::runtime_error &)
+	{
+		unbound_rejected = true;
+	}
+	assert(unbound_rejected);
 
-    const avm::LinkId malformed_frame = store.create_point();
-    bool malformed_frame_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.executor().execute(unbound_parameter, std::nullopt, malformed_frame));
-    }
-    catch (const std::runtime_error &)
-    {
-        malformed_frame_rejected = true;
-    }
-    assert(malformed_frame_rejected);
+	const avm::LinkId malformed_frame = store.create_point();
+	bool malformed_frame_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.executor().execute(unbound_parameter, std::nullopt, malformed_frame));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_frame_rejected = true;
+	}
+	assert(malformed_frame_rejected);
 
-    const avm::LinkId malformed_handle = builder.create_function_handle();
-    const avm::LinkId malformed_payload = store.create_point();
-    avm::encode_relation_entity(
-        store, avm::RelationEntity{v.function_relation, malformed_handle, malformed_payload});
-    bool malformed_definition_rejected = false;
-    try
-    {
-        static_cast<void>(runtime.execute(builder.call(malformed_handle, {})));
-    }
-    catch (const std::runtime_error &)
-    {
-        malformed_definition_rejected = true;
-    }
-    assert(malformed_definition_rejected);
+	const avm::LinkId malformed_handle = builder.create_function_handle();
+	const avm::LinkId malformed_payload = store.create_point();
+	avm::encode_relation_entity(store, avm::RelationEntity{v.function_relation, malformed_handle, malformed_payload});
+	bool malformed_definition_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(builder.call(malformed_handle, {})));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_definition_rejected = true;
+	}
+	assert(malformed_definition_rejected);
 
-    const auto binding_candidates = store.outgoing(v.binding_relation);
-    const auto frame_candidates = store.outgoing(v.frame_relation);
-    assert(binding_candidates.size() > 1);
-    assert(frame_candidates.size() > 1);
+	const auto binding_candidates = store.outgoing(v.binding_relation);
+	const auto frame_candidates = store.outgoing(v.frame_relation);
+	assert(binding_candidates.size() > 1);
+	assert(frame_candidates.size() > 1);
 
-    bool saw_identity_binding = false;
-    for (const avm::LinkId candidate : binding_candidates)
-    {
-        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
-        if (row.relation == v.binding_relation && row.subject == x)
-            saw_identity_binding = true;
-    }
-    assert(saw_identity_binding);
+	bool saw_identity_binding = false;
+	for (const avm::LinkId candidate : binding_candidates)
+	{
+		const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+		if (row.relation == v.binding_relation && row.subject == x)
+			saw_identity_binding = true;
+	}
+	assert(saw_identity_binding);
 
-    bool saw_identity_frame = false;
-    for (const avm::LinkId candidate : frame_candidates)
-    {
-        if (candidate == v.frame_relation)
-            continue;
-        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
-        if (row.relation != v.frame_relation)
-            continue;
-        const avm::DecodedCallFrame frame = avm::decode_call_frame(store, v, candidate);
-        if (frame.function == identity)
-            saw_identity_frame = true;
-    }
-    assert(saw_identity_frame);
+	bool saw_identity_frame = false;
+	for (const avm::LinkId candidate : frame_candidates)
+	{
+		if (candidate == v.frame_relation)
+			continue;
+		const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+		if (row.relation != v.frame_relation)
+			continue;
+		const avm::DecodedCallFrame frame = avm::decode_call_frame(store, v, candidate);
+		if (frame.function == identity)
+			saw_identity_frame = true;
+	}
+	assert(saw_identity_frame);
 
-    return 0;
+	return 0;
 }

--- a/test/function_runtime_test.cpp
+++ b/test/function_runtime_test.cpp
@@ -1,0 +1,158 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+    avm::BootstrapRuntime runtime(store, 8);
+    avm::ProgramBuilder builder = runtime.builder();
+    const avm::BootstrapVocabulary &v = runtime.vocabulary();
+    const avm::LinkId t = builder.literal(v.true_value);
+    const avm::LinkId f = builder.literal(v.false_value);
+
+    const avm::LinkId x = store.create_point();
+    const avm::LinkId identity = builder.create_function_handle();
+    const avm::LinkId identity_body = builder.parameter(x);
+    const avm::LinkId identity_definition = builder.define_function(identity, {x}, identity_body);
+    assert(runtime.execute(identity_definition) == identity);
+    assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
+    assert(runtime.execute(builder.call(identity, {f})) == v.false_value);
+
+    const avm::LinkId a = store.create_point();
+    const avm::LinkId b = store.create_point();
+    const avm::LinkId conjunction = builder.create_function_handle();
+    builder.define_function(
+        conjunction,
+        {a, b},
+        builder.logical_and(builder.parameter(a), builder.parameter(b)));
+    assert(runtime.execute(builder.call(conjunction, {t, t})) == v.true_value);
+    assert(runtime.execute(builder.call(conjunction, {t, f})) == v.false_value);
+
+    const avm::LinkId inner_x = store.create_point();
+    const avm::LinkId inner = builder.create_function_handle();
+    builder.define_function(inner, {inner_x}, builder.parameter(inner_x));
+
+    const avm::LinkId outer_x = store.create_point();
+    const avm::LinkId outer = builder.create_function_handle();
+    builder.define_function(outer, {outer_x}, builder.call(inner, {t}));
+    assert(runtime.execute(builder.call(outer, {f})) == v.true_value);
+
+    const avm::LinkId recurse_flag = store.create_point();
+    const avm::LinkId finite_recursive = builder.create_function_handle();
+    const avm::LinkId finite_body = builder.conditional(
+        builder.parameter(recurse_flag),
+        builder.call(finite_recursive, {f}),
+        t);
+    builder.define_function(finite_recursive, {recurse_flag}, finite_body);
+    assert(runtime.execute(builder.call(finite_recursive, {t})) == v.true_value);
+
+    const avm::LinkId infinite_param = store.create_point();
+    const avm::LinkId infinite = builder.create_function_handle();
+    const avm::LinkId infinite_body = builder.call(infinite, {t});
+    builder.define_function(infinite, {infinite_param}, infinite_body);
+    bool depth_guard_triggered = false;
+    try
+    {
+        static_cast<void>(runtime.execute(builder.call(infinite, {t})));
+    }
+    catch (const std::runtime_error &)
+    {
+        depth_guard_triggered = true;
+    }
+    assert(depth_guard_triggered);
+
+    bool arity_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(builder.call(identity, {})));
+    }
+    catch (const std::runtime_error &)
+    {
+        arity_rejected = true;
+    }
+    assert(arity_rejected);
+
+    const avm::LinkId undefined_function = builder.create_function_handle();
+    bool undefined_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(builder.call(undefined_function, {t})));
+    }
+    catch (const std::runtime_error &)
+    {
+        undefined_rejected = true;
+    }
+    assert(undefined_rejected);
+
+    const avm::LinkId unbound_formal = store.create_point();
+    const avm::LinkId unbound_parameter = builder.parameter(unbound_formal);
+    bool unbound_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(unbound_parameter));
+    }
+    catch (const std::runtime_error &)
+    {
+        unbound_rejected = true;
+    }
+    assert(unbound_rejected);
+
+    const avm::LinkId malformed_frame = store.create_point();
+    bool malformed_frame_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.executor().execute(unbound_parameter, std::nullopt, malformed_frame));
+    }
+    catch (const std::runtime_error &)
+    {
+        malformed_frame_rejected = true;
+    }
+    assert(malformed_frame_rejected);
+
+    const avm::LinkId malformed_handle = builder.create_function_handle();
+    const avm::LinkId malformed_payload = store.create_point();
+    avm::encode_relation_entity(
+        store, avm::RelationEntity{v.function_relation, malformed_handle, malformed_payload});
+    bool malformed_definition_rejected = false;
+    try
+    {
+        static_cast<void>(runtime.execute(builder.call(malformed_handle, {})));
+    }
+    catch (const std::runtime_error &)
+    {
+        malformed_definition_rejected = true;
+    }
+    assert(malformed_definition_rejected);
+
+    const auto binding_candidates = store.outgoing(v.binding_relation);
+    const auto frame_candidates = store.outgoing(v.frame_relation);
+    assert(binding_candidates.size() > 1);
+    assert(frame_candidates.size() > 1);
+
+    bool saw_identity_binding = false;
+    for (const avm::LinkId candidate : binding_candidates)
+    {
+        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+        if (row.relation == v.binding_relation && row.subject == x)
+            saw_identity_binding = true;
+    }
+    assert(saw_identity_binding);
+
+    bool saw_identity_frame = false;
+    for (const avm::LinkId candidate : frame_candidates)
+    {
+        if (candidate == v.frame_relation)
+            continue;
+        const avm::RelationEntity row = avm::decode_relation_entity(store, candidate);
+        if (row.relation != v.frame_relation)
+            continue;
+        const avm::DecodedCallFrame frame = avm::decode_call_frame(store, v, candidate);
+        if (frame.function == identity)
+            saw_identity_frame = true;
+    }
+    assert(saw_identity_frame);
+
+    return 0;
+}

--- a/test/function_runtime_test.cpp
+++ b/test/function_runtime_test.cpp
@@ -16,7 +16,7 @@ int main()
     const avm::LinkId identity = builder.create_function_handle();
     const avm::LinkId identity_body = builder.parameter(x);
     const avm::LinkId identity_definition = builder.define_function(identity, {x}, identity_body);
-    assert(runtime.execute(identity_definition) == identity);
+    assert(runtime.execute(identity_definition) == v.nil);
     assert(runtime.execute(builder.call(identity, {t})) == v.true_value);
     assert(runtime.execute(builder.call(identity, {f})) == v.false_value);
 

--- a/test/link_store_test.cpp
+++ b/test/link_store_test.cpp
@@ -9,66 +9,66 @@ namespace
 
 bool contains_id(const std::vector<avm::LinkId> &ids, avm::LinkId id)
 {
-    return std::find(ids.begin(), ids.end(), id) != ids.end();
+	return std::find(ids.begin(), ids.end(), id) != ids.end();
 }
 
 } // namespace
 
 int main()
 {
-    avm::InMemoryLinkStore store;
+	avm::InMemoryLinkStore store;
 
-    assert(store.size() == 0);
+	assert(store.size() == 0);
 
-    const avm::LinkId a = store.create_point();
-    const avm::LinkId b = store.create_point();
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
 
-    assert(a != avm::invalid_link_id);
-    assert(b != avm::invalid_link_id);
-    assert(a != b);
-    assert(store.get(a) == (avm::Link{a, a}));
-    assert(store.get(b) == (avm::Link{b, b}));
-    assert(store.find(a, a) == a);
-    assert(store.find(b, b) == b);
+	assert(a != avm::invalid_link_id);
+	assert(b != avm::invalid_link_id);
+	assert(a != b);
+	assert(store.get(a) == (avm::Link{a, a}));
+	assert(store.get(b) == (avm::Link{b, b}));
+	assert(store.find(a, a) == a);
+	assert(store.find(b, b) == b);
 
-    const std::size_t before_find = store.size();
-    assert(!store.find(a, b).has_value());
-    assert(store.size() == before_find);
+	const std::size_t before_find = store.size();
+	assert(!store.find(a, b).has_value());
+	assert(store.size() == before_find);
 
-    const avm::LinkId ab = store.intern(a, b);
-    assert(store.get(ab) == (avm::Link{a, b}));
-    assert(store.find(a, b) == ab);
+	const avm::LinkId ab = store.intern(a, b);
+	assert(store.get(ab) == (avm::Link{a, b}));
+	assert(store.find(a, b) == ab);
 
-    const std::size_t before_reintern = store.size();
-    assert(store.intern(a, b) == ab);
-    assert(store.size() == before_reintern);
+	const std::size_t before_reintern = store.size();
+	assert(store.intern(a, b) == ab);
+	assert(store.size() == before_reintern);
 
-    assert(contains_id(store.outgoing(a), a));
-    assert(contains_id(store.outgoing(a), ab));
-    assert(contains_id(store.incoming(b), b));
-    assert(contains_id(store.incoming(b), ab));
+	assert(contains_id(store.outgoing(a), a));
+	assert(contains_id(store.outgoing(a), ab));
+	assert(contains_id(store.incoming(b), b));
+	assert(contains_id(store.incoming(b), ab));
 
-    bool invalid_endpoint_rejected = false;
-    try
-    {
-        static_cast<void>(store.intern(a, 999999));
-    }
-    catch (const std::invalid_argument &)
-    {
-        invalid_endpoint_rejected = true;
-    }
-    assert(invalid_endpoint_rejected);
+	bool invalid_endpoint_rejected = false;
+	try
+	{
+		static_cast<void>(store.intern(a, 999999));
+	}
+	catch (const std::invalid_argument &)
+	{
+		invalid_endpoint_rejected = true;
+	}
+	assert(invalid_endpoint_rejected);
 
-    bool invalid_get_rejected = false;
-    try
-    {
-        static_cast<void>(store.get(999999));
-    }
-    catch (const std::out_of_range &)
-    {
-        invalid_get_rejected = true;
-    }
-    assert(invalid_get_rejected);
+	bool invalid_get_rejected = false;
+	try
+	{
+		static_cast<void>(store.get(999999));
+	}
+	catch (const std::out_of_range &)
+	{
+		invalid_get_rejected = true;
+	}
+	assert(invalid_get_rejected);
 
-    return 0;
+	return 0;
 }

--- a/test/program_model_test.cpp
+++ b/test/program_model_test.cpp
@@ -6,128 +6,128 @@
 
 int main()
 {
-    avm::InMemoryLinkStore store;
-    const avm::BootstrapVocabulary vocabulary = avm::BootstrapVocabulary::create(store);
-    avm::ProgramBuilder builder(store, vocabulary);
+	avm::InMemoryLinkStore store;
+	const avm::BootstrapVocabulary vocabulary = avm::BootstrapVocabulary::create(store);
+	avm::ProgramBuilder builder(store, vocabulary);
 
-    const std::vector<avm::LinkId> vocabulary_ids{
-        vocabulary.unit,
-        vocabulary.nil,
-        vocabulary.true_value,
-        vocabulary.false_value,
-        vocabulary.quote_relation,
-        vocabulary.parameter_relation,
-        vocabulary.sequence_relation,
-        vocabulary.not_relation,
-        vocabulary.and_relation,
-        vocabulary.or_relation,
-        vocabulary.if_relation,
-        vocabulary.function_relation,
-        vocabulary.call_relation,
-        vocabulary.binding_relation,
-        vocabulary.frame_relation,
-    };
-    for (const avm::LinkId id : vocabulary_ids)
-    {
-        assert(store.contains(id));
-        assert(store.get(id) == (avm::Link{id, id}));
-    }
+	const std::vector<avm::LinkId> vocabulary_ids{
+	    vocabulary.unit,
+	    vocabulary.nil,
+	    vocabulary.true_value,
+	    vocabulary.false_value,
+	    vocabulary.quote_relation,
+	    vocabulary.parameter_relation,
+	    vocabulary.sequence_relation,
+	    vocabulary.not_relation,
+	    vocabulary.and_relation,
+	    vocabulary.or_relation,
+	    vocabulary.if_relation,
+	    vocabulary.function_relation,
+	    vocabulary.call_relation,
+	    vocabulary.binding_relation,
+	    vocabulary.frame_relation,
+	};
+	for (const avm::LinkId id : vocabulary_ids)
+	{
+		assert(store.contains(id));
+		assert(store.get(id) == (avm::Link{id, id}));
+	}
 
-    assert(avm::encode_link_list(store, vocabulary.nil, {}) == vocabulary.nil);
-    assert(avm::decode_link_list(store, vocabulary.nil, vocabulary.nil).empty());
+	assert(avm::encode_link_list(store, vocabulary.nil, {}) == vocabulary.nil);
+	assert(avm::decode_link_list(store, vocabulary.nil, vocabulary.nil).empty());
 
-    const avm::LinkId a = store.create_point();
-    const avm::LinkId b = store.create_point();
-    const avm::LinkId c = store.create_point();
-    const std::vector<avm::LinkId> abc{a, b, c};
-    const avm::LinkId abc_list = avm::encode_link_list(store, vocabulary.nil, abc);
-    assert(avm::decode_link_list(store, vocabulary.nil, abc_list) == abc);
-    const std::size_t before_list_reencode = store.size();
-    assert(avm::encode_link_list(store, vocabulary.nil, abc) == abc_list);
-    assert(store.size() == before_list_reencode);
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
+	const avm::LinkId c = store.create_point();
+	const std::vector<avm::LinkId> abc{a, b, c};
+	const avm::LinkId abc_list = avm::encode_link_list(store, vocabulary.nil, abc);
+	assert(avm::decode_link_list(store, vocabulary.nil, abc_list) == abc);
+	const std::size_t before_list_reencode = store.size();
+	assert(avm::encode_link_list(store, vocabulary.nil, abc) == abc_list);
+	assert(store.size() == before_list_reencode);
 
-    bool cycle_rejected = false;
-    try
-    {
-        static_cast<void>(avm::decode_link_list(store, vocabulary.nil, a));
-    }
-    catch (const std::runtime_error &)
-    {
-        cycle_rejected = true;
-    }
-    assert(cycle_rejected);
+	bool cycle_rejected = false;
+	try
+	{
+		static_cast<void>(avm::decode_link_list(store, vocabulary.nil, a));
+	}
+	catch (const std::runtime_error &)
+	{
+		cycle_rejected = true;
+	}
+	assert(cycle_rejected);
 
-    const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
-    const std::size_t before_literal_rebuild = store.size();
-    assert(builder.literal(vocabulary.true_value) == true_literal);
-    assert(store.size() == before_literal_rebuild);
-    assert(avm::decode_relation_entity(store, true_literal) ==
-           (avm::RelationEntity{vocabulary.quote_relation, vocabulary.unit, vocabulary.true_value}));
+	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	const std::size_t before_literal_rebuild = store.size();
+	assert(builder.literal(vocabulary.true_value) == true_literal);
+	assert(store.size() == before_literal_rebuild);
+	assert(avm::decode_relation_entity(store, true_literal) ==
+	       (avm::RelationEntity{vocabulary.quote_relation, vocabulary.unit, vocabulary.true_value}));
 
-    const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
-    const avm::LinkId nested = builder.logical_not(builder.logical_and(true_literal, false_literal));
-    const avm::RelationEntity nested_decoded = avm::decode_relation_entity(store, nested);
-    assert(nested_decoded.relation == vocabulary.not_relation);
-    assert(nested_decoded.subject == vocabulary.unit);
-    const auto nested_args = avm::decode_link_list(store, vocabulary.nil, nested_decoded.object);
-    assert(nested_args.size() == 1);
+	const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
+	const avm::LinkId nested = builder.logical_not(builder.logical_and(true_literal, false_literal));
+	const avm::RelationEntity nested_decoded = avm::decode_relation_entity(store, nested);
+	assert(nested_decoded.relation == vocabulary.not_relation);
+	assert(nested_decoded.subject == vocabulary.unit);
+	const auto nested_args = avm::decode_link_list(store, vocabulary.nil, nested_decoded.object);
+	assert(nested_args.size() == 1);
 
-    const avm::LinkId if_expression = builder.conditional(true_literal, nested, false_literal);
-    const auto if_decoded = avm::decode_relation_entity(store, if_expression);
-    assert(if_decoded.relation == vocabulary.if_relation);
-    assert(avm::decode_link_list(store, vocabulary.nil, if_decoded.object) ==
-           (std::vector<avm::LinkId>{true_literal, nested, false_literal}));
+	const avm::LinkId if_expression = builder.conditional(true_literal, nested, false_literal);
+	const auto if_decoded = avm::decode_relation_entity(store, if_expression);
+	assert(if_decoded.relation == vocabulary.if_relation);
+	assert(avm::decode_link_list(store, vocabulary.nil, if_decoded.object) ==
+	       (std::vector<avm::LinkId>{true_literal, nested, false_literal}));
 
-    const avm::LinkId formal = store.create_point();
-    const avm::LinkId parameter_expression = builder.parameter(formal);
-    assert(avm::decode_relation_entity(store, parameter_expression) ==
-           (avm::RelationEntity{vocabulary.parameter_relation, vocabulary.unit, formal}));
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId parameter_expression = builder.parameter(formal);
+	assert(avm::decode_relation_entity(store, parameter_expression) ==
+	       (avm::RelationEntity{vocabulary.parameter_relation, vocabulary.unit, formal}));
 
-    const avm::LinkId function = builder.create_function_handle();
-    const avm::LinkId definition = builder.define_function(function, {formal}, parameter_expression);
-    const auto found = avm::find_function_definition(store, vocabulary, function);
-    assert(found.has_value());
-    assert(found->entity == definition);
-    assert(found->handle == function);
-    assert(found->parameters == (std::vector<avm::LinkId>{formal}));
-    assert(found->body == parameter_expression);
+	const avm::LinkId function = builder.create_function_handle();
+	const avm::LinkId definition = builder.define_function(function, {formal}, parameter_expression);
+	const auto found = avm::find_function_definition(store, vocabulary, function);
+	assert(found.has_value());
+	assert(found->entity == definition);
+	assert(found->handle == function);
+	assert(found->parameters == (std::vector<avm::LinkId>{formal}));
+	assert(found->body == parameter_expression);
 
-    const std::size_t before_definition_rebuild = store.size();
-    assert(builder.define_function(function, {formal}, parameter_expression) == definition);
-    assert(store.size() == before_definition_rebuild);
+	const std::size_t before_definition_rebuild = store.size();
+	assert(builder.define_function(function, {formal}, parameter_expression) == definition);
+	assert(store.size() == before_definition_rebuild);
 
-    bool conflicting_definition_rejected = false;
-    try
-    {
-        static_cast<void>(builder.define_function(function, {}, false_literal));
-    }
-    catch (const std::logic_error &)
-    {
-        conflicting_definition_rejected = true;
-    }
-    assert(conflicting_definition_rejected);
+	bool conflicting_definition_rejected = false;
+	try
+	{
+		static_cast<void>(builder.define_function(function, {}, false_literal));
+	}
+	catch (const std::logic_error &)
+	{
+		conflicting_definition_rejected = true;
+	}
+	assert(conflicting_definition_rejected);
 
-    const avm::LinkId call = builder.call(function, {true_literal});
-    const avm::CallExpression decoded_call = avm::decode_call_expression(store, vocabulary, call);
-    assert(decoded_call.function == function);
-    assert(decoded_call.arguments == (std::vector<avm::LinkId>{true_literal}));
+	const avm::LinkId call = builder.call(function, {true_literal});
+	const avm::CallExpression decoded_call = avm::decode_call_expression(store, vocabulary, call);
+	assert(decoded_call.function == function);
+	assert(decoded_call.arguments == (std::vector<avm::LinkId>{true_literal}));
 
-    const avm::LinkId sequence = builder.sequence({definition, call});
-    const avm::RelationEntity sequence_decoded = avm::decode_relation_entity(store, sequence);
-    assert(sequence_decoded.relation == vocabulary.sequence_relation);
-    assert(avm::decode_link_list(store, vocabulary.nil, sequence_decoded.object) ==
-           (std::vector<avm::LinkId>{definition, call}));
+	const avm::LinkId sequence = builder.sequence({definition, call});
+	const avm::RelationEntity sequence_decoded = avm::decode_relation_entity(store, sequence);
+	assert(sequence_decoded.relation == vocabulary.sequence_relation);
+	assert(avm::decode_link_list(store, vocabulary.nil, sequence_decoded.object) ==
+	       (std::vector<avm::LinkId>{definition, call}));
 
-    bool unknown_value_rejected = false;
-    try
-    {
-        static_cast<void>(builder.literal(999999));
-    }
-    catch (const std::invalid_argument &)
-    {
-        unknown_value_rejected = true;
-    }
-    assert(unknown_value_rejected);
+	bool unknown_value_rejected = false;
+	try
+	{
+		static_cast<void>(builder.literal(999999));
+	}
+	catch (const std::invalid_argument &)
+	{
+		unknown_value_rejected = true;
+	}
+	assert(unknown_value_rejected);
 
-    return 0;
+	return 0;
 }

--- a/test/relations_model_test.cpp
+++ b/test/relations_model_test.cpp
@@ -4,53 +4,53 @@
 
 int main()
 {
-    avm::InMemoryLinkStore store;
+	avm::InMemoryLinkStore store;
 
-    const avm::LinkId relation = store.create_point();
-    const avm::LinkId relation2 = store.create_point();
-    const avm::LinkId subject = store.create_point();
-    const avm::LinkId object = store.create_point();
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId relation2 = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
 
-    const avm::RelationEntity source{relation, subject, object};
+	const avm::RelationEntity source{relation, subject, object};
 
-    // A lookup for an absent triplet must not even create its inner (subject, object) dyad.
-    const std::size_t before_find = store.size();
-    assert(!avm::find_relation_entity(store, source).has_value());
-    assert(store.size() == before_find);
-    assert(!store.find(subject, object).has_value());
+	// A lookup for an absent triplet must not even create its inner (subject, object) dyad.
+	const std::size_t before_find = store.size();
+	assert(!avm::find_relation_entity(store, source).has_value());
+	assert(store.size() == before_find);
+	assert(!store.find(subject, object).has_value());
 
-    // The same rule holds when the inner dyad already exists but the outer entity does not.
-    const avm::LinkId subject_object_preexisting = store.intern(subject, object);
-    const std::size_t before_outer_find = store.size();
-    assert(!avm::find_relation_entity(store, source).has_value());
-    assert(store.size() == before_outer_find);
+	// The same rule holds when the inner dyad already exists but the outer entity does not.
+	const avm::LinkId subject_object_preexisting = store.intern(subject, object);
+	const std::size_t before_outer_find = store.size();
+	assert(!avm::find_relation_entity(store, source).has_value());
+	assert(store.size() == before_outer_find);
 
-    const avm::LinkId encoded = avm::encode_relation_entity(store, source);
-    assert(avm::decode_relation_entity(store, encoded) == source);
-    assert(avm::find_relation_entity(store, source) == encoded);
+	const avm::LinkId encoded = avm::encode_relation_entity(store, source);
+	assert(avm::decode_relation_entity(store, encoded) == source);
+	assert(avm::find_relation_entity(store, source) == encoded);
 
-    const auto subject_object = store.find(subject, object);
-    assert(subject_object == subject_object_preexisting);
-    assert(store.get(encoded) == (avm::Link{relation, *subject_object}));
+	const auto subject_object = store.find(subject, object);
+	assert(subject_object == subject_object_preexisting);
+	assert(store.get(encoded) == (avm::Link{relation, *subject_object}));
 
-    const std::size_t before_reencode = store.size();
-    assert(avm::encode_relation_entity(store, source) == encoded);
-    assert(store.size() == before_reencode);
+	const std::size_t before_reencode = store.size();
+	assert(avm::encode_relation_entity(store, source) == encoded);
+	assert(store.size() == before_reencode);
 
-    const avm::RelationEntity same_so_other_relation{relation2, subject, object};
-    const avm::LinkId encoded2 = avm::encode_relation_entity(store, same_so_other_relation);
-    assert(encoded2 != encoded);
-    assert(store.find(subject, object) == subject_object);
-    assert(avm::decode_relation_entity(store, encoded2) == same_so_other_relation);
+	const avm::RelationEntity same_so_other_relation{relation2, subject, object};
+	const avm::LinkId encoded2 = avm::encode_relation_entity(store, same_so_other_relation);
+	assert(encoded2 != encoded);
+	assert(store.find(subject, object) == subject_object);
+	assert(avm::decode_relation_entity(store, encoded2) == same_so_other_relation);
 
-    const avm::RelationEntity self{subject, subject, subject};
-    const avm::LinkId self_encoded = avm::encode_relation_entity(store, self);
-    assert(self_encoded == subject);
-    assert(avm::decode_relation_entity(store, self_encoded) == self);
+	const avm::RelationEntity self{subject, subject, subject};
+	const avm::LinkId self_encoded = avm::encode_relation_entity(store, self);
+	assert(self_encoded == subject);
+	assert(avm::decode_relation_entity(store, self_encoded) == self);
 
-    const avm::RelationEntity nested{encoded, encoded2, self_encoded};
-    const avm::LinkId nested_encoded = avm::encode_relation_entity(store, nested);
-    assert(avm::decode_relation_entity(store, nested_encoded) == nested);
+	const avm::RelationEntity nested{encoded, encoded2, self_encoded};
+	const avm::LinkId nested_encoded = avm::encode_relation_entity(store, nested);
+	assert(avm::decode_relation_entity(store, nested_encoded) == nested);
 
-    return 0;
+	return 0;
 }


### PR DESCRIPTION
Closes #37. Parent #25 / Epic #31.

## What changed
- extended `ExecutionContext` with an explicit frame LinkId and propagated it through recursive execution;
- represented each formal→actual binding as `(binding_relation, formal, actualValue)` in `LinkStore`;
- represented each call frame as `(frame_relation, parentFrameOrNil, Link(functionHandle, bindingList))`;
- parameter lookup now walks link-native frame/binding structures instead of a C++ parameter stack;
- implemented function calls, arity validation, nested calls, recursion and a frame-chain depth guard;
- kept recursive function identity via pre-existing function handles;
- added explicit rejection of the `frame_relation` vocabulary self-link as a frame instance;
- function-definition execution validates the stored definition and returns `nil`, keeping the runtime neutral for the upcoming JSON compatibility importer.

## Test coverage
The core now has 8 independent suites. Locally both strict Debug (`-Wall -Wextra -Wpedantic -Werror`) and ASan+UBSan pass 8/8.

New coverage includes:
- identity and two-parameter functions;
- Boolean expressions in function bodies;
- nested calls;
- same-formal LinkId shadowing across parent/child frames;
- finite recursion;
- unbounded recursion hitting the depth guard;
- arity mismatch and undefined functions;
- unbound parameters;
- malformed function definitions and frames;
- frame vocabulary self-link rejection;
- malformed binding rows and invalid parent frames;
- physical inspection of binding/frame entities in `LinkStore`;
- executor frame propagation.

The new runtime remains independent of JSON and the legacy LinksPlatform path.