### PR TITLE
AVM 1.0: project JSON programs into the link-native runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,8 @@ jobs:
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/function_runtime_test.cpp \
-            test/frame_runtime_test.cpp
+            test/frame_runtime_test.cpp \
+            test/deferred_definition_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   quality:
     name: Quality gates
@@ -32,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -54,6 +59,24 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
+
+      - name: One-time format deferred-definition changes
+        if: github.head_ref == 'agent/deferred-definitions'
+        shell: bash
+        run: |
+          set -euo pipefail
+          clang-format -i \
+            include/avm/program_model.h \
+            include/avm/bootstrap_runtime.h \
+            test/deferred_definition_test.cpp
+          if git diff --quiet; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add include/avm/program_model.h include/avm/bootstrap_runtime.h test/deferred_definition_test.cpp
+          git commit -m "style: clang-format deferred definitions"
+          git push origin HEAD:${{ github.head_ref }}
 
       - name: Check AVM 1.0 core formatting
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
 
-      - name: Check AVM 1.0 core formatting
+      - name: Check AVM 1.0 core and compatibility formatting
         shell: bash
         run: |
           set -euo pipefail
@@ -70,7 +70,9 @@ jobs:
             test/boolean_runtime_test.cpp \
             test/function_runtime_test.cpp \
             test/frame_runtime_test.cpp \
-            test/deferred_definition_test.cpp
+            test/deferred_definition_test.cpp \
+            test/json_projection_test.cpp \
+            test/json_legacy_conformance_test.cpp
 
   core:
     name: Core C++20 / warnings-as-errors
@@ -87,6 +89,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DAVM_BUILD_LEGACY=OFF
           -DAVM_BUILD_CORE_TESTS=ON
+          -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
           -DAVM_WARNINGS_AS_ERRORS=ON
 
       - name: Build core tests
@@ -95,8 +98,32 @@ jobs:
       - name: Run core tests
         run: ctest --test-dir build-core --output-on-failure
 
+  json-compat:
+    name: JSON projection / warnings-as-errors
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure JSON compatibility build
+        run: >-
+          cmake -S . -B build-json
+          -DCMAKE_BUILD_TYPE=Debug
+          -DAVM_BUILD_LEGACY=OFF
+          -DAVM_BUILD_CORE_TESTS=OFF
+          -DAVM_BUILD_JSON_COMPAT_TESTS=ON
+          -DAVM_WARNINGS_AS_ERRORS=ON
+
+      - name: Build JSON projection tests
+        run: cmake --build build-json --target avm_json_compat_tests --parallel
+
+      - name: Run JSON projection tests
+        run: ctest --test-dir build-json -R json_projection_tests --output-on-failure
+
   sanitizers:
-    name: Core ASan + UBSan
+    name: Core + JSON ASan + UBSan
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -110,11 +137,12 @@ jobs:
           -DCMAKE_BUILD_TYPE=Debug
           -DAVM_BUILD_LEGACY=OFF
           -DAVM_BUILD_CORE_TESTS=ON
+          -DAVM_BUILD_JSON_COMPAT_TESTS=ON
           -DAVM_WARNINGS_AS_ERRORS=ON
           -DAVM_ENABLE_SANITIZERS=ON
 
       - name: Build sanitizer tests
-        run: cmake --build build-sanitizers --target avm_core_tests --parallel
+        run: cmake --build build-sanitizers --target avm_core_tests avm_json_compat_tests --parallel
 
       - name: Run sanitizer tests
         env:
@@ -136,7 +164,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure full compatibility build
-        run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DAVM_BUILD_LEGACY=ON -DAVM_BUILD_CORE_TESTS=ON
+        run: >-
+          cmake -S . -B build
+          -DCMAKE_BUILD_TYPE=Release
+          -DAVM_BUILD_LEGACY=ON
+          -DAVM_BUILD_CORE_TESTS=ON
+          -DAVM_BUILD_JSON_COMPAT_TESTS=ON
 
       - name: Build
         run: cmake --build build --config Release --parallel
@@ -147,7 +180,7 @@ jobs:
   release-artifact:
     name: Tagged Linux artifact
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [core, sanitizers]
+    needs: [core, json-compat, sanitizers]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -155,7 +188,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Configure release build
-        run: cmake -S . -B build-release -DCMAKE_BUILD_TYPE=Release -DAVM_BUILD_LEGACY=ON
+        run: >-
+          cmake -S . -B build-release
+          -DCMAKE_BUILD_TYPE=Release
+          -DAVM_BUILD_LEGACY=ON
+          -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
 
       - name: Build AVM executable
         run: cmake --build build-release --target avm --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
-permissions:
-  contents: write
-
 jobs:
   quality:
     name: Quality gates
@@ -35,8 +32,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Install clang-format
         run: |
@@ -59,24 +54,6 @@ jobs:
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
-
-      - name: One-time format deferred-definition changes
-        if: github.head_ref == 'agent/deferred-definitions'
-        shell: bash
-        run: |
-          set -euo pipefail
-          clang-format -i \
-            include/avm/program_model.h \
-            include/avm/bootstrap_runtime.h \
-            test/deferred_definition_test.cpp
-          if git diff --quiet; then
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add include/avm/program_model.h include/avm/bootstrap_runtime.h test/deferred_definition_test.cpp
-          git commit -m "style: clang-format deferred definitions"
-          git push origin HEAD:${{ github.head_ref }}
 
       - name: Check AVM 1.0 core formatting
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(AVM_BUILD_LEGACY "Build the legacy JSON compatibility executable and tests" ON)
 option(AVM_BUILD_CORE_TESTS "Build AVM 1.0 core tests" ON)
