### PR TITLE
AVM 1.0: add persistent reference LinkStore with reopen invariants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,7 @@ jobs:
             test/projection_test.cpp \
             test/raw_carrier_test.cpp \
             test/protocol_adapter_boundary_test.cpp \
+            test/persistent_link_store_test.cpp \
             test/json_projection_test.cpp \
             test/legacy_facade_test.cpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,16 @@ if(AVM_BUILD_CORE_TESTS)
         test/raw_carrier_test.cpp
         raw_carrier_tests)
 
+    avm_add_core_test(
+        avm_protocol_adapter_boundary_test
+        test/protocol_adapter_boundary_test.cpp
+        protocol_adapter_boundary_tests)
+
+    avm_add_core_test(
+        avm_persistent_link_store_test
+        test/persistent_link_store_test.cpp
+        persistent_link_store_tests)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -215,7 +225,9 @@ if(AVM_BUILD_CORE_TESTS)
         avm_frame_runtime_test
         avm_deferred_definition_test
         avm_projection_test
-        avm_raw_carrier_test)
+        avm_raw_carrier_test
+        avm_protocol_adapter_boundary_test
+        avm_persistent_link_store_test)
 endif()
 
 if(AVM_BUILD_JSON_COMPAT_TESTS)

--- a/docs/persistent-link-store.md
+++ b/docs/persistent-link-store.md
@@ -1,0 +1,80 @@
+# Persistent reference LinkStore
+
+`PersistentLinkStore` is the first persistence conformance backend for the AVM 1.0 `LinkStore` contract. Its purpose is to prove stable link identity and deterministic reopen semantics. It is deliberately a simple snapshot backend, not a production storage engine.
+
+## Contract
+
+The backend implements exactly the same semantic interface as `InMemoryLinkStore`:
+
+```text
+create_point
+intern(begin, end)
+find(begin, end)
+get(id)
+outgoing(begin)
+incoming(end)
+contains(id)
+size()
+```
+
+The Executor, Relations Model codec and projection layer depend only on `LinkStore`; they do not know whether the store is in-memory or persistent.
+
+## Identity and reopen
+
+Link IDs start at `1` and are persisted explicitly. Records are ordered by LinkId and v1 requires a contiguous namespace. After reopen:
+
+- every persisted LinkId denotes the same `(begin,end)` pair;
+- exact pair identity is rebuilt from records;
+- outgoing and incoming indexes are rebuilt deterministically;
+- `intern(a,b)` reuses the same canonical LinkId;
+- `find` and all other read operations do not rewrite the snapshot.
+
+A point remains an ordinary self-link `(id,id)`.
+
+## Snapshot format v1
+
+All integers are unsigned little-endian values. The file layout is:
+
+```text
+8 bytes   magic = "AVMLNK1\0"
+u32       version = 1
+u32       reserved = 0
+u64       record_count
+repeat record_count times:
+    u64   LinkId
+    u64   begin LinkId
+    u64   end LinkId
+```
+
+The loader rejects:
+
+- wrong or truncated magic;
+- unsupported version or non-zero reserved field;
+- truncated integers/records;
+- non-contiguous or duplicate LinkIds;
+- duplicate canonical `(begin,end)` pairs;
+- endpoints that do not exist in the completed snapshot;
+- impossible partial self-references;
+- trailing bytes after the declared records.
+
+This strictness prevents a corrupt file from being silently accepted as a different aset.
+
+## Mutation durability
+
+For v1 every successful new point or new canonical pair rewrites the complete snapshot. Reusing an existing pair performs no write.
+
+This gives simple deterministic persistence semantics suitable for conformance tests, but it is **not** a crash-consistency guarantee. In particular v1 has no WAL, fsync protocol, atomic snapshot swap, locking or concurrent-writer support. Those concerns belong to a production backend such as a later PMM adapter.
+
+## Why this backend exists
+
+AVM needs a concrete proof that persistence does not leak into VM semantics. The reference backend therefore optimizes for auditability:
+
+```text
+same LinkStore contract
+        |
+        +-- InMemoryLinkStore
+        |
+        +-- PersistentLinkStore -- close/reopen --> same LinkIds and links
+```
+
+A future PMM or LinksPlatform adapter should pass the same backend-neutral conformance suite rather than changing Executor behavior.

