### PR TITLE
AVM 1.0: separate raw source storage from denotation links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce RawCarrier isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E '#include "avm/|nlohmann|[Aa]num|[Aa]bit' include/avm/raw_carrier.h; then
+            echo "ERROR: RawCarrier must remain independent of AVM semantic/protocol layers"
+            exit 1
+          fi
+
       - name: Check AVM 1.0 and compatibility formatting
         shell: bash
         run: |
@@ -83,6 +92,7 @@ jobs:
             test/frame_runtime_test.cpp \
             test/deferred_definition_test.cpp \
             test/projection_test.cpp \
+            test/raw_carrier_test.cpp \
             test/json_projection_test.cpp \
             test/legacy_facade_test.cpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,11 @@ if(AVM_BUILD_CORE_TESTS)
         test/projection_test.cpp
         projection_tests)
 
+    avm_add_core_test(
+        avm_raw_carrier_test
+        test/raw_carrier_test.cpp
+        raw_carrier_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -209,7 +214,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_function_runtime_test
         avm_frame_runtime_test
         avm_deferred_definition_test
-        avm_projection_test)
+        avm_projection_test
+        avm_raw_carrier_test)
 endif()
 
 if(AVM_BUILD_JSON_COMPAT_TESTS)

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -86,7 +86,8 @@ Core:
 - `function_runtime_tests`;
 - `frame_runtime_tests`;
 - `deferred_definition_tests`;
-- `projection_tests` — parser-independent `ProjectionDescription`, read-only `find_projection`, explicit `realize_projection`, canonical reuse, invalid graph/anchor rejection and no-partial-write checks for missing anchors.
+- `projection_tests` — parser-independent `ProjectionDescription`, read-only `find_projection`, explicit `realize_projection`, canonical reuse, invalid graph/anchor rejection and no-partial-write checks for missing anchors;
+- `raw_carrier_tests` — opaque binary raw storage, independent raw/document identity, no LinkStore mutation on load/read/delete, and survival of realized denotation after raw deletion.
 
 Compatibility:
 

