### PR TITLE
AVM 1.0: preserve Def/Call order with deferred definitions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/function_runtime_test.cpp \
-            test/frame_runtime_test.cpp
+            test/frame_runtime_test.cpp \
+            test/deferred_definition_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   quality:
     name: Quality gates
@@ -32,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -54,6 +59,24 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
+
+      - name: One-time format deferred-definition changes
+        if: github.head_ref == 'agent/deferred-definitions'
+        shell: bash
+        run: |
+          set -euo pipefail
+          clang-format -i \
+            include/avm/program_model.h \
+            include/avm/bootstrap_runtime.h \
+            test/deferred_definition_test.cpp
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add include/avm/program_model.h include/avm/bootstrap_runtime.h test/deferred_definition_test.cpp
+          git commit -m "style: clang-format deferred definitions"
+          git push origin HEAD:${{ github.head_ref }}
 
       - name: Check AVM 1.0 core formatting
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   quality:
     name: Quality gates
@@ -35,8 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -59,24 +54,6 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
-
-      - name: One-time format deferred-definition changes
-        if: github.head_ref == 'agent/deferred-definitions'
-        shell: bash
-        run: |
-          set -euo pipefail
-          clang-format -i \
-            include/avm/program_model.h \
-            include/avm/bootstrap_runtime.h \
-            test/deferred_definition_test.cpp
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add include/avm/program_model.h include/avm/bootstrap_runtime.h test/deferred_definition_test.cpp
-          git commit -m "style: clang-format deferred definitions"
-          git push origin HEAD:${{ github.head_ref }}
 
       - name: Check AVM 1.0 core formatting
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,11 @@ if(AVM_BUILD_CORE_TESTS)
         test/frame_runtime_test.cpp
         frame_runtime_tests)
 
+    avm_add_core_test(
+        avm_deferred_definition_test
+        test/deferred_definition_test.cpp
+        deferred_definition_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -189,5 +194,6 @@ if(AVM_BUILD_CORE_TESTS)
         avm_program_model_test
         avm_boolean_runtime_test
         avm_function_runtime_test
-        avm_frame_runtime_test)
+        avm_frame_runtime_test
+        avm_deferred_definition_test)
 endif()

--- a/docs/deferred-definitions.md
+++ b/docs/deferred-definitions.md
@@ -1,0 +1,43 @@
+# Deferred function definitions
+
+AVM 1.0 distinguishes an executable `Def` node from the immutable function-definition row it materializes.
+
+## Why two shapes exist
+
+Projection/import must be able to construct an entire program graph before execution while preserving declaration order. If the importer inserted the final function-definition row immediately, a `Call` located before `Def` in a sequence could incorrectly find the function.
+
+The projection therefore emits a deferred definition expression:
+
+```text
+parameters        = List(formal1, formal2, ...)
+definitionPayload = Link(parameters, bodyRoot)
+payload           = Link(functionHandle, definitionPayload)
+defExpression     = (function_relation, unit, payload)
+```
+
+No callable definition exists merely because this expression is present in the store.
+
+## Execution
+
+When `Executor` dispatches `defExpression` to the bootstrap `function_relation` handler, the runtime decodes the node and materializes:
+
+```text
+(function_relation, functionHandle, definitionPayload)
+```
+
+The stored definition remains immutable and canonical. Re-executing the same deferred definition is idempotent. Executing a different definition for the same handle is an explicit conflict.
+
+This gives a direct ordering property:
+
+```text
+Sequence(Def(f), Call(f))  -> succeeds
+Sequence(Call(f), Def(f))  -> Call observes no definition and fails
+```
+
+## Recursion
+
+The function handle is created before the body graph is built. The body can therefore contain `Call(handle, ...)` even though the final definition row does not exist yet. Executing the `Def` node makes that recursive handle callable without rewriting the body.
+
+## Boundary
+
+The deferred node is part of the link-native AVM program model and has no JSON dependency. The JSON compatibility importer in #47 will use this shape to map textual `Def` syntax while keeping execution exclusively in `BootstrapRuntime` and `Executor`.

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -281,27 +281,27 @@ private:
 			                          throw std::logic_error("If truth table returned a non-Boolean selector");
 		                          });
 
