### PR TITLE
AVM 1.0: prove external protocol adapter boundary without parser coupling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,15 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce external protocol-parser boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R -n -E '#include.*([Aa]num|[Aa]bit)|anum_parser|AnumParser|[Aa]bits?' src include/avm; then
+            echo "ERROR: Anum grammar/parser coupling must stay outside AVM production core"
+            exit 1
+          fi
+
       - name: Check AVM 1.0 and compatibility formatting
         shell: bash
         run: |
@@ -93,6 +102,7 @@ jobs:
             test/deferred_definition_test.cpp \
             test/projection_test.cpp \
             test/raw_carrier_test.cpp \
+            test/protocol_adapter_boundary_test.cpp \
             test/json_projection_test.cpp \
             test/legacy_facade_test.cpp
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,7 +46,7 @@ The C++ suites use `assert(...)` for invariant checks. CMake Release configurati
 
 The `CI` workflow separates six concerns:
 
-1. `Quality gates` — source-size policy, removal guard for `resolve_operator`/`func_def`/`param_stack`, and strict clang-format verification.
+1. `Quality gates` — source-size policy, removal guard for `resolve_operator`/`func_def`/`param_stack`, raw-carrier isolation, Anum/parser boundary enforcement and strict clang-format verification.
 2. `Core C++20 / warnings-as-errors` — Linux Debug core-only build and CTest.
 3. `JSON projection / warnings-as-errors` — Linux Debug build of JSON -> links -> runtime -> JSON with legacy facade disabled.
 4. `Legacy facade / warnings-as-errors` — strict build of the CLI and compatibility facade plus projection and roundtrip tests. This proves the historical outward API delegates to the new semantic path.
@@ -73,6 +73,14 @@ The historical recursive JSON interpreter was removed after its behavior was com
 
 The compatibility function name `clear_func_env()` remains only as an API reset shim. It destroys the current `JsonCompatibilitySession`; there is no `func_env` data structure behind it.
 
+## Protocol-layer guards
+
+`RawCarrier` is required to remain storage-only. CI rejects AVM semantic includes, JSON, Anum or abit references in `raw_carrier.h`.
+
+Production `src`/`include/avm` are also checked for direct Anum/abit parser coupling. The canonical grammar, tokenization, quotation/context projection and L3 parser belong outside AVM. The stable handoff into the VM is a completed `ProjectionDescription` over externally resolved `Anchor(LinkId)` values.
+
+No production `AnumParser` or generic protocol-adapter base class is required. Replaceability is tested by independently implemented adapters that converge through the same neutral projection contract.
+
 ## Test suites
 
 Core:
@@ -87,7 +95,8 @@ Core:
 - `frame_runtime_tests`;
 - `deferred_definition_tests`;
 - `projection_tests` — parser-independent `ProjectionDescription`, read-only `find_projection`, explicit `realize_projection`, canonical reuse, invalid graph/anchor rejection and no-partial-write checks for missing anchors;
-- `raw_carrier_tests` — opaque binary raw storage, independent raw/document identity, no LinkStore mutation on load/read/delete, and survival of realized denotation after raw deletion.
+- `raw_carrier_tests` — opaque binary raw storage, independent raw/document identity, no LinkStore mutation on load/read/delete, and survival of realized denotation after raw deletion;
+- `protocol_adapter_boundary_tests` — two unrelated external toy adapters consume different source representations, receive explicit context, converge to the same canonical relation entity, preserve non-mutating `find`, remain independent of raw lifetime, and demonstrate context-dependent denotation without parser coupling in AVM.
 
 Compatibility:
 