--- a/include/avm/persistent_link_store.h
+++ b/include/avm/persistent_link_store.h
@@ -1,0 +1,239 @@
+#pragma once
+
+#include "avm/link_store.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <limits>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+class PersistentLinkStore final : public LinkStore
+{
+public:
+	explicit PersistentLinkStore(std::filesystem::path path) : path_(std::move(path))
+	{
+		if (std::filesystem::exists(path_))
+			load();
+	}
+
+	LinkId create_point() override
+	{
+		const LinkId id = allocate_id();
+		insert_link(id, Link{id, id});
+		persist();
+		return id;
+	}
+
+	LinkId intern(LinkId begin, LinkId end) override
+	{
+		require_existing_endpoint(begin, "begin");
+		require_existing_endpoint(end, "end");
+
+		if (const auto existing = find(begin, end))
+			return *existing;
+
+		const LinkId id = allocate_id();
+		insert_link(id, Link{begin, end});
+		persist();
+		return id;
+	}
+
+	std::optional<LinkId> find(LinkId begin, LinkId end) const override
+	{
+		const auto it = exact_.find({begin, end});
+		if (it == exact_.end())
+			return std::nullopt;
+		return it->second;
+	}
+
+	Link get(LinkId id) const override
+	{
+		const auto it = links_.find(id);
+		if (it == links_.end())
+			throw std::out_of_range("unknown LinkId");
+		return it->second;
+	}
+
+	std::vector<LinkId> outgoing(LinkId begin) const override
+	{
+		const auto it = outgoing_.find(begin);
+		if (it == outgoing_.end())
+			return {};
+		return it->second;
+	}
+
+	std::vector<LinkId> incoming(LinkId end) const override
+	{
+		const auto it = incoming_.find(end);
+		if (it == incoming_.end())
+			return {};
+		return it->second;
+	}
+
+	bool contains(LinkId id) const override { return links_.contains(id); }
+
+	std::size_t size() const override { return links_.size(); }
+
+	const std::filesystem::path &path() const { return path_; }
+
+private:
+	using Pair = std::pair<LinkId, LinkId>;
+
+	static constexpr std::array<char, 8> magic_{{'A', 'V', 'M', 'L', 'N', 'K', '1', '\0'}};
+	static constexpr std::uint32_t format_version_ = 1;
+
+	static void write_u32(std::ostream &output, std::uint32_t value)
+	{
+		for (unsigned shift = 0; shift < 32; shift += 8)
+			output.put(static_cast<char>((value >> shift) & 0xffU));
+	}
+
+	static void write_u64(std::ostream &output, std::uint64_t value)
+	{
+		for (unsigned shift = 0; shift < 64; shift += 8)
+			output.put(static_cast<char>((value >> shift) & 0xffU));
+	}
+
+	static std::uint32_t read_u32(std::istream &input)
+	{
+		std::uint32_t value = 0;
+		for (unsigned shift = 0; shift < 32; shift += 8)
+		{
+			const int byte = input.get();
+			if (byte == std::char_traits<char>::eof())
+				throw std::runtime_error("truncated persistent LinkStore");
+			value |= static_cast<std::uint32_t>(static_cast<unsigned char>(byte)) << shift;
+		}
+		return value;
+	}
+
+	static std::uint64_t read_u64(std::istream &input)
+	{
+		std::uint64_t value = 0;
+		for (unsigned shift = 0; shift < 64; shift += 8)
+		{
+			const int byte = input.get();
+			if (byte == std::char_traits<char>::eof())
+				throw std::runtime_error("truncated persistent LinkStore");
+			value |= static_cast<std::uint64_t>(static_cast<unsigned char>(byte)) << shift;
+		}
+		return value;
+	}
+
+	LinkId allocate_id()
+	{
+		if (next_id_ == invalid_link_id || next_id_ == std::numeric_limits<LinkId>::max())
+			throw std::overflow_error("LinkId space exhausted");
+		return next_id_++;
+	}
+
+	void require_existing_endpoint(LinkId id, const char *role) const
+	{
+		if (!contains(id))
+			throw std::invalid_argument(std::string("unknown ") + role + " LinkId");
+	}
+
+	void insert_link(LinkId id, Link link)
+	{
+		const Pair pair{link.begin, link.end};
+		if (id == invalid_link_id || links_.contains(id))
+			throw std::runtime_error("duplicate or invalid persistent LinkId");
+		if (exact_.contains(pair))
+			throw std::runtime_error("duplicate canonical pair in persistent LinkStore");
+
+		links_.emplace(id, link);
+		exact_.emplace(pair, id);
+		outgoing_[link.begin].push_back(id);
+		incoming_[link.end].push_back(id);
+	}
+
+	void persist() const
+	{
+		if (path_.has_parent_path())
+			std::filesystem::create_directories(path_.parent_path());
+
+		std::ofstream output(path_, std::ios::binary | std::ios::trunc);
+		if (!output)
+			throw std::runtime_error("cannot open persistent LinkStore for writing");
+
+		output.write(magic_.data(), static_cast<std::streamsize>(magic_.size()));
+		write_u32(output, format_version_);
+		write_u32(output, 0);
+		write_u64(output, static_cast<std::uint64_t>(links_.size()));
+		for (const auto &[id, link] : links_)
+		{
+			write_u64(output, id);
+			write_u64(output, link.begin);
+			write_u64(output, link.end);
+		}
+		output.flush();
+		if (!output)
+			throw std::runtime_error("failed to persist LinkStore snapshot");
+	}
+
+	void load()
+	{
+		std::ifstream input(path_, std::ios::binary);
+		if (!input)
+			throw std::runtime_error("cannot open persistent LinkStore for reading");
+
+		std::array<char, magic_.size()> magic{};
+		input.read(magic.data(), static_cast<std::streamsize>(magic.size()));
+		if (input.gcount() != static_cast<std::streamsize>(magic.size()) || magic != magic_)
+			throw std::runtime_error("invalid persistent LinkStore magic");
+
+		const std::uint32_t version = read_u32(input);
+		const std::uint32_t reserved = read_u32(input);
+		if (version != format_version_ || reserved != 0)
+			throw std::runtime_error("unsupported persistent LinkStore format");
+
+		const std::uint64_t count = read_u64(input);
+		if (count >= std::numeric_limits<LinkId>::max())
+			throw std::runtime_error("persistent LinkStore record count is too large");
+
+		for (std::uint64_t index = 0; index < count; ++index)
+		{
+			const LinkId id = read_u64(input);
+			const LinkId begin = read_u64(input);
+			const LinkId end = read_u64(input);
+			if (id != index + 1)
+				throw std::runtime_error("persistent LinkStore LinkIds are not contiguous");
+			insert_link(id, Link{begin, end});
+		}
+
+		if (input.peek() != std::char_traits<char>::eof())
+			throw std::runtime_error("persistent LinkStore contains trailing data");
+
+		for (const auto &[id, link] : links_)
+		{
+			if (!contains(link.begin) || !contains(link.end))
+				throw std::runtime_error("persistent LinkStore contains unknown endpoint");
+			if (link.begin == id || link.end == id)
+			{
+				if (link.begin != id || link.end != id)
+					throw std::runtime_error("persistent LinkStore contains invalid self reference");
+			}
+		}
+
+		next_id_ = static_cast<LinkId>(count) + 1;
+	}
+
+	std::filesystem::path path_;
+	LinkId next_id_{1};
+	std::map<LinkId, Link> links_;
+	std::map<Pair, LinkId> exact_;
+	std::map<LinkId, std::vector<LinkId>> outgoing_;
+	std::map<LinkId, std::vector<LinkId>> incoming_;
+};
+
+} // namespace avm

