### PR TITLE
CI: execute protocol adapter boundary test in all core lanes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,11 @@ if(AVM_BUILD_CORE_TESTS)
         test/raw_carrier_test.cpp
         raw_carrier_tests)
 
+    avm_add_core_test(
+        avm_protocol_adapter_boundary_test
+        test/protocol_adapter_boundary_test.cpp
+        protocol_adapter_boundary_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -215,7 +220,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_frame_runtime_test
         avm_deferred_definition_test
         avm_projection_test
-        avm_raw_carrier_test)
+        avm_raw_carrier_test
+        avm_protocol_adapter_boundary_test)
 endif()
 
 if(AVM_BUILD_JSON_COMPAT_TESTS)


### PR DESCRIPTION
Superseded by PR #64 before merge. #64 contains the same `protocol_adapter_boundary_test` CMake registration and exercises it together with the new persistent backend through the full CI matrix. Keeping two overlapping PRs would create unnecessary history/divergence.