--- a/docs/protocol-adapter-contract.md
+++ b/docs/protocol-adapter-contract.md
@@ -1,0 +1,86 @@
+# External protocol adapter contract
+
+AVM 1.0 deliberately does **not** define an Anum parser interface. The stable boundary is composition of two neutral AVM contracts:
+
+```text
+optional raw source -> RawCarrier
+external parse / validate / quote / project(context)
+                    -> ProjectionDescription
+                    -> find_projection | realize_projection
+                    -> LinkStore denotation
+```
+
+The protocol implementation stays outside the VM. It may be Anum/MTS, another binary format, JSON, a prebuilt AST or a generated structure. AVM receives only opaque raw bytes when the caller chooses to retain them and a completed structural projection when the caller wants to query or realize denotation.
+
+## Responsibilities of the external adapter
+
+An adapter owns all protocol/model meaning needed before the AVM boundary:
+
+- source grammar and tokenization;
+- validation;
+- quoting/unquoting or description-level semantics;
+- projection context `K`;
+- external symbol/identity resolution into existing `Anchor(LinkId)` values;
+- construction of a topologically valid `ProjectionDescription`.
+
+The context is explicit adapter input. `LinkStore` does not guess context and `ProjectionDescription` does not perform name lookup.
+
+## Responsibilities of AVM
+
+AVM owns only the L4-facing mechanics:
+
+- optional opaque raw retention through `RawCarrier`;
+- a typed structural description made from `Anchor` and projection-local `Node` references;
+- read-only `find_projection(const LinkStore&, ...)`;
+- explicit `realize_projection(LinkStore&, ...)`;
+- canonical dyad identity supplied by `LinkStore::intern`.
+
+Neither raw loading nor projection query creates denotation.
+
+## No mandatory adapter base class
+
+There is intentionally no `AnumParser`, `ProtocolAdapter` virtual base class or template concept in AVM core. Such an abstraction would prescribe the source/AST/context types of external protocols without improving the memory contract.
+
+Replaceability is structural: any component that can produce a valid `ProjectionDescription` over resolved anchors can use AVM. Tests exercise this with two unrelated toy adapters:
+
+1. one consumes opaque binary bytes loaded from `RawCarrier`;
+2. another consumes an already parsed toy AST;
+3. both project the same relation entity over the same context;
+4. after one realization, the other finds exactly the same canonical LinkIds.
+
+That is the interoperability property AVM actually requires.
+
+## Context changes denotation explicitly
+
+If two adapters use the same structural rule but different resolved anchors/context, they may produce a different denotation. This is expected and tested. The store does not choose between contexts and does not silently create missing anchors.
+
+## Mapping to `anum_docs`
+
+The intended integration point follows the layer split documented in `netkeep80/anum_docs` and the invariants of its apamemory roadmap issue #72:
+
+```text
+Anum L3
+  raw syntax / parser / protocol / quote / context projection
+       |
+       v
+AVM neutral boundary
+  RawCarrier (optional) + ProjectionDescription
+       |
+       v
+AVM L4
+  find_projection / realize_projection / LinkStore
+```
+
+The key invariants align directly:
+
+- `raw(A)` may exist without `den(A)`;
+- loading raw does not realize denotation;
+- `find(A)` is observational and non-mutating;
+- `realize(A)` is the explicit materialization operation;
+- context and protocol semantics stay outside memory.
+
+This contract does not claim to define canonical MTS quotation, Anum grammar or the final external-symbol identity policy. Those remain the responsibility of the canonical L3 implementation.
+
+## Consequence for AVM issue #3
+
+The old request to add Anum serialization/deserialization directly to AVM should not reintroduce a parser inside the VM. A future production integration should implement an adapter against the canonical `anum_docs` L3 API and feed this boundary. Once that adapter exists, issue #3 can be closed as superseded or narrowed to that concrete integration package.

--- a/test/protocol_adapter_boundary_test.cpp
+++ b/test/protocol_adapter_boundary_test.cpp
@@ -46,7 +46,7 @@ public:
 		if (!source.relation_entity)
 			throw std::invalid_argument("toy AST does not describe a relation entity");
 