--- a/test/persistent_link_store_test.cpp
+++ b/test/persistent_link_store_test.cpp
@@ -1,0 +1,185 @@
+#include "avm/persistent_link_store.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+std::filesystem::path temporary_path(const std::string &suffix)
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() /
+	       ("avm-persistent-link-store-" + std::to_string(nonce) + "-" + suffix + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+std::vector<char> read_file(const std::filesystem::path &path)
+{
+	std::ifstream input(path, std::ios::binary);
+	return {std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>()};
+}
+
+void expect_open_failure(const std::filesystem::path &path)
+{
+	bool rejected = false;
+	try
+	{
+		avm::PersistentLinkStore store(path);
+		static_cast<void>(store);
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+}
+
+void test_empty_reopen()
+{
+	const std::filesystem::path path = temporary_path("empty");
+	FileCleanup cleanup{path};
+	{
+		avm::PersistentLinkStore store(path);
+		assert(store.size() == 0);
+		const avm::LinkId point = store.create_point();
+		assert(point == 1);
+	}
+	{
+		avm::PersistentLinkStore reopened(path);
+		assert(reopened.size() == 1);
+		assert(reopened.get(1) == (avm::Link{1, 1}));
+	}
+}
+
+void test_reopen_identity_and_indexes()
+{
+	const std::filesystem::path path = temporary_path("identity");
+	FileCleanup cleanup{path};
+	avm::LinkId first = avm::invalid_link_id;
+	avm::LinkId second = avm::invalid_link_id;
+	avm::LinkId pair = avm::invalid_link_id;
+	avm::LinkId entity = avm::invalid_link_id;
+	std::vector<avm::LinkId> outgoing_before;
+	std::vector<avm::LinkId> incoming_before;
+
+	{
+		avm::PersistentLinkStore store(path);
+		first = store.create_point();
+		second = store.create_point();
+		pair = store.intern(first, second);
+		assert(store.intern(first, second) == pair);
+		entity = avm::encode_relation_entity(store, avm::RelationEntity{first, second, first});
+		outgoing_before = store.outgoing(first);
+		incoming_before = store.incoming(second);
+	}
+
+	const std::vector<char> bytes_before_find = read_file(path);
+	{
+		avm::PersistentLinkStore reopened(path);
+		assert(reopened.size() == 5);
+		assert(reopened.find(first, second) == pair);
+		assert(reopened.intern(first, second) == pair);
+		assert(reopened.outgoing(first) == outgoing_before);
+		assert(reopened.incoming(second) == incoming_before);
+		assert(avm::decode_relation_entity(reopened, entity) == (avm::RelationEntity{first, second, first}));
+
+		const std::size_t size_before_miss = reopened.size();
+		assert(!reopened.find(second, second + 1000).has_value());
+		assert(reopened.size() == size_before_miss);
+	}
+	assert(read_file(path) == bytes_before_find);
+
+	{
+		avm::PersistentLinkStore reopened_again(path);
+		assert(reopened_again.find(first, second) == pair);
+		assert(avm::decode_relation_entity(reopened_again, entity) ==
+		       (avm::RelationEntity{first, second, first}));
+	}
+}
+
+void test_corruption_rejection()
+{
+	const std::filesystem::path bad_magic_path = temporary_path("bad-magic");
+	FileCleanup bad_magic_cleanup{bad_magic_path};
+	{
+		std::ofstream output(bad_magic_path, std::ios::binary | std::ios::trunc);
+		output << "not-an-avm-store";
+	}
+	expect_open_failure(bad_magic_path);
+
+	const std::filesystem::path truncated_path = temporary_path("truncated");
+	FileCleanup truncated_cleanup{truncated_path};
+	{
+		avm::PersistentLinkStore store(truncated_path);
+		store.create_point();
+	}
+	std::filesystem::resize_file(truncated_path, 20);
+	expect_open_failure(truncated_path);
+
+	const std::filesystem::path trailing_path = temporary_path("trailing");
+	FileCleanup trailing_cleanup{trailing_path};
+	{
+		avm::PersistentLinkStore store(trailing_path);
+		store.create_point();
+	}
+	{
+		std::ofstream output(trailing_path, std::ios::binary | std::ios::app);
+		output.put('x');
+	}
+	expect_open_failure(trailing_path);
+}
+
+void test_endpoint_validation_survives_reopen()
+{
+	const std::filesystem::path path = temporary_path("endpoint");
+	FileCleanup cleanup{path};
+	{
+		avm::PersistentLinkStore store(path);
+		store.create_point();
+		bool rejected = false;
+		try
+		{
+			static_cast<void>(store.intern(1, 9999));
+		}
+		catch (const std::invalid_argument &)
+		{
+			rejected = true;
+		}
+		assert(rejected);
+		assert(store.size() == 1);
+	}
+	{
+		avm::PersistentLinkStore reopened(path);
+		assert(reopened.size() == 1);
+		assert(reopened.get(1) == (avm::Link{1, 1}));
+	}
+}
+
+} // namespace
+
+int main()
+{
+	test_empty_reopen();
+	test_reopen_identity_and_indexes();
+	test_corruption_rejection();
+	test_endpoint_validation_survives_reopen();
+	return 0;
+}

--- a/test/persistent_link_store_test.cpp
+++ b/test/persistent_link_store_test.cpp
@@ -110,8 +110,8 @@ void test_reopen_identity_and_indexes()
 	{
 		avm::PersistentLinkStore reopened_again(path);
 		assert(reopened_again.find(first, second) == pair);
-		assert(avm::decode_relation_entity(reopened_again, entity) ==
-		       (avm::RelationEntity{first, second, first}));
+		const avm::RelationEntity reopened_entity = avm::decode_relation_entity(reopened_again, entity);
+		assert(reopened_entity == (avm::RelationEntity{first, second, first}));
 	}
 }
 