+option(AVM_BUILD_JSON_COMPAT_TESTS "Build JSON projection and conformance tests" ON)
 option(AVM_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(AVM_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
@@ -196,4 +197,45 @@ if(AVM_BUILD_CORE_TESTS)
         avm_function_runtime_test
         avm_frame_runtime_test
         avm_deferred_definition_test)
+endif()
+
+if(AVM_BUILD_JSON_COMPAT_TESTS)
+    add_executable(avm_json_projection_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/json_projection_test.cpp")
+    target_include_directories(avm_json_projection_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+    avm_apply_quality(avm_json_projection_test)
+    avm_enable_test_assertions(avm_json_projection_test)
+    add_test(NAME json_projection_tests COMMAND avm_json_projection_test)
+
+    set(AVM_JSON_COMPAT_TARGETS avm_json_projection_test)
+
+    if(AVM_BUILD_LEGACY)
+        add_executable(avm_json_legacy_conformance_test
+            "${CMAKE_CURRENT_SOURCE_DIR}/test/json_legacy_conformance_test.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp"
+            "${CMAKE_CURRENT_SOURCE_DIR}/include/avm.h"
+            "${CMAKE_CURRENT_SOURCE_DIR}/3p/UnitedMemoryLinks.h")
+        target_include_directories(avm_json_legacy_conformance_test PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/include"
+            "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+        target_compile_definitions(avm_json_legacy_conformance_test PRIVATE AVM_NO_MAIN)
+        avm_enable_test_assertions(avm_json_legacy_conformance_test)
+
+        if(WIN32)
+            target_link_libraries(avm_json_legacy_conformance_test PRIVATE
+                "${CMAKE_CURRENT_SOURCE_DIR}/3p/doublets_ffi.dll.lib")
+            if(MSVC)
+                target_link_options(avm_json_legacy_conformance_test PRIVATE /STACK:8388608)
+            else()
+                target_link_options(avm_json_legacy_conformance_test PRIVATE -Wl,--stack,8388608)
+            endif()
+        endif()
+
+        add_test(NAME json_legacy_conformance_tests COMMAND avm_json_legacy_conformance_test)
+        list(APPEND AVM_JSON_COMPAT_TARGETS avm_json_legacy_conformance_test)
+    endif()
+
+    add_custom_target(avm_json_compat_tests DEPENDS ${AVM_JSON_COMPAT_TARGETS})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,11 @@ if(AVM_BUILD_CORE_TESTS)
         test/frame_runtime_test.cpp
         frame_runtime_tests)
 
+    avm_add_core_test(
+        avm_deferred_definition_test
+        test/deferred_definition_test.cpp
+        deferred_definition_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -189,5 +194,6 @@ if(AVM_BUILD_CORE_TESTS)
         avm_program_model_test
         avm_boolean_runtime_test
         avm_function_runtime_test
-        avm_frame_runtime_test)
+        avm_frame_runtime_test
+        avm_deferred_definition_test)
 endif()

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,66 +1,91 @@
 # AVM CI/CD policy
 
-The AVM 1.0 core is intentionally testable without the legacy JSON interpreter or the optional LinksPlatform dependency.
+The AVM 1.0 core is intentionally testable without the legacy JSON interpreter or the optional LinksPlatform dependency. JSON projection tests are also independently buildable, so the compatibility boundary can be verified without compiling the historical semantic implementation.
 
 ## CMake switches
 
-- `AVM_BUILD_LEGACY=ON|OFF` — build the historical JSON-facing executable and compatibility tests.
-- `AVM_BUILD_CORE_TESTS=ON|OFF` — build the link-native AVM 1.0 test suites.
-- `AVM_WARNINGS_AS_ERRORS=ON|OFF` — enable strict compiler diagnostics for targets using the core quality profile.
+- `AVM_BUILD_LEGACY=ON|OFF` — build the historical JSON-facing executable and legacy serializer/interpreter tests.
+- `AVM_BUILD_CORE_TESTS=ON|OFF` — build the link-native AVM 1.0 core suites.
+- `AVM_BUILD_JSON_COMPAT_TESTS=ON|OFF` — build the new JSON projection tests and, when legacy is enabled, the temporary old-vs-new conformance suite.
+- `AVM_WARNINGS_AS_ERRORS=ON|OFF` — enable strict compiler diagnostics for targets using the AVM quality profile.
 - `AVM_ENABLE_SANITIZERS=ON|OFF` — enable AddressSanitizer and UndefinedBehaviorSanitizer on supported non-MSVC toolchains.
 
-The fast validation command is:
+The fast core validation command is:
 
 ```bash
 cmake -S . -B build-core \
   -DCMAKE_BUILD_TYPE=Debug \
   -DAVM_BUILD_LEGACY=OFF \
   -DAVM_BUILD_CORE_TESTS=ON \
+  -DAVM_BUILD_JSON_COMPAT_TESTS=OFF \
   -DAVM_WARNINGS_AS_ERRORS=ON
 cmake --build build-core --target avm_core_tests --parallel
 ctest --test-dir build-core --output-on-failure
 ```
 
+The JSON projection can be checked without legacy execution semantics:
+
+```bash
+cmake -S . -B build-json \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DAVM_BUILD_LEGACY=OFF \
+  -DAVM_BUILD_CORE_TESTS=OFF \
+  -DAVM_BUILD_JSON_COMPAT_TESTS=ON \
+  -DAVM_WARNINGS_AS_ERRORS=ON
+cmake --build build-json --target avm_json_compat_tests --parallel
+ctest --test-dir build-json -R json_projection_tests --output-on-failure
+```
+
 ## Assertions are part of the test contract
 
-The current C++ suites use `assert(...)` for invariant checks. CMake Release configurations normally define `NDEBUG`, which would compile those checks out. Therefore every C++ test target explicitly undefines `NDEBUG` (`-UNDEBUG` or `/UNDEBUG`) regardless of build type.
+The C++ suites use `assert(...)` for invariant checks. CMake Release configurations normally define `NDEBUG`, which would compile those checks out. Therefore every C++ test target explicitly undefines `NDEBUG` (`-UNDEBUG` or `/UNDEBUG`) regardless of build type.
 
-`assertions_enabled_tests` additionally fails at compile time if `NDEBUG` reaches a core test target and verifies at runtime that an assertion expression is actually evaluated. The strict core lane uses Debug to maximize diagnostic visibility; the portable matrix still exercises Release builds with assertions forced active in test executables.
+`assertions_enabled_tests` additionally fails at compile time if `NDEBUG` reaches a core test target and verifies at runtime that an assertion expression is actually evaluated. The strict lanes use Debug to maximize diagnostic visibility; the portable matrix still exercises Release builds with assertions forced active in test executables.
 
 ## Pull-request gates
 
-The `CI` workflow has four independent concerns:
+The `CI` workflow separates five concerns:
 
-1. `Quality gates` — source-size policy and strict clang-format verification for the AVM 1.0 core files.
+1. `Quality gates` — source-size policy and strict clang-format verification for the AVM 1.0 core and compatibility source files.
 2. `Core C++20 / warnings-as-errors` — Linux Debug core-only build with strict warnings and CTest.
-3. `Core ASan + UBSan` — Debug core-only build under AddressSanitizer and UndefinedBehaviorSanitizer.
-4. `Portable / <os>` — full compatibility Release build and test matrix on Linux, Windows and macOS.
+3. `JSON projection / warnings-as-errors` — Linux Debug build of the new JSON projection path with legacy execution disabled.
+4. `Core + JSON ASan + UBSan` — core and JSON projection suites under AddressSanitizer and UndefinedBehaviorSanitizer.
+5. `Portable / <os>` — full Release build and all tests on Linux, Windows and macOS. During #47 this includes the temporary old-vs-new JSON conformance suite.
 
 Recommended branch-protection required checks for `main` are:
 
 - `Quality gates`;
 - `Core C++20 / warnings-as-errors`;
-- `Core ASan + UBSan`.
+- `JSON projection / warnings-as-errors`;
+- `Core + JSON ASan + UBSan`.
 
-The portable matrix should also stay green, but the three fast core gates are the minimum architectural merge barrier. This separation keeps the new link-native core independently verifiable even if a legacy/platform-specific dependency is temporarily unavailable.
+The portable matrix should also remain green before merge. Separating fast gates keeps the link-native core and the JSON projection independently diagnosable while the historical path is being removed.
 
 ## Test-suite growth rule
 
-Every new AVM 1.0 semantic layer must add a separately named CTest suite and be included in the `avm_core_tests` aggregate target. The intended progression is:
+Every new semantic layer must have a separately named CTest suite and an aggregate target appropriate to its boundary.
+
+Core progression:
 
 - `assertions_enabled_tests`;
 - `link_store_tests`;
 - `relations_model_tests`;
 - `executor_tests`;
-- program-model tests;
-- Boolean/If runtime tests;
-- function/frame/recursion tests;
-- JSON compatibility/conformance tests during the migration phase.
+- `program_model_tests`;
+- `boolean_runtime_tests`;
+- `function_runtime_tests`;
+- `frame_runtime_tests`;
+- `deferred_definition_tests`.
 
-Tests should prefer explicit invariants over broad end-to-end snapshots: canonical identity reuse, non-mutating lookup, malformed-link rejection, lazy branch behavior, frame materialization and recursion bounds should each be asserted directly.
+Compatibility migration:
+
+- `json_projection_tests` — permanent intended behavior of JSON -> links -> runtime -> result projection;
+- `json_legacy_conformance_tests` — temporary side-by-side migration guard, removed after #48 deletes the legacy semantic interpreter.
+
+Tests should prefer explicit invariants over broad snapshots: canonical identity reuse, non-mutating lookup, malformed-link rejection, lazy branch behavior, frame materialization, declaration order, recursion bounds, projection independence from source JSON lifetime and adapter-vs-core error semantics should each be asserted directly.
 
 ## Tagged delivery
 
-A push of a tag matching `v*` builds the Linux `avm` executable and uploads it as a workflow artifact named `avm-<tag>-linux-x86_64` after the core and sanitizer gates pass.
+A push of a tag matching `v*` builds the Linux `avm` executable and uploads it as a workflow artifact named `avm-<tag>-linux-x86_64` after the core, JSON projection and sanitizer gates pass.
 
 This is deliberately a minimal CD step. Publishing a GitHub Release, binary signing and a multi-platform release bundle should be enabled only after the versioning/signing policy and the legacy-to-AVM-1.0 executable transition are settled.

--- a/docs/deferred-definitions.md
+++ b/docs/deferred-definitions.md
@@ -1,0 +1,43 @@
+# Deferred function definitions
+
+AVM 1.0 distinguishes an executable `Def` node from the immutable function-definition row it materializes.
+
+## Why two shapes exist
+
+Projection/import must be able to construct an entire program graph before execution while preserving declaration order. If the importer inserted the final function-definition row immediately, a `Call` located before `Def` in a sequence could incorrectly find the function.
+
+The projection therefore emits a deferred definition expression:
+
+```text
+parameters        = List(formal1, formal2, ...)
+definitionPayload = Link(parameters, bodyRoot)
+payload           = Link(functionHandle, definitionPayload)
+defExpression     = (function_relation, unit, payload)
+```
+
+No callable definition exists merely because this expression is present in the store.
+
+## Execution
+
+When `Executor` dispatches `defExpression` to the bootstrap `function_relation` handler, the runtime decodes the node and materializes:
+
+```text
+(function_relation, functionHandle, definitionPayload)
+```
+
+The stored definition remains immutable and canonical. Re-executing the same deferred definition is idempotent. Executing a different definition for the same handle is an explicit conflict.
+
+This gives a direct ordering property:
+
+```text
+Sequence(Def(f), Call(f))  -> succeeds
+Sequence(Call(f), Def(f))  -> Call observes no definition and fails
+```
+
+## Recursion
+
+The function handle is created before the body graph is built. The body can therefore contain `Call(handle, ...)` even though the final definition row does not exist yet. Executing the `Def` node makes that recursive handle callable without rewriting the body.
+
+## Boundary
+
+The deferred node is part of the link-native AVM program model and has no JSON dependency. The JSON compatibility importer in #47 will use this shape to map textual `Def` syntax while keeping execution exclusively in `BootstrapRuntime` and `Executor`.

--- a/docs/json-compatibility-runtime.md
+++ b/docs/json-compatibility-runtime.md
@@ -1,0 +1,67 @@
+# JSON compatibility is a projection layer
+
+AVM 1.0 does not execute a JSON AST. JSON remains supported as an external compatibility syntax, but the semantic path is now:
+
+```text
+JSON
+  -> JsonProgramImporter
+  -> LinkStore program graph
+  -> BootstrapRuntime / Executor
+  -> result LinkId
+  -> JSON result projection
+```
+
+Once `import_program()` returns a root LinkId, execution no longer depends on the source JSON object. The conformance suite explicitly destroys/replaces the source JSON value before executing the imported graph.
+
+## Text names stop at the importer
+
+Operator names (`Not`, `And`, `Or`, `If`, `Def`, `Call`), function names and formal parameter names are projection syntax. `JsonProgramImporter` resolves them to opaque LinkIds.
+
+The runtime receives:
+
+- relation LinkIds for dispatch;
+- function-handle LinkIds;
+- formal-parameter LinkIds;
+- link-native call frames and bindings;
+- expression payloads represented as canonical dyads.
+
+There is no string operator dispatcher, function-name map or parameter-name map in `Executor` or `BootstrapRuntime`.
+
+## Function symbols and deferred Def
+
+The importer may allocate a function handle before its definition is executed. This supports recursion and forward references in the projected graph.
+
+A JSON `Def` becomes the deferred definition expression defined by #46. Merely importing it does not create the callable function-definition row. Execution of that node performs materialization, preserving `Def`/`Call` order.
+
+A subsequent syntactic redefinition receives a new handle so later projected calls can refer to the replacement definition without mutating an existing immutable definition row.
+
+## JSON literals
+
+Boolean and null values map directly to bootstrap vocabulary identities.
+
+Other scalar JSON values currently use projection-owned opaque point identities. The importer maintains a type-aware JSON-value-to-LinkId table and the reverse LinkId-to-JSON table for result projection. This is intentionally a compatibility mechanism, not the final AVM primitive-data model.
+
+A later storage/data-model issue can replace these opaque values without changing execution semantics.
+
+## Compatibility sequence
+
+The link-native core `sequence_relation` is fail-fast: an exception in a child expression aborts execution. The historical JSON interpreter behaved differently because malformed/undefined child expressions returned `E`, and an array continued with later elements.
+
+To preserve that behavior without weakening the core, `JsonCompatibilitySession` owns a separate compatibility sequence relation. Its handler executes each already-projected child through `Executor`, converts a child runtime failure to `nil`, and continues to the next expression.
+
+Thus compatibility policy remains at the adapter boundary rather than becoming a VM invariant.
+
+## Error boundary
+
+`JsonProgramImporter` throws `JsonProjectionError` for malformed syntax. Lower AVM layers throw explicit runtime/logic errors for malformed link structures or execution failures.
+
+`JsonCompatibilitySession::interpret()` is the legacy-shaped convenience facade: it maps those failures to JSON `null`. Direct users of `import_program()` and `execute()` retain explicit errors.
+
+## Conformance strategy
+
+During migration, two independent suites are used:
+
+1. `json_projection_tests` asserts intended behavior of the new projection/runtime path without depending on the old semantic interpreter.
+2. `json_legacy_conformance_tests` executes a representative corpus through both the historical interpreter and the new path and compares projected results.
+
+The side-by-side suite exists only for the migration window. After conformance is established and the old semantic interpreter is deleted in #48, the independent projection suite becomes the permanent compatibility contract.

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -281,27 +281,27 @@ private:
 			                          throw std::logic_error("If truth table returned a non-Boolean selector");
 		                          });
 