-		avm::ProjectionDescription description;
+		avm::ProjectionDescription description{{}, avm::ProjectionRef::anchor(context.relation)};
 		description.nodes.push_back(
 		    {avm::ProjectionRef::anchor(context.subject), avm::ProjectionRef::anchor(context.object)});
 		description.nodes.push_back(

--- a/test/protocol_adapter_boundary_test.cpp
+++ b/test/protocol_adapter_boundary_test.cpp
@@ -1,0 +1,166 @@
+#include "avm/projection.h"
+#include "avm/raw_carrier.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace
+{
+
+struct ToyContext
+{
+	avm::LinkId relation;
+	avm::LinkId subject;
+	avm::LinkId object;
+};
+
+class BinaryToyAdapter
+{
+public:
+	avm::ProjectionDescription project(const avm::RawBytes &source, const ToyContext &context) const
+	{
+		if (source != avm::RawBytes{0xca, 0xfe, 0x01})
+			throw std::invalid_argument("unexpected toy binary source");
+
+		return avm::ProjectionDescription{
+		    {
+		        {avm::ProjectionRef::anchor(context.subject), avm::ProjectionRef::anchor(context.object)},
+		        {avm::ProjectionRef::anchor(context.relation), avm::ProjectionRef::node(0)},
+		    },
+		    avm::ProjectionRef::node(1),
+		};
+	}
+};
+
+struct ToyAst
+{
+	bool relation_entity = false;
+};
+
+class AstToyAdapter
+{
+public:
+	avm::ProjectionDescription project(const ToyAst &source, const ToyContext &context) const
+	{
+		if (!source.relation_entity)
+			throw std::invalid_argument("toy AST does not describe a relation entity");
+
+		avm::ProjectionDescription description;
+		description.nodes.push_back(
+		    {avm::ProjectionRef::anchor(context.subject), avm::ProjectionRef::anchor(context.object)});
+		description.nodes.push_back(
+		    {avm::ProjectionRef::anchor(context.relation), avm::ProjectionRef::node(0)});
+		description.root = avm::ProjectionRef::node(1);
+		return description;
+	}
+};
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryRawCarrier raw;
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const ToyContext context{relation, subject, object};
+
+	const std::size_t anchor_count = store.size();
+	const avm::RawDocumentId raw_id = raw.put({0xca, 0xfe, 0x01});
+	assert(store.size() == anchor_count);
+
+	const auto loaded = raw.get(raw_id);
+	assert(loaded.has_value());
+	const BinaryToyAdapter binary_adapter;
+	const avm::ProjectionDescription binary_projection = binary_adapter.project(*loaded, context);
+	assert(store.size() == anchor_count);
+
+	const std::size_t before_find = store.size();
+	assert(!avm::find_projection(store, binary_projection).has_value());
+	assert(store.size() == before_find);
+
+	const avm::ProjectionResult realized = avm::realize_projection(store, binary_projection);
+	assert(realized.nodes.size() == 2);
+	assert(realized.root == realized.nodes[1]);
+	assert(avm::decode_relation_entity(store, realized.root) ==
+	       (avm::RelationEntity{relation, subject, object}));
+
+	const std::size_t after_realize = store.size();
+	const AstToyAdapter ast_adapter;
+	const avm::ProjectionDescription ast_projection = ast_adapter.project(ToyAst{true}, context);
+	assert(store.size() == after_realize);
+
+	const auto found_via_other_adapter = avm::find_projection(store, ast_projection);
+	assert(found_via_other_adapter.has_value());
+	assert(found_via_other_adapter->root == realized.root);
+	assert(found_via_other_adapter->nodes == realized.nodes);
+	assert(store.size() == after_realize);
+
+	const avm::ProjectionResult realized_again = avm::realize_projection(store, ast_projection);
+	assert(realized_again.root == realized.root);
+	assert(realized_again.nodes == realized.nodes);
+	assert(store.size() == after_realize);
+
+	assert(raw.erase(raw_id));
+	assert(!raw.contains(raw_id));
+	assert(store.size() == after_realize);
+	assert(avm::find_projection(store, ast_projection)->root == realized.root);
+
+	const avm::LinkId another_object = store.create_point();
+	const ToyContext another_context{relation, subject, another_object};
+	const avm::ProjectionDescription context_projection = ast_adapter.project(ToyAst{true}, another_context);
+	const std::size_t before_context_find = store.size();
+	assert(!avm::find_projection(store, context_projection).has_value());
+	assert(store.size() == before_context_find);
+
+	const avm::ProjectionResult context_realized = avm::realize_projection(store, context_projection);
+	assert(context_realized.root != realized.root);
+	assert(avm::decode_relation_entity(store, context_realized.root) ==
+	       (avm::RelationEntity{relation, subject, another_object}));
+
+	const ToyContext missing_context{relation, subject, 999999};
+	const avm::ProjectionDescription missing_projection = ast_adapter.project(ToyAst{true}, missing_context);
+	const std::size_t before_missing = store.size();
+	assert(!avm::find_projection(store, missing_projection).has_value());
+	assert(store.size() == before_missing);
+
+	bool missing_realize_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, missing_projection));
+	}
+	catch (const std::invalid_argument &)
+	{
+		missing_realize_rejected = true;
+	}
+	assert(missing_realize_rejected);
+	assert(store.size() == before_missing);
+
+	bool bad_binary_rejected = false;
+	try
+	{
+		static_cast<void>(binary_adapter.project(avm::RawBytes{0x00}, context));
+	}
+	catch (const std::invalid_argument &)
+	{
+		bad_binary_rejected = true;
+	}
+	assert(bad_binary_rejected);
+	assert(store.size() == before_missing);
+
+	bool bad_ast_rejected = false;
+	try
+	{
+		static_cast<void>(ast_adapter.project(ToyAst{false}, context));
+	}
+	catch (const std::invalid_argument &)
+	{
+		bad_ast_rejected = true;
+	}
+	assert(bad_ast_rejected);
+	assert(store.size() == before_missing);
+
+	return 0;
+}