-		executor_.register_native(vocabulary_.function_relation,
-		                          [this](const ExecutionContext &context, Executor &)
-		                          {
-			                          if (context.subject == vocabulary_.function_relation)
-				                          throw std::runtime_error("function vocabulary identity is not executable");
+		executor_.register_native(
+		    vocabulary_.function_relation,
+		    [this](const ExecutionContext &context, Executor &)
+		    {
+			    if (context.subject == vocabulary_.function_relation)
+				    throw std::runtime_error("function vocabulary identity is not executable");
 
-			                          if (context.subject == vocabulary_.unit)
-			                          {
-				                          const DeferredFunctionDefinition definition =
-				                              decode_deferred_function_definition(store_, vocabulary_, context.entity);
-				                          static_cast<void>(materialize_function_definition(
-				                              store_, vocabulary_, definition.handle, definition.parameters, definition.body));
-				                          return vocabulary_.nil;
-			                          }
+			    if (context.subject == vocabulary_.unit)
+			    {
+				    const DeferredFunctionDefinition definition =
+				        decode_deferred_function_definition(store_, vocabulary_, context.entity);
+				    static_cast<void>(materialize_function_definition(store_, vocabulary_, definition.handle,
+				                                                      definition.parameters, definition.body));
+				    return vocabulary_.nil;
+			    }
 
-			                          const auto definition =
-			                              find_function_definition(store_, vocabulary_, context.subject);
-			                          if (!definition || definition->entity != context.entity)
-				                          throw std::runtime_error("function definition entity is malformed or ambiguous");
-			                          return vocabulary_.nil;
-		                          });
+			    const auto definition = find_function_definition(store_, vocabulary_, context.subject);
+			    if (!definition || definition->entity != context.entity)
+				    throw std::runtime_error("function definition entity is malformed or ambiguous");
+			    return vocabulary_.nil;
+		    });
 
 		executor_.register_native(vocabulary_.parameter_relation,
 		                          [this](const ExecutionContext &context, Executor &)

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -286,7 +286,20 @@ private:
 		                          {
 			                          if (context.subject == vocabulary_.function_relation)
 				                          throw std::runtime_error("function vocabulary identity is not executable");
-			                          static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
+
+			                          if (context.subject == vocabulary_.unit)
+			                          {
+				                          const DeferredFunctionDefinition definition =
+				                              decode_deferred_function_definition(store_, vocabulary_, context.entity);
+				                          static_cast<void>(materialize_function_definition(
+				                              store_, vocabulary_, definition.handle, definition.parameters, definition.body));
+				                          return vocabulary_.nil;
+			                          }
+
+			                          const auto definition =
+			                              find_function_definition(store_, vocabulary_, context.subject);
+			                          if (!definition || definition->entity != context.entity)
+				                          throw std::runtime_error("function definition entity is malformed or ambiguous");
 			                          return vocabulary_.nil;
 		                          });
 

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -155,9 +155,8 @@ struct DeferredFunctionDefinition
 	LinkId body;
 };
 
