### PR TITLE
AVM 1.0: add parser-independent projection find/realize boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
             test/function_runtime_test.cpp \
             test/frame_runtime_test.cpp \
             test/deferred_definition_test.cpp \
+            test/projection_test.cpp \
             test/json_projection_test.cpp \
             test/legacy_facade_test.cpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,11 @@ if(AVM_BUILD_CORE_TESTS)
         test/deferred_definition_test.cpp
         deferred_definition_tests)
 
+    avm_add_core_test(
+        avm_projection_test
+        test/projection_test.cpp
+        projection_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -203,7 +208,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_boolean_runtime_test
         avm_function_runtime_test
         avm_frame_runtime_test
-        avm_deferred_definition_test)
+        avm_deferred_definition_test
+        avm_projection_test)
 endif()
 
 if(AVM_BUILD_JSON_COMPAT_TESTS)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -85,7 +85,8 @@ Core:
 - `boolean_runtime_tests`;
 - `function_runtime_tests`;
 - `frame_runtime_tests`;
-- `deferred_definition_tests`.
+- `deferred_definition_tests`;
+- `projection_tests` — parser-independent `ProjectionDescription`, read-only `find_projection`, explicit `realize_projection`, canonical reuse, invalid graph/anchor rejection and no-partial-write checks for missing anchors.
 
 Compatibility:
 

--- a/docs/projection-boundary.md
+++ b/docs/projection-boundary.md
@@ -1,0 +1,88 @@
+# ProjectionDescription: parser-independent find/realize boundary
+
+`ProjectionDescription` is the neutral boundary between an external protocol/model projection and AVM storage. It deliberately contains no JSON syntax, Anum abits, parser state, quotation rules or execution semantics.
+
+## Why projection points are not implicit
+
+`InMemoryLinkStore::create_point()` creates a unique identity represented physically as a self-link `{id,id}`. Two points are therefore different identities even though both have the same structural shape "self-link".
+
+A read-only query cannot correctly discover an anonymous point merely by looking for a self-link: there can be many such links and none is structurally preferred. Hiding an external-name-to-point map inside `ProjectionDescription` would turn the memory layer into an identity resolver.
+
+AVM 1.0 v0.1 therefore uses two explicit reference kinds:
+
+```text
+Anchor(LinkId)    identity already resolved by the external adapter/context
+Node(NodeId)      result of an earlier dyad node in the same projection
+```
+
+The projection boundary itself never calls `create_point()`.
+
+## Description graph
+
+A projection is a topologically ordered list of dyads plus a root reference:
+
+```text
+node[0] = Link(Anchor(a), Anchor(b))
+node[1] = Link(Node(0),   Anchor(c))
+root    = Node(1)
+```
+
+A node may only reference an earlier node. This matches the current immutable `LinkStore` construction model and makes cycles/forward references explicit validation errors rather than partially materialized states.
+
+The root may also be an `Anchor`, including for an empty node list.
+
+## `find_projection`
+
+```text
+find_projection(const LinkStore&, description)
+    -> optional<ProjectionResult>
+```
+
+The operation is query-only by type and behavior:
+
+1. validate the description structure;
+2. resolve anchors with `contains`;
+3. resolve each dyad only with `find(begin,end)`;
+4. return absence as soon as a required anchor or dyad is missing;
+5. return the existing canonical LinkIds when the complete projection exists.
+
+It never calls `create_point` or `intern`. Tests assert store size before/after successful and unsuccessful queries.
+
+## `realize_projection`
+
+```text
+realize_projection(LinkStore&, description)
+    -> ProjectionResult
+```
+
+Realization is the explicit mutating operation:
+
+1. validate the full projection before writes;
+2. verify **all anchors** before writes;
+3. process nodes in topological order with `intern(begin,end)`;
+4. reuse existing canonical links where available;
+5. return the root and per-node LinkIds.
+
+Pre-validating every anchor prevents an ordinary missing-anchor error from creating a valid prefix and then failing halfway through the description.
+
+Repeated realization of the same description over the same anchors is idempotent because `intern` is canonical.
+
+## Identity ownership
+
+The external adapter/context owns the question "which existing AVM identity corresponds to this protocol-level entity?" and supplies an `Anchor(LinkId)` after resolving it.
+
+If a future protocol needs persistent external-symbol-to-point identity creation, that must become a separate explicit resolver contract. It must not be smuggled into query semantics, because doing so would violate the `find`-does-not-create invariant.
+
+## Relationship to Anum/MTS
+
+This layer corresponds to an L3/L4 boundary, not to Anum syntax itself:
+
+```text
+external raw source
+  -> external parse / validate / quote / project(context)
+  -> ProjectionDescription
+  -> AVM find_projection | realize_projection
+  -> canonical LinkStore denotation
+```
+
+`anum_docs` can later provide the real parser/projector adapter. AVM only knows the completed structural description and resolved anchors.