--- a/test/protocol_adapter_boundary_test.cpp
+++ b/test/protocol_adapter_boundary_test.cpp
@@ -47,10 +47,16 @@ public:
 			throw std::invalid_argument("toy AST does not describe a relation entity");
 
 		avm::ProjectionDescription description{{}, avm::ProjectionRef::anchor(context.relation)};
-		description.nodes.push_back(
-		    {avm::ProjectionRef::anchor(context.subject), avm::ProjectionRef::anchor(context.object)});
-		description.nodes.push_back(
-		    {avm::ProjectionRef::anchor(context.relation), avm::ProjectionRef::node(0)});
+		const avm::ProjectionNode subject_object{
+		    avm::ProjectionRef::anchor(context.subject),
+		    avm::ProjectionRef::anchor(context.object),
+		};
+		const avm::ProjectionNode relation_subject_object{
+		    avm::ProjectionRef::anchor(context.relation),
+		    avm::ProjectionRef::node(0),
+		};
+		description.nodes.push_back(subject_object);
+		description.nodes.push_back(relation_subject_object);
 		description.root = avm::ProjectionRef::node(1);
 		return description;
 	}
@@ -84,8 +90,8 @@ int main()
 	const avm::ProjectionResult realized = avm::realize_projection(store, binary_projection);
 	assert(realized.nodes.size() == 2);
 	assert(realized.root == realized.nodes[1]);
-	assert(avm::decode_relation_entity(store, realized.root) ==
-	       (avm::RelationEntity{relation, subject, object}));
+	const avm::RelationEntity decoded = avm::decode_relation_entity(store, realized.root);
+	assert(decoded == (avm::RelationEntity{relation, subject, object}));
 
 	const std::size_t after_realize = store.size();
 	const AstToyAdapter ast_adapter;
@@ -117,8 +123,8 @@ int main()
 
 	const avm::ProjectionResult context_realized = avm::realize_projection(store, context_projection);
 	assert(context_realized.root != realized.root);
-	assert(avm::decode_relation_entity(store, context_realized.root) ==
-	       (avm::RelationEntity{relation, subject, another_object}));
+	const avm::RelationEntity context_decoded = avm::decode_relation_entity(store, context_realized.root);
+	assert(context_decoded == (avm::RelationEntity{relation, subject, another_object}));
 
 	const ToyContext missing_context{relation, subject, 999999};
 	const avm::ProjectionDescription missing_projection = ast_adapter.project(ToyAst{true}, missing_context);


### PR DESCRIPTION
Closes #55. Parent #26 / Epic #31.

## Contract
This PR deliberately adds no production Anum parser and no mandatory `ProtocolAdapter` base class. The stable integration surface is already the composition of:

`RawCarrier (optional) + external parse/validate/project(context) -> ProjectionDescription -> find_projection | realize_projection -> LinkStore`.

External adapters own grammar, validation, quotation/context semantics and protocol identity resolution into existing `Anchor(LinkId)` values. AVM owns only opaque raw retention, neutral structural descriptions, observational find and explicit realization.

## Replaceability proof
Adds a test-only conformance suite with two unrelated adapters:
- a binary adapter consumes opaque bytes loaded through `RawCarrier`;
- an AST adapter consumes an already parsed toy structure;
- both project the same Relations Model entity over the same explicit context;
- after one adapter realizes it, the other finds exactly the same canonical root and node LinkIds;
- repeated realization is idempotent;
- deleting raw source does not affect denotation;
- changing context changes denotation explicitly;
- missing context anchors and invalid external source fail without hidden LinkStore mutation.

## Layer enforcement
CI now rejects direct Anum/abit parser coupling under production `src` and `include/avm`, while the existing RawCarrier isolation guard remains in force. The new adapter-boundary suite is part of strict C++20, ASan/UBSan and portable Linux/Windows/macOS coverage.

## Documentation
Documents the exact L3/L4 responsibility split and maps it to `anum_docs` / apamemory #72 invariants: `raw(A)` independent of `den(A)`, load does not realize, find does not mutate, realize is explicit, and context/protocol semantics stay outside memory.

This establishes the AVM side of the future canonical Anum integration without duplicating the Anum parser in this repository.