-inline DeferredFunctionDefinition decode_deferred_function_definition(const LinkStore &store,
-                                                                      const BootstrapVocabulary &vocabulary,
-                                                                      LinkId entity)
+inline DeferredFunctionDefinition
+decode_deferred_function_definition(const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId entity)
 {
 	const RelationEntity decoded = decode_relation_entity(store, entity);
 	if (decoded.relation != vocabulary.function_relation || decoded.subject != vocabulary.unit)

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -123,6 +123,55 @@ inline std::optional<FunctionDefinition> find_function_definition(const LinkStor
 	return found;
 }
 
+inline LinkId materialize_function_definition(LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId handle,
+                                              const std::vector<LinkId> &parameters, LinkId body)
+{
+	if (!store.contains(handle))
+		throw std::invalid_argument("function handle is not present in LinkStore");
+	if (!store.contains(body))
+		throw std::invalid_argument("function body is not present in LinkStore");
+	for (const LinkId parameter : parameters)
+	{
+		if (!store.contains(parameter))
+			throw std::invalid_argument("formal parameter is not present in LinkStore");
+	}
+
+	if (const auto existing = find_function_definition(store, vocabulary, handle))
+	{
+		if (existing->parameters == parameters && existing->body == body)
+			return existing->entity;
+		throw std::logic_error("function handle already has a different definition");
+	}
+
+	const LinkId parameter_list = encode_link_list(store, vocabulary.nil, parameters);
+	const LinkId payload = store.intern(parameter_list, body);
+	return encode_relation_entity(store, RelationEntity{vocabulary.function_relation, handle, payload});
+}
+
+struct DeferredFunctionDefinition
+{
+	LinkId handle;
+	std::vector<LinkId> parameters;
+	LinkId body;
+};
+
+inline DeferredFunctionDefinition decode_deferred_function_definition(const LinkStore &store,
+                                                                      const BootstrapVocabulary &vocabulary,
+                                                                      LinkId entity)
+{
+	const RelationEntity decoded = decode_relation_entity(store, entity);
+	if (decoded.relation != vocabulary.function_relation || decoded.subject != vocabulary.unit)
+		throw std::invalid_argument("entity is not an AVM deferred function definition");
+
+	const Link outer_payload = store.get(decoded.object);
+	const Link definition_payload = store.get(outer_payload.end);
+	return DeferredFunctionDefinition{
+	    outer_payload.begin,
+	    decode_link_list(store, vocabulary.nil, definition_payload.begin),
+	    definition_payload.end,
+	};
+}
+
 struct CallExpression
 {
 	LinkId function;
@@ -188,23 +237,20 @@ public:
 
 	LinkId define_function(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
 	{
+		return materialize_function_definition(store_, vocabulary_, handle, parameters, body);
+	}
+
+	LinkId deferred_function_definition(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
+	{
 		require(handle, "function handle");
 		require(body, "function body");
-		for (const LinkId parameter_id : parameters)
-			require(parameter_id, "formal parameter");
+		for (const LinkId parameter : parameters)
+			require(parameter, "formal parameter");
 
 		const LinkId parameter_list = encode_link_list(store_, vocabulary_.nil, parameters);
-		const LinkId payload = store_.intern(parameter_list, body);
-		const RelationEntity source{vocabulary_.function_relation, handle, payload};
-
-		if (const auto existing = find_function_definition(store_, vocabulary_, handle))
-		{
-			if (existing->parameters == parameters && existing->body == body)
-				return existing->entity;
-			throw std::logic_error("function handle already has a different definition");
-		}
-
-		return encode_relation_entity(store_, source);
+		const LinkId definition_payload = store_.intern(parameter_list, body);
+		const LinkId payload = store_.intern(handle, definition_payload);
+		return expression(vocabulary_.function_relation, payload);
 	}
 
 	LinkId call(LinkId function, const std::vector<LinkId> &arguments)

--- a/test/deferred_definition_test.cpp
+++ b/test/deferred_definition_test.cpp
@@ -1,0 +1,129 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store, 16);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &v = runtime.vocabulary();
+
+	const avm::LinkId t = builder.literal(v.true_value);
+	const avm::LinkId f = builder.literal(v.false_value);
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId handle = builder.create_function_handle();
+	const avm::LinkId body = builder.parameter(formal);
+	const avm::LinkId deferred = builder.deferred_function_definition(handle, {formal}, body);
+
+	assert(!avm::find_function_definition(store, v, handle).has_value());
+	const avm::DeferredFunctionDefinition decoded = avm::decode_deferred_function_definition(store, v, deferred);
+	assert(decoded.handle == handle);
+	assert(decoded.parameters == (std::vector<avm::LinkId>{formal}));
+	assert(decoded.body == body);
+
+	const avm::LinkId call = builder.call(handle, {t});
+	bool call_before_definition_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(call));
+	}
+	catch (const std::runtime_error &)
+	{
+		call_before_definition_rejected = true;
+	}
+	assert(call_before_definition_rejected);
+
+	assert(runtime.execute(deferred) == v.nil);
+	const auto materialized = avm::find_function_definition(store, v, handle);
+	assert(materialized.has_value());
+	assert(materialized->handle == handle);
+	assert(materialized->parameters == (std::vector<avm::LinkId>{formal}));
+	assert(materialized->body == body);
+	assert(runtime.execute(call) == v.true_value);
+
+	const std::size_t before_repeat = store.size();
+	assert(runtime.execute(deferred) == v.nil);
+	assert(store.size() == before_repeat);
+
+	const avm::LinkId conflicting = builder.deferred_function_definition(handle, {formal}, f);
+	bool conflict_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(conflicting));
+	}
+	catch (const std::logic_error &)
+	{
+		conflict_rejected = true;
+	}
+	assert(conflict_rejected);
+
+	avm::InMemoryLinkStore ordered_store;
+	avm::BootstrapRuntime ordered_runtime(ordered_store, 16);
+	avm::ProgramBuilder ordered_builder = ordered_runtime.builder();
+	const avm::BootstrapVocabulary &ordered_v = ordered_runtime.vocabulary();
+	const avm::LinkId ordered_t = ordered_builder.literal(ordered_v.true_value);
+	const avm::LinkId ordered_formal = ordered_store.create_point();
+	const avm::LinkId ordered_handle = ordered_builder.create_function_handle();
+	const avm::LinkId ordered_body = ordered_builder.parameter(ordered_formal);
+	const avm::LinkId ordered_def =
+	    ordered_builder.deferred_function_definition(ordered_handle, {ordered_formal}, ordered_body);
+	const avm::LinkId ordered_call = ordered_builder.call(ordered_handle, {ordered_t});
+	assert(ordered_runtime.execute(ordered_builder.sequence({ordered_def, ordered_call})) == ordered_v.true_value);
+
+	avm::InMemoryLinkStore reversed_store;
+	avm::BootstrapRuntime reversed_runtime(reversed_store, 16);
+	avm::ProgramBuilder reversed_builder = reversed_runtime.builder();
+	const avm::BootstrapVocabulary &reversed_v = reversed_runtime.vocabulary();
+	const avm::LinkId reversed_t = reversed_builder.literal(reversed_v.true_value);
+	const avm::LinkId reversed_formal = reversed_store.create_point();
+	const avm::LinkId reversed_handle = reversed_builder.create_function_handle();
+	const avm::LinkId reversed_body = reversed_builder.parameter(reversed_formal);
+	const avm::LinkId reversed_def =
+	    reversed_builder.deferred_function_definition(reversed_handle, {reversed_formal}, reversed_body);
+	const avm::LinkId reversed_call = reversed_builder.call(reversed_handle, {reversed_t});
+	bool reversed_sequence_rejected = false;
+	try
+	{
+		static_cast<void>(reversed_runtime.execute(reversed_builder.sequence({reversed_call, reversed_def})));
+	}
+	catch (const std::runtime_error &)
+	{
+		reversed_sequence_rejected = true;
+	}
+	assert(reversed_sequence_rejected);
+	assert(!avm::find_function_definition(reversed_store, reversed_v, reversed_handle).has_value());
+
+	avm::InMemoryLinkStore recursive_store;
+	avm::BootstrapRuntime recursive_runtime(recursive_store, 16);
+	avm::ProgramBuilder recursive_builder = recursive_runtime.builder();
+	const avm::BootstrapVocabulary &recursive_v = recursive_runtime.vocabulary();
+	const avm::LinkId recursive_t = recursive_builder.literal(recursive_v.true_value);
+	const avm::LinkId recursive_f = recursive_builder.literal(recursive_v.false_value);
+	const avm::LinkId flag = recursive_store.create_point();
+	const avm::LinkId recursive_handle = recursive_builder.create_function_handle();
+	const avm::LinkId recursive_body = recursive_builder.conditional(
+	    recursive_builder.parameter(flag), recursive_builder.call(recursive_handle, {recursive_f}), recursive_t);
+	const avm::LinkId recursive_def =
+	    recursive_builder.deferred_function_definition(recursive_handle, {flag}, recursive_body);
+	const avm::LinkId recursive_call = recursive_builder.call(recursive_handle, {recursive_t});
+	assert(recursive_runtime.execute(recursive_builder.sequence({recursive_def, recursive_call})) ==
+	       recursive_v.true_value);
+
+	const avm::LinkId malformed_payload = store.create_point();
+	const avm::LinkId malformed = avm::encode_relation_entity(
+	    store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
+	bool malformed_rejected = false;
+	try
+	{
+		static_cast<void>(avm::decode_deferred_function_definition(store, v, malformed));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_rejected = true;
+	}
+	assert(malformed_rejected);
+
+	return 0;
+}