--- a/include/avm/projection.h
+++ b/include/avm/projection.h
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <optional>
 #include <stdexcept>
+#include <utility>
 #include <vector>
 
 namespace avm

--- a/include/avm/projection.h
+++ b/include/avm/projection.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "avm/link_store.h"
+
+#include <cstddef>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace avm
+{
+
+using ProjectionNodeId = std::size_t;
+
+struct ProjectionRef
+{
+	enum class Kind
+	{
+		Anchor,
+		Node,
+	};
+
+	Kind kind;
+	LinkId anchor_id;
+	ProjectionNodeId node_id;
+
+	static ProjectionRef anchor(LinkId id)
+	{
+		return ProjectionRef{Kind::Anchor, id, 0};
+	}
+
+	static ProjectionRef node(ProjectionNodeId id)
+	{
+		return ProjectionRef{Kind::Node, invalid_link_id, id};
+	}
+
+	bool operator==(const ProjectionRef &) const = default;
+};
+
+struct ProjectionNode
+{
+	ProjectionRef begin;
+	ProjectionRef end;
+
+	bool operator==(const ProjectionNode &) const = default;
+};
+
+struct ProjectionDescription
+{
+	std::vector<ProjectionNode> nodes;
+	ProjectionRef root;
+};
+
+struct ProjectionResult
+{
+	LinkId root;
+	std::vector<LinkId> nodes;
+};
+
+namespace detail
+{
+
+inline void validate_projection_ref(const ProjectionRef &ref, ProjectionNodeId available_nodes)
+{
+	if (ref.kind == ProjectionRef::Kind::Anchor)
+	{
+		if (ref.anchor_id == invalid_link_id)
+			throw std::invalid_argument("projection anchor cannot be invalid LinkId");
+		return;
+	}
+
+	if (ref.node_id >= available_nodes)
+		throw std::invalid_argument("projection node reference must target an earlier node");
+}
+
+inline void validate_projection_description(const ProjectionDescription &description)
+{
+	for (ProjectionNodeId index = 0; index < description.nodes.size(); ++index)
+	{
+		validate_projection_ref(description.nodes[index].begin, index);
+		validate_projection_ref(description.nodes[index].end, index);
+	}
+
+	validate_projection_ref(description.root, description.nodes.size());
+}
+
+inline std::optional<LinkId> resolve_projection_ref(const LinkStore &store, const ProjectionRef &ref,
+                                                    const std::vector<LinkId> &resolved_nodes)
+{
+	if (ref.kind == ProjectionRef::Kind::Anchor)
+	{
+		if (!store.contains(ref.anchor_id))
+			return std::nullopt;
+		return ref.anchor_id;
+	}
+
+	return resolved_nodes[ref.node_id];
+}
+
+inline void require_all_projection_anchors(const LinkStore &store, const ProjectionDescription &description)
+{
+	const auto require_anchor = [&store](const ProjectionRef &ref)
+	{
+		if (ref.kind == ProjectionRef::Kind::Anchor && !store.contains(ref.anchor_id))
+			throw std::invalid_argument("projection anchor is not present in LinkStore");
+	};
+
+	for (const ProjectionNode &node : description.nodes)
+	{
+		require_anchor(node.begin);
+		require_anchor(node.end);
+	}
+	require_anchor(description.root);
+}
+
+} // namespace detail
+
+inline std::optional<ProjectionResult> find_projection(const LinkStore &store, const ProjectionDescription &description)
+{
+	detail::validate_projection_description(description);
+
+	std::vector<LinkId> resolved_nodes;
+	resolved_nodes.reserve(description.nodes.size());
+
+	for (const ProjectionNode &node : description.nodes)
+	{
+		const auto begin = detail::resolve_projection_ref(store, node.begin, resolved_nodes);
+		const auto end = detail::resolve_projection_ref(store, node.end, resolved_nodes);
+		if (!begin || !end)
+			return std::nullopt;
+
+		const auto existing = store.find(*begin, *end);
+		if (!existing)
+			return std::nullopt;
+		resolved_nodes.push_back(*existing);
+	}
+
+	const auto root = detail::resolve_projection_ref(store, description.root, resolved_nodes);
+	if (!root)
+		return std::nullopt;
+
+	return ProjectionResult{*root, std::move(resolved_nodes)};
+}
+
+inline ProjectionResult realize_projection(LinkStore &store, const ProjectionDescription &description)
+{
+	detail::validate_projection_description(description);
+	detail::require_all_projection_anchors(store, description);
+
+	std::vector<LinkId> resolved_nodes;
+	resolved_nodes.reserve(description.nodes.size());
+
+	for (const ProjectionNode &node : description.nodes)
+	{
+		const LinkId begin = *detail::resolve_projection_ref(store, node.begin, resolved_nodes);
+		const LinkId end = *detail::resolve_projection_ref(store, node.end, resolved_nodes);
+		resolved_nodes.push_back(store.intern(begin, end));
+	}
+
+	const LinkId root = *detail::resolve_projection_ref(store, description.root, resolved_nodes);
+	return ProjectionResult{root, std::move(resolved_nodes)};
+}
+
+} // namespace avm