-		executor_.register_native(vocabulary_.function_relation,
-		                          [this](const ExecutionContext &context, Executor &)
-		                          {
-			                          if (context.subject == vocabulary_.function_relation)
-				                          throw std::runtime_error("function vocabulary identity is not executable");
+		executor_.register_native(
+		    vocabulary_.function_relation,
+		    [this](const ExecutionContext &context, Executor &)
+		    {
+			    if (context.subject == vocabulary_.function_relation)
+				    throw std::runtime_error("function vocabulary identity is not executable");
 
-			                          if (context.subject == vocabulary_.unit)
-			                          {
-				                          const DeferredFunctionDefinition definition =
-				                              decode_deferred_function_definition(store_, vocabulary_, context.entity);
-				                          static_cast<void>(materialize_function_definition(
-				                              store_, vocabulary_, definition.handle, definition.parameters, definition.body));
-				                          return vocabulary_.nil;
-			                          }
+			    if (context.subject == vocabulary_.unit)
+			    {
+				    const DeferredFunctionDefinition definition =
+				        decode_deferred_function_definition(store_, vocabulary_, context.entity);
+				    static_cast<void>(materialize_function_definition(store_, vocabulary_, definition.handle,
+				                                                      definition.parameters, definition.body));
+				    return vocabulary_.nil;
+			    }
 
-			                          const auto definition =
-			                              find_function_definition(store_, vocabulary_, context.subject);
-			                          if (!definition || definition->entity != context.entity)
-				                          throw std::runtime_error("function definition entity is malformed or ambiguous");
-			                          return vocabulary_.nil;
-		                          });
+			    const auto definition = find_function_definition(store_, vocabulary_, context.subject);
+			    if (!definition || definition->entity != context.entity)
+				    throw std::runtime_error("function definition entity is malformed or ambiguous");
+			    return vocabulary_.nil;
+		    });
 
 		executor_.register_native(vocabulary_.parameter_relation,
 		                          [this](const ExecutionContext &context, Executor &)

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -286,7 +286,20 @@ private:
 		                          {
 			                          if (context.subject == vocabulary_.function_relation)
 				                          throw std::runtime_error("function vocabulary identity is not executable");
-			                          static_cast<void>(find_function_definition(store_, vocabulary_, context.subject));
+
+			                          if (context.subject == vocabulary_.unit)
+			                          {
+				                          const DeferredFunctionDefinition definition =
+				                              decode_deferred_function_definition(store_, vocabulary_, context.entity);
+				                          static_cast<void>(materialize_function_definition(
+				                              store_, vocabulary_, definition.handle, definition.parameters, definition.body));
+				                          return vocabulary_.nil;
+			                          }
+
+			                          const auto definition =
+			                              find_function_definition(store_, vocabulary_, context.subject);
+			                          if (!definition || definition->entity != context.entity)
+				                          throw std::runtime_error("function definition entity is malformed or ambiguous");
 			                          return vocabulary_.nil;
 		                          });
 