### PR DESCRIPTION
Closes #59 and #62. Parent #27 / Epic #31.

## Backend
Adds `PersistentLinkStore`, a deliberately simple versioned binary snapshot backend implementing the existing `LinkStore` interface. Executor, Relations Model and projection semantics remain backend-agnostic.

## Persistence contract
- explicit stable LinkIds;
- canonical `(begin,end)` identity survives close/reopen;
- exact/outgoing/incoming indexes are rebuilt deterministically;
- existing `intern` and all read/query operations perform no snapshot rewrite;
- v1 format is documented as unsigned little-endian `AVMLNK1` records;
- loader rejects bad/truncated magic, unsupported format, non-contiguous/duplicate ids, duplicate canonical pairs, unknown endpoints, impossible partial self-reference and trailing bytes.

This is a conformance/reference backend, not a production durability claim: no WAL, fsync protocol, concurrent writers or crash-atomic snapshot swap.

## Tests
Adds `persistent_link_store_tests` covering create/reopen, stable IDs, canonical pair reuse across reopen, outgoing/incoming equivalence, Relations Model decode after reopen, non-mutating reads, repeated reopen, corruption rejection and invalid endpoint writes.

Also fixes #62 by actually registering `protocol_adapter_boundary_test.cpp` in CMake/CTest; PR #58 had only formatting-checked it. Both adapter and persistence suites are now dependencies of `avm_core_tests`, so strict `-Werror`, ASan/UBSan and portable Linux/Windows/macOS execute their assertions.

## CI rule
Merge only after the complete existing CI matrix is green and GitHub reports the PR mergeable.