--- a/test/deferred_definition_test.cpp
+++ b/test/deferred_definition_test.cpp
@@ -112,8 +112,8 @@ int main()
 	       recursive_v.true_value);
 
 	const avm::LinkId malformed_payload = store.create_point();
-	const avm::LinkId malformed = avm::encode_relation_entity(
-	    store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
+	const avm::LinkId malformed =
+	    avm::encode_relation_entity(store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
 	bool malformed_rejected = false;
 	try
 	{


### PR DESCRIPTION
Closes #46. Child of #38 / #25 / Epic #31.

## What changed
- factored immutable function materialization into `materialize_function_definition`;
- added a link-native deferred definition expression `(function_relation, unit, payload)`;
- added decoder/builder APIs for deferred definitions;
- bootstrap `function_relation` handler now materializes definitions only when the Def node executes;
- retained immediate `define_function()` for direct core construction;
- documented why projection and runtime definition shapes are distinct;
- added a dedicated deferred-definition suite to the core CI gate.

## Semantic invariant
Program projection can build the whole graph without making functions callable early:

- `Sequence(Def(f), Call(f))` succeeds;
- `Sequence(Call(f), Def(f))` fails before materializing `f`;
- recursive bodies can reference the preallocated handle before Def executes.

## Tests
The new suite covers absent-before-execution, materialization, repeated idempotent Def, conflicting Def, call-before-Def, Def-before-Call, recursive deferred definitions and malformed payload rejection.

CI must pass strict clang-format, C++20 warnings-as-errors, ASan+UBSan and the full Linux/Windows/macOS compatibility matrix before merge.