--- a/include/avm/json_compat.h
+++ b/include/avm/json_compat.h
@@ -1,0 +1,324 @@
+#pragma once
+
+#include "avm/bootstrap_runtime.h"
+#include "nlohmann/json.hpp"
+
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+class JsonProjectionError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+class JsonProgramImporter
+{
+public:
+	using Json = nlohmann::json;
+
+	JsonProgramImporter(LinkStore &store, const BootstrapVocabulary &vocabulary)
+	    : store_(store), vocabulary_(vocabulary), builder_(store, vocabulary)
+	{
+	}
+
+	LinkId import_program(const Json &expression) { return import_expression(expression); }
+
+	Json project_value(LinkId value) const
+	{
+		if (value == vocabulary_.nil)
+			return nullptr;
+		if (value == vocabulary_.true_value)
+			return true;
+		if (value == vocabulary_.false_value)
+			return false;
+
+		const auto literal = literals_by_id_.find(value);
+		if (literal == literals_by_id_.end())
+			throw JsonProjectionError("result LinkId has no JSON projection");
+		return literal->second;
+	}
+
+private:
+	struct FunctionSymbol
+	{
+		LinkId handle;
+		bool syntactically_defined;
+	};
+
+	LinkId import_expression(const Json &expression)
+	{
+		switch (expression.type())
+		{
+		case Json::value_t::null:
+			return builder_.literal(vocabulary_.nil);
+		case Json::value_t::boolean:
+			return builder_.literal(expression.get<bool>() ? vocabulary_.true_value : vocabulary_.false_value);
+		case Json::value_t::string:
+			return import_string(expression.get_ref<const std::string &>());
+		case Json::value_t::number_integer:
+		case Json::value_t::number_unsigned:
+		case Json::value_t::number_float:
+			return import_opaque_literal(expression);
+		case Json::value_t::array:
+			return import_sequence(expression);
+		case Json::value_t::object:
+			return import_operator(expression);
+		default:
+			throw JsonProjectionError("unsupported JSON value in AVM program projection");
+		}
+	}
+
+	LinkId import_string(const std::string &value)
+	{
+		if (const auto formal = find_formal(value))
+			return builder_.parameter(*formal);
+		return import_opaque_literal(Json(value));
+	}
+
+	LinkId import_opaque_literal(const Json &value)
+	{
+		const std::string key = std::to_string(static_cast<int>(value.type())) + ":" + value.dump();
+		const auto existing = literal_ids_.find(key);
+		LinkId value_id;
+		if (existing != literal_ids_.end())
+		{
+			value_id = existing->second;
+		}
+		else
+		{
+			value_id = store_.create_point();
+			literal_ids_.emplace(key, value_id);
+			literals_by_id_.emplace(value_id, value);
+		}
+		return builder_.literal(value_id);
+	}
+
+	LinkId import_sequence(const Json &sequence)
+	{
+		std::vector<LinkId> expressions;
+		expressions.reserve(sequence.size());
+		for (const Json &item : sequence)
+			expressions.push_back(import_expression(item));
+		return builder_.sequence(expressions);
+	}
+
+	LinkId import_operator(const Json &expression)
+	{
+		if (expression.size() != 1)
+			throw JsonProjectionError("operator expression must contain exactly one member");
+
+		const auto member = expression.begin();
+		const std::string &name = member.key();
+		const Json &arguments = member.value();
+		if (!arguments.is_array() || arguments.empty())
+			throw JsonProjectionError("operator arguments must be a non-empty JSON array");
+
+		if (name == "Not")
+		{
+			require_arity(arguments, 1, "Not");
+			return builder_.logical_not(import_expression(arguments[0]));
+		}
+		if (name == "And")
+		{
+			require_arity(arguments, 2, "And");
+			return builder_.logical_and(import_expression(arguments[0]), import_expression(arguments[1]));
+		}
+		if (name == "Or")
+		{
+			require_arity(arguments, 2, "Or");
+			return builder_.logical_or(import_expression(arguments[0]), import_expression(arguments[1]));
+		}
+		if (name == "If")
+		{
+			require_arity(arguments, 3, "If");
+			return builder_.conditional(import_expression(arguments[0]), import_expression(arguments[1]),
+			                            import_expression(arguments[2]));
+		}
+		if (name == "Def")
+			return import_definition(arguments);
+		if (name == "Call")
+			return import_call(arguments);
+
+		throw JsonProjectionError("unknown JSON AVM operator: " + name);
+	}
+
+	LinkId import_definition(const Json &arguments)
+	{
+		require_arity(arguments, 3, "Def");
+		if (!arguments[0].is_string())
+			throw JsonProjectionError("Def function name must be a string");
+		if (!arguments[1].is_array())
+			throw JsonProjectionError("Def formal parameters must be an array");
+
+		const std::string function_name = arguments[0].get<std::string>();
+		const std::optional<FunctionSymbol> previous = current_function_symbol(function_name);
+		const FunctionSymbol symbol = begin_definition(function_name);
+
+		std::vector<LinkId> parameters;
+		std::map<std::string, LinkId> scope;
+		parameters.reserve(arguments[1].size());
+		for (const Json &parameter : arguments[1])
+		{
+			if (!parameter.is_string())
+			{
+				restore_function_symbol(function_name, previous);
+				throw JsonProjectionError("Def formal parameter names must be strings");
+			}
+			const LinkId formal = store_.create_point();
+			parameters.push_back(formal);
+			scope[parameter.get<std::string>()] = formal;
+		}
+
+		parameter_scopes_.push_back(std::move(scope));
+		try
+		{
+			const LinkId body = import_expression(arguments[2]);
+			parameter_scopes_.pop_back();
+			return builder_.deferred_function_definition(symbol.handle, parameters, body);
+		}
+		catch (...)
+		{
+			parameter_scopes_.pop_back();
+			restore_function_symbol(function_name, previous);
+			throw;
+		}
+	}
+
+	LinkId import_call(const Json &arguments)
+	{
+		if (arguments.empty() || !arguments[0].is_string())
+			throw JsonProjectionError("Call requires a string function name");
+
+		const LinkId function = function_for_call(arguments[0].get_ref<const std::string &>());
+		std::vector<LinkId> actuals;
+		actuals.reserve(arguments.size() - 1);
+		for (std::size_t i = 1; i < arguments.size(); ++i)
+			actuals.push_back(import_expression(arguments[i]));
+		return builder_.call(function, actuals);
+	}
+
+	std::optional<LinkId> find_formal(const std::string &name) const
+	{
+		for (auto scope = parameter_scopes_.rbegin(); scope != parameter_scopes_.rend(); ++scope)
+		{
+			const auto formal = scope->find(name);
+			if (formal != scope->end())
+				return formal->second;
+		}
+		return std::nullopt;
+	}
+
+	std::optional<FunctionSymbol> current_function_symbol(const std::string &name) const
+	{
+		const auto found = functions_.find(name);
+		if (found == functions_.end())
+			return std::nullopt;
+		return found->second;
+	}
+
+	FunctionSymbol begin_definition(const std::string &name)
+	{
+		const auto found = functions_.find(name);
+		if (found == functions_.end())
+		{
+			const FunctionSymbol symbol{builder_.create_function_handle(), true};
+			functions_[name] = symbol;
+			return symbol;
+		}
+
+		if (!found->second.syntactically_defined)
+		{
+			found->second.syntactically_defined = true;
+			return found->second;
+		}
+
+		const FunctionSymbol replacement{builder_.create_function_handle(), true};
+		found->second = replacement;
+		return replacement;
+	}
+
+	LinkId function_for_call(const std::string &name)
+	{
+		const auto found = functions_.find(name);
+		if (found != functions_.end())
+			return found->second.handle;
+
+		const FunctionSymbol provisional{builder_.create_function_handle(), false};
+		functions_[name] = provisional;
+		return provisional.handle;
+	}
+
+	void restore_function_symbol(const std::string &name, const std::optional<FunctionSymbol> &previous)
+	{
+		if (previous)
+			functions_[name] = *previous;
+		else
+			functions_.erase(name);
+	}
+
+	static void require_arity(const Json &arguments, std::size_t expected, const char *operator_name)
+	{
+		if (arguments.size() != expected)
+			throw JsonProjectionError(std::string(operator_name) + " has invalid arity");
+	}
+
+	LinkStore &store_;
+	const BootstrapVocabulary &vocabulary_;
+	ProgramBuilder builder_;
+	std::map<std::string, FunctionSymbol> functions_;
+	std::vector<std::map<std::string, LinkId>> parameter_scopes_;
+	std::map<std::string, LinkId> literal_ids_;
+	std::map<LinkId, Json> literals_by_id_;
+};
+
+class JsonCompatibilitySession
+{
+public:
+	using Json = nlohmann::json;
+
+	explicit JsonCompatibilitySession(std::size_t max_call_depth = 1000)
+	    : store_(), runtime_(store_, max_call_depth), importer_(store_, runtime_.vocabulary())
+	{
+	}
+
+	LinkId import_program(const Json &expression) { return importer_.import_program(expression); }
+
+	LinkId execute(LinkId root) { return runtime_.execute(root); }
+
+	Json project_result(LinkId value) const { return importer_.project_value(value); }
+
+	Json interpret(const Json &expression)
+	{
+		try
+		{
+			return project_result(execute(import_program(expression)));
+		}
+		catch (const std::exception &)
+		{
+			return nullptr;
+		}
+	}
+
+	const LinkStore &store() const { return store_; }
+
+	LinkStore &store() { return store_; }
+
+	const BootstrapRuntime &runtime() const { return runtime_; }
+
+	BootstrapRuntime &runtime() { return runtime_; }
+
+private:
+	InMemoryLinkStore store_;
+	BootstrapRuntime runtime_;
+	JsonProgramImporter importer_;
+};
+
+} // namespace avm