--- a/docs/raw-carrier.md
+++ b/docs/raw-carrier.md
@@ -1,0 +1,68 @@
+# RawCarrier: `raw(A)` is not `den(A)`
+
+`RawCarrier` stores opaque source material independently from AVM denotation links.
+
+The boundary enforces the invariant:
+
+```text
+raw(A) can exist while den(A) does not exist
+```
+
+and, conversely, a realized denotation can remain after its original raw carrier entry has been deleted.
+
+## Contract
+
+```text
+RawDocumentId put(RawBytes)
+optional<RawBytes> get(RawDocumentId) const
+bool contains(RawDocumentId) const
+bool erase(RawDocumentId)
+size_t size() const
+```
+
+The interface has no `LinkStore` parameter, no `ProjectionDescription`, no executor and no parser API. Therefore a raw load cannot materialize a link as an accidental side effect.
+
+`RawBytes` is binary, not text. Zero bytes and arbitrary byte values are valid payload content. Interpretation and character encoding belong to an external protocol adapter.
+
+## Identity
+
+`RawDocumentId` identifies a carrier record only. It is not a `LinkId` and does not define denotation identity.
+
+The in-memory reference carrier currently allocates a fresh document ID for every `put`, even for byte-identical payloads. Another backend may choose a different deduplication policy. That storage policy must not change the denotation produced by an external projector.
+
+## Lifecycle independence
+
+The supported lifecycle is deliberately asymmetric:
+
+```text
+put(raw)                 -> only RawCarrier changes
+project(raw, context)    -> external operation; produces ProjectionDescription
+find_projection(...)     -> only observes LinkStore
+realize_projection(...)  -> explicitly changes LinkStore
+erase(raw)               -> only RawCarrier changes
+```
+
+Deleting raw source never cascades into `LinkStore`. Deleting realized denotation, when such an operation is introduced, must likewise be explicit and must not be inferred from raw carrier lifetime.
+
+## Relationship to Anum
+
+For a future Anum adapter:
+
+```text
+RawCarrier
+   |
+   v
+external Anum L3 parser / validator / projector(context)
+   |
+   v
+ProjectionDescription
+   |
+   +--> find_projection(const LinkStore&, ...)
+   `--> realize_projection(LinkStore&, ...)
+```
+
+AVM does not know whether the bytes are Anum, JSON, a binary protocol or something else. This is intentional: parser/protocol semantics remain above the L4 memory boundary.
+
+## Reference implementation
+
+`InMemoryRawCarrier` is a test/reference backend only. Persistent raw storage, files, PMM integration, hashes and retention policies belong to backend work rather than to the semantic memory contract.

--- a/include/avm/raw_carrier.h
+++ b/include/avm/raw_carrier.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+using RawDocumentId = std::uint64_t;
+inline constexpr RawDocumentId invalid_raw_document_id = 0;
+using RawBytes = std::vector<std::uint8_t>;
+
+class RawCarrier
+{
+public:
+	virtual ~RawCarrier() = default;
+
+	virtual RawDocumentId put(RawBytes payload) = 0;
+	virtual std::optional<RawBytes> get(RawDocumentId id) const = 0;
+	virtual bool contains(RawDocumentId id) const = 0;
+	virtual bool erase(RawDocumentId id) = 0;
+	virtual std::size_t size() const = 0;
+};
+
+class InMemoryRawCarrier final : public RawCarrier
+{
+public:
+	RawDocumentId put(RawBytes payload) override
+	{
+		const RawDocumentId id = allocate_id();
+		documents_.emplace(id, std::move(payload));
+		return id;
+	}
+
+	std::optional<RawBytes> get(RawDocumentId id) const override
+	{
+		const auto found = documents_.find(id);
+		if (found == documents_.end())
+			return std::nullopt;
+		return found->second;
+	}
+
+	bool contains(RawDocumentId id) const override
+	{
+		return documents_.contains(id);
+	}
+
+	bool erase(RawDocumentId id) override
+	{
+		return documents_.erase(id) != 0;
+	}
+
+	std::size_t size() const override
+	{
+		return documents_.size();
+	}
+
+private:
+	RawDocumentId allocate_id()
+	{
+		if (next_id_ == invalid_raw_document_id)
+			throw std::overflow_error("RawDocumentId space exhausted");
+
+		const RawDocumentId id = next_id_;
+		if (next_id_ == std::numeric_limits<RawDocumentId>::max())
+			next_id_ = invalid_raw_document_id;
+		else
+			++next_id_;
+		return id;
+	}
+
+	std::map<RawDocumentId, RawBytes> documents_;
+	RawDocumentId next_id_ = 1;
+};
+
+} // namespace avm

--- a/include/avm/raw_carrier.h
+++ b/include/avm/raw_carrier.h
@@ -46,20 +46,11 @@ public:
 		return found->second;
 	}
 
-	bool contains(RawDocumentId id) const override
-	{
-		return documents_.contains(id);
-	}
+	bool contains(RawDocumentId id) const override { return documents_.contains(id); }
 
-	bool erase(RawDocumentId id) override
-	{
-		return documents_.erase(id) != 0;
-	}
+	bool erase(RawDocumentId id) override { return documents_.erase(id) != 0; }
 
-	std::size_t size() const override
-	{
-		return documents_.size();
-	}
+	std::size_t size() const override { return documents_.size(); }
 
 private:
 	RawDocumentId allocate_id()

--- a/test/raw_carrier_test.cpp
+++ b/test/raw_carrier_test.cpp
@@ -1,0 +1,78 @@
+#include "avm/projection.h"
+#include "avm/raw_carrier.h"
+
+#include <cassert>
+
+int main()
+{
+	avm::InMemoryRawCarrier raw;
+	avm::InMemoryLinkStore store;
+
+	const std::size_t initial_link_count = store.size();
+	const avm::RawBytes binary_payload{0x00, 0x01, 0x7f, 0x80, 0xff, 0x00};
+	const avm::RawDocumentId first = raw.put(binary_payload);
+	assert(first != avm::invalid_raw_document_id);
+	assert(raw.contains(first));
+	assert(raw.size() == 1);
+	assert(raw.get(first).has_value());
+	assert(*raw.get(first) == binary_payload);
+	assert(store.size() == initial_link_count);
+
+	const avm::RawDocumentId same_bytes = raw.put(binary_payload);
+	assert(same_bytes != first);
+	assert(raw.size() == 2);
+	assert(*raw.get(same_bytes) == binary_payload);
+	assert(store.size() == initial_link_count);
+
+	const avm::RawDocumentId empty = raw.put({});
+	assert(raw.contains(empty));
+	assert(raw.get(empty).has_value());
+	assert(raw.get(empty)->empty());
+	assert(raw.size() == 3);
+	assert(store.size() == initial_link_count);
+
+	assert(!raw.contains(avm::invalid_raw_document_id));
+	assert(!raw.get(avm::invalid_raw_document_id).has_value());
+	assert(!raw.get(999999).has_value());
+	assert(!raw.erase(999999));
+	assert(store.size() == initial_link_count);
+
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
+	const avm::ProjectionDescription description{
+	    {{avm::ProjectionRef::anchor(a), avm::ProjectionRef::anchor(b)}},
+	    avm::ProjectionRef::node(0),
+	};
+
+	const std::size_t before_projection = store.size();
+	assert(!avm::find_projection(store, description).has_value());
+	assert(store.size() == before_projection);
+
+	const avm::ProjectionResult realized = avm::realize_projection(store, description);
+	assert(store.contains(realized.root));
+	assert(store.get(realized.root) == (avm::Link{a, b}));
+	const std::size_t realized_link_count = store.size();
+
+	assert(raw.erase(first));
+	assert(!raw.contains(first));
+	assert(!raw.get(first).has_value());
+	assert(raw.size() == 2);
+	assert(store.size() == realized_link_count);
+	assert(store.contains(realized.root));
+	assert(avm::find_projection(store, description)->root == realized.root);
+
+	raw.erase(same_bytes);
+	raw.erase(empty);
+	assert(raw.size() == 0);
+	assert(store.size() == realized_link_count);
+	assert(store.contains(realized.root));
+
+	const avm::RawDocumentId after_clear = raw.put({0x41, 0x00, 0x42});
+	assert(after_clear != first);
+	assert(after_clear != same_bytes);
+	assert(after_clear != empty);
+	assert(*raw.get(after_clear) == (avm::RawBytes{0x41, 0x00, 0x42}));
+	assert(store.size() == realized_link_count);
+
+	return 0;
+}


### PR DESCRIPTION
Closes #54. Parent #26 / Epic #31.

## Boundary
Adds `RawCarrier` and an in-memory reference implementation for opaque binary source material:

- independent `RawDocumentId` namespace;
- `put/get/contains/erase/size`;
- arbitrary bytes including zero values;
- no `LinkStore`, projection, executor, JSON or Anum/parser dependency in the carrier header.

`RawDocumentId` is a carrier record identity, not a `LinkId` and not denotation identity. The reference backend deliberately gives byte-identical loads different document IDs, demonstrating that raw storage policy does not define semantic identity.

## Lifecycle invariant
The tests prove:

- raw load/read/delete leave `LinkStore::size()` unchanged;
- raw can exist while denotation is absent;
- a separately produced `ProjectionDescription` can be realized explicitly;
- deleting every raw carrier record leaves the realized denotation intact and findable;
- loading new raw data later still does not touch realized links.

## CI
- adds `raw_carrier_tests` to the core aggregate, warnings-as-errors, ASan/UBSan and portable matrix;
- quality gate statically rejects AVM/protocol/parser dependencies in `raw_carrier.h`.

This PR does not parse source bytes and does not connect raw lifetime to denotation lifetime.