--- a/include/avm/projection.h
+++ b/include/avm/projection.h
@@ -25,15 +25,9 @@ struct ProjectionRef
 	LinkId anchor_id;
 	ProjectionNodeId node_id;
 
-	static ProjectionRef anchor(LinkId id)
-	{
-		return ProjectionRef{Kind::Anchor, id, 0};
-	}
+	static ProjectionRef anchor(LinkId id) { return ProjectionRef{Kind::Anchor, id, 0}; }
 
-	static ProjectionRef node(ProjectionNodeId id)
-	{
-		return ProjectionRef{Kind::Node, invalid_link_id, id};
-	}
+	static ProjectionRef node(ProjectionNodeId id) { return ProjectionRef{Kind::Node, invalid_link_id, id}; }
 
 	bool operator==(const ProjectionRef &) const = default;
 };

--- a/test/projection_test.cpp
+++ b/test/projection_test.cpp
@@ -1,0 +1,163 @@
+#include "avm/projection.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
+	const avm::LinkId c = store.create_point();
+
+	const avm::ProjectionDescription single{
+	    {{avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)}},
+	    avm::ProjectionRef::node(0),
+	};
+	const std::size_t before_find = store.size();
+	assert(!avm::find_projection(store, single).has_value());
+	assert(store.size() == before_find);
+
+	const avm::ProjectionResult single_realized = avm::realize_projection(store, single);
+	assert(single_realized.nodes.size() == 1);
+	assert(single_realized.root == single_realized.nodes[0]);
+	assert(store.get(single_realized.root) == (avm::Link{a, b}));
+
+	const std::size_t after_single_realize = store.size();
+	const auto single_found = avm::find_projection(store, single);
+	assert(single_found.has_value());
+	assert(single_found->root == single_realized.root);
+	assert(single_found->nodes == single_realized.nodes);
+	assert(store.size() == after_single_realize);
+	assert(avm::realize_projection(store, single).root == single_realized.root);
+	assert(store.size() == after_single_realize);
+
+	const avm::ProjectionDescription nested{
+	    {
+	        {avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)},
+	        {avm::ProjectionRef::node(0), avm::ProjectionRef::anchor(c)},
+	    },
+	    avm::ProjectionRef::node(1),
+	};
+	const std::size_t before_nested_find = store.size();
+	assert(!avm::find_projection(store, nested).has_value());
+	assert(store.size() == before_nested_find);
+
+	const avm::ProjectionResult nested_realized = avm::realize_projection(store, nested);
+	assert(nested_realized.nodes.size() == 2);
+	assert(nested_realized.nodes[0] == single_realized.root);
+	assert(store.get(nested_realized.root) == (avm::Link{single_realized.root, c}));
+
+	const std::size_t after_nested_realize = store.size();
+	const auto nested_found = avm::find_projection(store, nested);
+	assert(nested_found.has_value());
+	assert(nested_found->root == nested_realized.root);
+	assert(nested_found->nodes == nested_realized.nodes);
+	assert(store.size() == after_nested_realize);
+
+	const avm::ProjectionDescription duplicate_nodes{
+	    {
+	        {avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)},
+	        {avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)},
+	    },
+	    avm::ProjectionRef::node(1),
+	};
+	const std::size_t before_duplicate = store.size();
+	const avm::ProjectionResult duplicate_result = avm::realize_projection(store, duplicate_nodes);
+	assert(duplicate_result.nodes.size() == 2);
+	assert(duplicate_result.nodes[0] == duplicate_result.nodes[1]);
+	assert(duplicate_result.root == single_realized.root);
+	assert(store.size() == before_duplicate);
+
+	const avm::ProjectionDescription anchor_root{{}, avm::ProjectionRef::anchor(c)};
+	const std::size_t before_anchor_root = store.size();
+	const auto anchor_found = avm::find_projection(store, anchor_root);
+	assert(anchor_found.has_value());
+	assert(anchor_found->root == c);
+	assert(anchor_found->nodes.empty());
+	assert(avm::realize_projection(store, anchor_root).root == c);
+	assert(store.size() == before_anchor_root);
+
+	const avm::LinkId missing_anchor = 999999;
+	const avm::ProjectionDescription missing{
+	    {{avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(missing_anchor)}},
+	    avm::ProjectionRef::node(0),
+	};
+	const std::size_t before_missing_find = store.size();
+	assert(!avm::find_projection(store, missing).has_value());
+	assert(store.size() == before_missing_find);
+
+	bool missing_realize_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, missing));
+	}
+	catch (const std::invalid_argument &)
+	{
+		missing_realize_rejected = true;
+	}
+	assert(missing_realize_rejected);
+	assert(store.size() == before_missing_find);
+
+	const avm::LinkId d = store.create_point();
+	const avm::LinkId e = store.create_point();
+	const avm::ProjectionDescription no_partial_write{
+	    {
+	        {avm::ProjectionRef::anchor(d), avm::ProjectionRef::anchor(e)},
+	        {avm::ProjectionRef::node(0), avm::ProjectionRef::anchor(missing_anchor)},
+	    },
+	    avm::ProjectionRef::node(1),
+	};
+	const std::size_t before_no_partial_write = store.size();
+	bool no_partial_write_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, no_partial_write));
+	}
+	catch (const std::invalid_argument &)
+	{
+		no_partial_write_rejected = true;
+	}
+	assert(no_partial_write_rejected);
+	assert(store.size() == before_no_partial_write);
+	assert(!store.find(d, e).has_value());
+
+	const std::vector<avm::ProjectionDescription> malformed{
+	    {{{avm::ProjectionRef::node(0), avm::ProjectionRef::anchor(a)}}, avm::ProjectionRef::node(0)},
+	    {{{avm::ProjectionRef::node(1), avm::ProjectionRef::anchor(a)}}, avm::ProjectionRef::node(0)},
+	    {{{avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)}}, avm::ProjectionRef::node(1)},
+	    {{{avm::ProjectionRef::anchor(avm::invalid_link_id), avm::ProjectionRef::anchor(a)}},
+	     avm::ProjectionRef::node(0)},
+	};
+
+	for (const avm::ProjectionDescription &description : malformed)
+	{
+		const std::size_t before_invalid = store.size();
+		bool find_rejected = false;
+		try
+		{
+			static_cast<void>(avm::find_projection(store, description));
+		}
+		catch (const std::invalid_argument &)
+		{
+			find_rejected = true;
+		}
+		assert(find_rejected);
+		assert(store.size() == before_invalid);
+
+		bool realize_rejected = false;
+		try
+		{
+			static_cast<void>(avm::realize_projection(store, description));
+		}
+		catch (const std::invalid_argument &)
+		{
+			realize_rejected = true;
+		}
+		assert(realize_rejected);
+		assert(store.size() == before_invalid);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Closes #53. Parent #26 / Epic #31.

## Boundary
Adds neutral `ProjectionDescription` types with no JSON, Anum grammar, abits or parser dependency:

- `Anchor(LinkId)` — identity already resolved by the external adapter/context;
- `Node(NodeId)` — result of an earlier dyad in the same topologically ordered projection;
- `ProjectionNode{begin,end}`;
- root ref + `ProjectionResult`.

The model deliberately does not create anonymous points: `create_point()` establishes unique identity and a read-only structural query cannot infer which self-link an external entity means.

## Semantics
`find_projection(const LinkStore&, ...)`:
- validates the graph;
- uses only `contains` and `find`;
- never creates/interns;
- returns absence when an anchor/dyad is missing.

`realize_projection(LinkStore&, ...)`:
- validates the graph and all anchors before writes;
- materializes nodes in deterministic topological order using `intern` only;
- reuses canonical links;
- repeated realization is idempotent;
- never calls `create_point`.

## Tests
Adds `projection_tests` to the required core aggregate and sanitizer/portable coverage. Cases include missing/successful find with store-size checks, nested projections, partial-existing graphs, duplicate-node canonical convergence, anchor roots, missing anchors, prevalidation preventing ordinary partial writes, and malformed self/forward/root/invalid-anchor references.

## Documentation
Explains identity ownership and the intended external boundary:

`external parse/validate/quote/project(context) -> ProjectionDescription -> AVM find|realize -> LinkStore`.

This PR does not implement an Anum parser or protocol semantics.