--- a/include/avm/json_compat.h
+++ b/include/avm/json_compat.h
@@ -24,9 +24,11 @@ class JsonProgramImporter
 public:
 	using Json = nlohmann::json;
 
-	JsonProgramImporter(LinkStore &store, const BootstrapVocabulary &vocabulary)
-	    : store_(store), vocabulary_(vocabulary), builder_(store, vocabulary)
+	JsonProgramImporter(LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId sequence_relation)
+	    : store_(store), vocabulary_(vocabulary), sequence_relation_(sequence_relation), builder_(store, vocabulary)
 	{
+		if (!store_.contains(sequence_relation_))
+			throw std::invalid_argument("JSON compatibility sequence relation is not present in LinkStore");
 	}
 
 	LinkId import_program(const Json &expression) { return import_expression(expression); }
@@ -107,7 +109,9 @@ private:
 		expressions.reserve(sequence.size());
 		for (const Json &item : sequence)
 			expressions.push_back(import_expression(item));
-		return builder_.sequence(expressions);
+
+		const LinkId payload = encode_link_list(store_, vocabulary_.nil, expressions);
+		return encode_relation_entity(store_, RelationEntity{sequence_relation_, vocabulary_.unit, payload});
 	}
 
 	LinkId import_operator(const Json &expression)
@@ -272,6 +276,7 @@ private:
 
 	LinkStore &store_;
 	const BootstrapVocabulary &vocabulary_;
+	LinkId sequence_relation_;
 	ProgramBuilder builder_;
 	std::map<std::string, FunctionSymbol> functions_;
 	std::vector<std::map<std::string, LinkId>> parameter_scopes_;
@@ -285,8 +290,10 @@ public:
 	using Json = nlohmann::json;
 
 	explicit JsonCompatibilitySession(std::size_t max_call_depth = 1000)
-	    : store_(), runtime_(store_, max_call_depth), importer_(store_, runtime_.vocabulary())
+	    : store_(), runtime_(store_, max_call_depth), sequence_relation_(store_.create_point()),
+	      importer_(store_, runtime_.vocabulary(), sequence_relation_)
 	{
+		register_sequence_handler();
 	}
 
 	LinkId import_program(const Json &expression) { return importer_.import_program(expression); }
@@ -315,9 +322,39 @@ public:
 
 	BootstrapRuntime &runtime() { return runtime_; }
 
+	LinkId sequence_relation() const { return sequence_relation_; }
+
 private:
+	void register_sequence_handler()
+	{
+		runtime_.executor().register_native(
+		    sequence_relation_,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    if (context.subject != runtime_.vocabulary().unit)
+				    throw std::runtime_error("JSON compatibility sequence is not an executable expression");
+
+			    const std::vector<LinkId> expressions =
+			        decode_link_list(store_, runtime_.vocabulary().nil, context.object);
+			    LinkId result = runtime_.vocabulary().nil;
+			    for (const LinkId expression : expressions)
+			    {
+				    try
+				    {
+					    result = executor.execute(expression, context.entity, context.frame);
+				    }
+				    catch (const std::exception &)
+				    {
+					    result = runtime_.vocabulary().nil;
+				    }
+			    }
+			    return result;
+		    });
+	}
+
 	InMemoryLinkStore store_;
 	BootstrapRuntime runtime_;
+	LinkId sequence_relation_;
 	JsonProgramImporter importer_;
 };
 

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -155,9 +155,8 @@ struct DeferredFunctionDefinition
 	LinkId body;
 };
 
-inline DeferredFunctionDefinition decode_deferred_function_definition(const LinkStore &store,
-                                                                      const BootstrapVocabulary &vocabulary,
-                                                                      LinkId entity)
+inline DeferredFunctionDefinition
+decode_deferred_function_definition(const LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId entity)
 {
 	const RelationEntity decoded = decode_relation_entity(store, entity);
 	if (decoded.relation != vocabulary.function_relation || decoded.subject != vocabulary.unit)

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -123,6 +123,55 @@ inline std::optional<FunctionDefinition> find_function_definition(const LinkStor
 	return found;
 }
 
+inline LinkId materialize_function_definition(LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId handle,
+                                              const std::vector<LinkId> &parameters, LinkId body)
+{
+	if (!store.contains(handle))
+		throw std::invalid_argument("function handle is not present in LinkStore");
+	if (!store.contains(body))
+		throw std::invalid_argument("function body is not present in LinkStore");
+	for (const LinkId parameter : parameters)
+	{
+		if (!store.contains(parameter))
+			throw std::invalid_argument("formal parameter is not present in LinkStore");
+	}
+
+	if (const auto existing = find_function_definition(store, vocabulary, handle))
+	{
+		if (existing->parameters == parameters && existing->body == body)
+			return existing->entity;
+		throw std::logic_error("function handle already has a different definition");
+	}
+
+	const LinkId parameter_list = encode_link_list(store, vocabulary.nil, parameters);
+	const LinkId payload = store.intern(parameter_list, body);
+	return encode_relation_entity(store, RelationEntity{vocabulary.function_relation, handle, payload});
+}
+
+struct DeferredFunctionDefinition
+{
+	LinkId handle;
+	std::vector<LinkId> parameters;
+	LinkId body;
+};
+
+inline DeferredFunctionDefinition decode_deferred_function_definition(const LinkStore &store,
+                                                                      const BootstrapVocabulary &vocabulary,
+                                                                      LinkId entity)
+{
+	const RelationEntity decoded = decode_relation_entity(store, entity);
+	if (decoded.relation != vocabulary.function_relation || decoded.subject != vocabulary.unit)
+		throw std::invalid_argument("entity is not an AVM deferred function definition");
+
+	const Link outer_payload = store.get(decoded.object);
+	const Link definition_payload = store.get(outer_payload.end);
+	return DeferredFunctionDefinition{
+	    outer_payload.begin,
+	    decode_link_list(store, vocabulary.nil, definition_payload.begin),
+	    definition_payload.end,
+	};
+}
+
 struct CallExpression
 {
 	LinkId function;
@@ -188,23 +237,20 @@ public:
 
 	LinkId define_function(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
 	{
+		return materialize_function_definition(store_, vocabulary_, handle, parameters, body);
+	}
+
+	LinkId deferred_function_definition(LinkId handle, const std::vector<LinkId> &parameters, LinkId body)
+	{
 		require(handle, "function handle");
 		require(body, "function body");
-		for (const LinkId parameter_id : parameters)
-			require(parameter_id, "formal parameter");
+		for (const LinkId parameter : parameters)
+			require(parameter, "formal parameter");
 
 		const LinkId parameter_list = encode_link_list(store_, vocabulary_.nil, parameters);
-		const LinkId payload = store_.intern(parameter_list, body);
-		const RelationEntity source{vocabulary_.function_relation, handle, payload};
-
-		if (const auto existing = find_function_definition(store_, vocabulary_, handle))
-		{
-			if (existing->parameters == parameters && existing->body == body)
-				return existing->entity;
-			throw std::logic_error("function handle already has a different definition");
-		}
-
-		return encode_relation_entity(store_, source);
+		const LinkId definition_payload = store_.intern(parameter_list, body);
+		const LinkId payload = store_.intern(handle, definition_payload);
+		return expression(vocabulary_.function_relation, payload);
 	}
 
 	LinkId call(LinkId function, const std::vector<LinkId> &arguments)

--- a/test/deferred_definition_test.cpp
+++ b/test/deferred_definition_test.cpp
@@ -1,0 +1,129 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store, 16);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &v = runtime.vocabulary();
+
+	const avm::LinkId t = builder.literal(v.true_value);
+	const avm::LinkId f = builder.literal(v.false_value);
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId handle = builder.create_function_handle();
+	const avm::LinkId body = builder.parameter(formal);
+	const avm::LinkId deferred = builder.deferred_function_definition(handle, {formal}, body);
+
+	assert(!avm::find_function_definition(store, v, handle).has_value());
+	const avm::DeferredFunctionDefinition decoded = avm::decode_deferred_function_definition(store, v, deferred);
+	assert(decoded.handle == handle);
+	assert(decoded.parameters == (std::vector<avm::LinkId>{formal}));
+	assert(decoded.body == body);
+
+	const avm::LinkId call = builder.call(handle, {t});
+	bool call_before_definition_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(call));
+	}
+	catch (const std::runtime_error &)
+	{
+		call_before_definition_rejected = true;
+	}
+	assert(call_before_definition_rejected);
+
+	assert(runtime.execute(deferred) == v.nil);
+	const auto materialized = avm::find_function_definition(store, v, handle);
+	assert(materialized.has_value());
+	assert(materialized->handle == handle);
+	assert(materialized->parameters == (std::vector<avm::LinkId>{formal}));
+	assert(materialized->body == body);
+	assert(runtime.execute(call) == v.true_value);
+
+	const std::size_t before_repeat = store.size();
+	assert(runtime.execute(deferred) == v.nil);
+	assert(store.size() == before_repeat);
+
+	const avm::LinkId conflicting = builder.deferred_function_definition(handle, {formal}, f);
+	bool conflict_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(conflicting));
+	}
+	catch (const std::logic_error &)
+	{
+		conflict_rejected = true;
+	}
+	assert(conflict_rejected);
+
+	avm::InMemoryLinkStore ordered_store;
+	avm::BootstrapRuntime ordered_runtime(ordered_store, 16);
+	avm::ProgramBuilder ordered_builder = ordered_runtime.builder();
+	const avm::BootstrapVocabulary &ordered_v = ordered_runtime.vocabulary();
+	const avm::LinkId ordered_t = ordered_builder.literal(ordered_v.true_value);
+	const avm::LinkId ordered_formal = ordered_store.create_point();
+	const avm::LinkId ordered_handle = ordered_builder.create_function_handle();
+	const avm::LinkId ordered_body = ordered_builder.parameter(ordered_formal);
+	const avm::LinkId ordered_def =
+	    ordered_builder.deferred_function_definition(ordered_handle, {ordered_formal}, ordered_body);
+	const avm::LinkId ordered_call = ordered_builder.call(ordered_handle, {ordered_t});
+	assert(ordered_runtime.execute(ordered_builder.sequence({ordered_def, ordered_call})) == ordered_v.true_value);
+
+	avm::InMemoryLinkStore reversed_store;
+	avm::BootstrapRuntime reversed_runtime(reversed_store, 16);
+	avm::ProgramBuilder reversed_builder = reversed_runtime.builder();
+	const avm::BootstrapVocabulary &reversed_v = reversed_runtime.vocabulary();
+	const avm::LinkId reversed_t = reversed_builder.literal(reversed_v.true_value);
+	const avm::LinkId reversed_formal = reversed_store.create_point();
+	const avm::LinkId reversed_handle = reversed_builder.create_function_handle();
+	const avm::LinkId reversed_body = reversed_builder.parameter(reversed_formal);
+	const avm::LinkId reversed_def =
+	    reversed_builder.deferred_function_definition(reversed_handle, {reversed_formal}, reversed_body);
+	const avm::LinkId reversed_call = reversed_builder.call(reversed_handle, {reversed_t});
+	bool reversed_sequence_rejected = false;
+	try
+	{
+		static_cast<void>(reversed_runtime.execute(reversed_builder.sequence({reversed_call, reversed_def})));
+	}
+	catch (const std::runtime_error &)
+	{
+		reversed_sequence_rejected = true;
+	}
+	assert(reversed_sequence_rejected);
+	assert(!avm::find_function_definition(reversed_store, reversed_v, reversed_handle).has_value());
+
+	avm::InMemoryLinkStore recursive_store;
+	avm::BootstrapRuntime recursive_runtime(recursive_store, 16);
+	avm::ProgramBuilder recursive_builder = recursive_runtime.builder();
+	const avm::BootstrapVocabulary &recursive_v = recursive_runtime.vocabulary();
+	const avm::LinkId recursive_t = recursive_builder.literal(recursive_v.true_value);
+	const avm::LinkId recursive_f = recursive_builder.literal(recursive_v.false_value);
+	const avm::LinkId flag = recursive_store.create_point();
+	const avm::LinkId recursive_handle = recursive_builder.create_function_handle();
+	const avm::LinkId recursive_body = recursive_builder.conditional(
+	    recursive_builder.parameter(flag), recursive_builder.call(recursive_handle, {recursive_f}), recursive_t);
+	const avm::LinkId recursive_def =
+	    recursive_builder.deferred_function_definition(recursive_handle, {flag}, recursive_body);
+	const avm::LinkId recursive_call = recursive_builder.call(recursive_handle, {recursive_t});
+	assert(recursive_runtime.execute(recursive_builder.sequence({recursive_def, recursive_call})) ==
+	       recursive_v.true_value);
+
+	const avm::LinkId malformed_payload = store.create_point();
+	const avm::LinkId malformed = avm::encode_relation_entity(
+	    store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
+	bool malformed_rejected = false;
+	try
+	{
+		static_cast<void>(avm::decode_deferred_function_definition(store, v, malformed));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_rejected = true;
+	}
+	assert(malformed_rejected);
+
+	return 0;
+}

--- a/test/deferred_definition_test.cpp
+++ b/test/deferred_definition_test.cpp
@@ -112,8 +112,8 @@ int main()
 	       recursive_v.true_value);
 
 	const avm::LinkId malformed_payload = store.create_point();
-	const avm::LinkId malformed = avm::encode_relation_entity(
-	    store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
+	const avm::LinkId malformed =
+	    avm::encode_relation_entity(store, avm::RelationEntity{v.function_relation, v.unit, malformed_payload});
 	bool malformed_rejected = false;
 	try
 	{

--- a/test/json_legacy_conformance_test.cpp
+++ b/test/json_legacy_conformance_test.cpp
@@ -1,0 +1,90 @@
+#include "avm.h"
+#include "avm/json_compat.h"
+
+#include <cassert>
+#include <vector>
+
+rel_t *interpret(const json &expr);
+void export_json(const rel_t *ent, json &j);
+void clear_func_env();
+
+namespace
+{
+
+json legacy_result(const json &expression)
+{
+	clear_func_env();
+	rel_t *result = interpret(expression);
+	json output;
+	export_json(result, output);
+	return output;
+}
+
+json new_result(const json &expression)
+{
+	avm::JsonCompatibilitySession session;
+	return session.interpret(expression);
+}
+
+void require_same(const json &expression)
+{
+	assert(new_result(expression) == legacy_result(expression));
+}
+
+} // namespace
+
+int main()
+{
+	const std::vector<json> cases{
+	    true,
+	    false,
+	    nullptr,
+	    json{{"Not", json::array({true})}},
+	    json{{"Not", json::array({false})}},
+	    json{{"And", json::array({false, false})}},
+	    json{{"And", json::array({false, true})}},
+	    json{{"And", json::array({true, false})}},
+	    json{{"And", json::array({true, true})}},
+	    json{{"Or", json::array({false, false})}},
+	    json{{"Or", json::array({false, true})}},
+	    json{{"Or", json::array({true, false})}},
+	    json{{"Or", json::array({true, true})}},
+	    json{{"Not", json::array({json{{"And", json::array({true, false})}}})}},
+	    json{{"If", json::array({true, false, true})}},
+	    json{{"If", json::array({false, false, true})}},
+	    json{{"If", json::array({true, true, json{{"Call", json::array({"missing"})}}})}},
+	    json::array({true, false, true}),
+	    json::array({json{{"Def", json::array({"id", json::array({"x"}), "x"})}},
+	                 json{{"Call", json::array({"id", true})}}}),
+	    json::array({json{{"Def",
+	                      json::array({"both", json::array({"a", "b"}),
+	                                   json{{"And", json::array({"a", "b"})}}})}},
+	                 json{{"Call", json::array({"both", true, false})}}}),
+	    json::array({json{{"Def",
+	                      json::array({"recur", json::array({"flag"}),
+	                                   json{{"If", json::array({"flag",
+	                                                             json{{"Call", json::array({"recur", false})}},
+	                                                             true})}}})}},
+	                 json{{"Call", json::array({"recur", true})}}}),
+	    json::array({json{{"Def", json::array({"id", json::array({"x"}), "x"})}},
+	                 json{{"Call", json::array({"id", 42})}}}),
+	    json::array({json{{"Def", json::array({"id", json::array({"x"}), "x"})}},
+	                 json{{"Call", json::array({"id", "hello"})}}}),
+	    json::array({json{{"Call", json::array({"later", true})}},
+	                 json{{"Def", json::array({"later", json::array({"x"}), "x"})}},
+	                 json{{"Call", json::array({"later", true})}}}),
+	    json::object(),
+	    json{{"Xor", json::array({true, false})}},
+	    json{{"Not", json::array()}},
+	    json{{"Not", true}},
+	    json{{"Not", json::array({true, false})}},
+	    json{{"If", json::array({nullptr, true, false})}},
+	    json{{"Def", json::array({42, json::array(), true})}},
+	    json{{"Call", json::array({"missing", true})}},
+	};
+
+	for (const json &expression : cases)
+		require_same(expression);
+
+	return 0;
+}

--- a/test/json_legacy_conformance_test.cpp
+++ b/test/json_legacy_conformance_test.cpp
@@ -2,6 +2,7 @@
 #include "avm/json_compat.h"
 
 #include <cassert>
+#include <iostream>
 #include <vector>
 
 rel_t *interpret(const json &expr);
@@ -28,7 +29,16 @@ json new_result(const json &expression)
 
 void require_same(const json &expression)
 {
-	assert(new_result(expression) == legacy_result(expression));
+	const json legacy = legacy_result(expression);
+	const json current = new_result(expression);
+	if (current != legacy)
+	{
+		std::cerr << "JSON conformance mismatch\n"
+		          << "expression: " << expression.dump() << '\n'
+		          << "legacy:     " << legacy.dump() << '\n'
+		          << "new:        " << current.dump() << std::endl;
+	}
+	assert(current == legacy);
 }
 
 } // namespace

--- a/test/json_projection_test.cpp
+++ b/test/json_projection_test.cpp
@@ -1,0 +1,183 @@
+#include "avm/json_compat.h"
+
+#include <cassert>
+
+namespace
+{
+
+using Json = nlohmann::json;
+
+Json run(const Json &expression, std::size_t max_depth = 1000)
+{
+	avm::JsonCompatibilitySession session(max_depth);
+	return session.interpret(expression);
+}
+
+} // namespace
+
+int main()
+{
+	assert(run(true) == Json(true));
+	assert(run(false) == Json(false));
+	assert(run(nullptr).is_null());
+
+	assert(run(Json{{"Not", Json::array({true})}}) == Json(false));
+	assert(run(Json{{"Not", Json::array({false})}}) == Json(true));
+
+	assert(run(Json{{"And", Json::array({false, false})}}) == Json(false));
+	assert(run(Json{{"And", Json::array({false, true})}}) == Json(false));
+	assert(run(Json{{"And", Json::array({true, false})}}) == Json(false));
+	assert(run(Json{{"And", Json::array({true, true})}}) == Json(true));
+
+	assert(run(Json{{"Or", Json::array({false, false})}}) == Json(false));
+	assert(run(Json{{"Or", Json::array({false, true})}}) == Json(true));
+	assert(run(Json{{"Or", Json::array({true, false})}}) == Json(true));
+	assert(run(Json{{"Or", Json::array({true, true})}}) == Json(true));
+
+	const Json nested = {{"Not", Json::array({Json{{"And", Json::array({true, false})}}})}};
+	assert(run(nested) == Json(true));
+
+	const Json deeply_nested = {{"And",
+	                             Json::array({Json{{"Or", Json::array({true, false})}},
+	                                          Json{{"Not", Json::array({false})}}})}};
+	assert(run(deeply_nested) == Json(true));
+
+	assert(run(Json{{"If", Json::array({true, false, true})}}) == Json(false));
+	assert(run(Json{{"If", Json::array({false, false, true})}}) == Json(true));
+
+	const Json lazy_true = {
+	    {"If", Json::array({true, true, Json{{"Call", Json::array({"missing"})}}})}};
+	assert(run(lazy_true) == Json(true));
+
+	const Json lazy_false = {
+	    {"If", Json::array({false, Json{{"Call", Json::array({"missing"})}}, false})}};
+	assert(run(lazy_false) == Json(false));
+
+	const Json selected_failure = {
+	    {"If", Json::array({true, Json{{"Call", Json::array({"missing"})}}, false})}};
+	assert(run(selected_failure).is_null());
+
+	assert(run(Json::array()).is_null());
+	assert(run(Json::array({true, false, true})) == Json(true));
+
+	const Json identity_program = Json::array({
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	    Json{{"Call", Json::array({"id", true})}},
+	});
+	assert(run(identity_program) == Json(true));
+
+	const Json two_argument_program = Json::array({
+	    Json{{"Def",
+	          Json::array({"both", Json::array({"a", "b"}), Json{{"And", Json::array({"a", "b"})}}})}},
+	    Json{{"Call", Json::array({"both", true, false})}},
+	});
+	assert(run(two_argument_program) == Json(false));
+
+	const Json nested_calls = Json::array({
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	    Json{{"Def",
+	          Json::array({"negate", Json::array({"x"}),
+	                       Json{{"Not", Json::array({Json{{"Call", Json::array({"id", "x"})}}})}}})}},
+	    Json{{"Call", Json::array({"negate", false})}},
+	});
+	assert(run(nested_calls) == Json(true));
+
+	const Json shadowing = Json::array({
+	    Json{{"Def", Json::array({"inner", Json::array({"x"}), "x"})}},
+	    Json{{"Def",
+	          Json::array({"outer", Json::array({"x"}), Json{{"Call", Json::array({"inner", false})}}})}},
+	    Json{{"Call", Json::array({"outer", true})}},
+	});
+	assert(run(shadowing) == Json(false));
+
+	const Json finite_recursive = Json::array({
+	    Json{{"Def",
+	          Json::array({"recur", Json::array({"flag"}),
+	                       Json{{"If",
+	                             Json::array({"flag", Json{{"Call", Json::array({"recur", false})}}, true})}}})}},
+	    Json{{"Call", Json::array({"recur", true})}},
+	});
+	assert(run(finite_recursive, 16) == Json(true));
+
+	const Json infinite_recursive = Json::array({
+	    Json{{"Def",
+	          Json::array({"loop", Json::array({"x"}), Json{{"Call", Json::array({"loop", "x"})}}})}},
+	    Json{{"Call", Json::array({"loop", true})}},
+	});
+	assert(run(infinite_recursive, 4).is_null());
+
+	const Json call_before_def = Json::array({
+	    Json{{"Call", Json::array({"id", true})}},
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	});
+	assert(run(call_before_def).is_null());
+
+	const Json forward_reference = Json::array({
+	    Json{{"Def",
+	          Json::array({"first", Json::array({"x"}), Json{{"Call", Json::array({"second", "x"})}}})}},
+	    Json{{"Def", Json::array({"second", Json::array({"y"}), "y"})}},
+	    Json{{"Call", Json::array({"first", true})}},
+	});
+	assert(run(forward_reference) == Json(true));
+
+	const Json redefinition = Json::array({
+	    Json{{"Def", Json::array({"value", Json::array(), true})}},
+	    Json{{"Call", Json::array({"value"})}},
+	    Json{{"Def", Json::array({"value", Json::array(), false})}},
+	    Json{{"Call", Json::array({"value"})}},
+	});
+	assert(run(redefinition) == Json(false));
+
+	const Json number_identity = Json::array({
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	    Json{{"Call", Json::array({"id", 42})}},
+	});
+	assert(run(number_identity) == Json(42));
+
+	const Json float_identity = Json::array({
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	    Json{{"Call", Json::array({"id", 3.25})}},
+	});
+	assert(run(float_identity) == Json(3.25));
+
+	const Json string_identity = Json::array({
+	    Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}},
+	    Json{{"Call", Json::array({"id", "hello"})}},
+	});
+	assert(run(string_identity) == Json("hello"));
+
+	avm::JsonCompatibilitySession detached_session;
+	Json source = Json{{"Not", Json::array({false})}};
+	const avm::LinkId detached_root = detached_session.import_program(source);
+	source = nullptr;
+	const avm::RelationEntity detached_entity =
+	    avm::decode_relation_entity(detached_session.store(), detached_root);
+	assert(detached_entity.relation == detached_session.runtime().vocabulary().not_relation);
+	const avm::LinkId detached_result = detached_session.execute(detached_root);
+	assert(detached_session.project_result(detached_result) == Json(true));
+
+	avm::JsonCompatibilitySession persistent_session;
+	assert(persistent_session.interpret(
+	           Json{{"Def", Json::array({"id", Json::array({"x"}), "x"})}})
+	           .is_null());
+	assert(persistent_session.interpret(Json{{"Call", Json::array({"id", false})}}) == Json(false));
+
+	assert(run(Json::object()).is_null());
+	assert(run(Json{{"Not", Json::array({true})}, {"And", Json::array({true, true})}}).is_null());
+	assert(run(Json{{"Xor", Json::array({true, false})}}).is_null());
+	assert(run(Json{{"Not", Json::array()}}).is_null());
+	assert(run(Json{{"Not", true}}).is_null());
+	assert(run(Json{{"Not", Json::array({true, false})}}).is_null());
+	assert(run(Json{{"And", Json::array({true})}}).is_null());
+	assert(run(Json{{"Or", Json::array({true, false, true})}}).is_null());
+	assert(run(Json{{"If", Json::array({true, false})}}).is_null());
+	assert(run(Json{{"If", Json::array({nullptr, true, false})}}).is_null());
+	assert(run(Json{{"Def", Json::array({42, Json::array(), true})}}).is_null());
+	assert(run(Json{{"Def", Json::array({"f", true, true})}}).is_null());
+	assert(run(Json{{"Def", Json::array({"f", Json::array({42}), true})}}).is_null());
+	assert(run(Json{{"Call", Json::array()}}).is_null());
+	assert(run(Json{{"Call", Json::array({42})}}).is_null());
+	assert(run(Json{{"Call", Json::array({"missing", true})}}).is_null());
+
+	return 0;
+}


### PR DESCRIPTION
Closes #47. Parent #38 / #25 / Epic #31.

## Architectural change
JSON is now a projection/result boundary, not an execution AST:

`JSON -> JsonProgramImporter -> LinkStore root LinkId -> BootstrapRuntime/Executor -> result LinkId -> JSON projection`.

Textual operator/function/parameter names are resolved only by the importer. Runtime dispatch, function handles, bindings and frames use LinkIds.

## Compatibility behavior
- Not/And/Or/If project into the existing link-native program model;
- Def uses the deferred-definition mechanism from #46, preserving execution order and recursion;
- Call uses projected function handles;
- scalar number/string values use projection-owned opaque LinkIds with reversible JSON result projection;
- JSON arrays use a dedicated compatibility sequence relation so historical errors-as-null/continue behavior does not weaken the fail-fast core sequence;
- imported programs remain executable after the original JSON value is destroyed.

## Tests
Adds two layers:
- `json_projection_tests`: independent intended behavior of the new path, with truth tables, nesting, lazy If, sequences, functions, nesting/shadowing, recursion/depth guard, Def/Call order, forward references, redefinition, scalar roundtrip, malformed syntax and source-JSON lifetime independence;
- `json_legacy_conformance_tests`: temporary side-by-side old-vs-new corpus used only during migration to #48.

CI gains an independent JSON warnings-as-errors lane; ASan/UBSan covers core + JSON projection; portable Linux/Windows/macOS runs the full old/new conformance suite.

This PR intentionally does not delete the historical semantic interpreter yet. #48 does that only after this conformance gate is green.