### PR TITLE
AVM 1.0: execute persisted programs after backend reopen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
             test/raw_carrier_test.cpp \
             test/protocol_adapter_boundary_test.cpp \
             test/persistent_link_store_test.cpp \
+            test/vertical_slice_test.cpp \
             test/json_projection_test.cpp \
             test/legacy_facade_test.cpp
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,6 +214,15 @@ if(AVM_BUILD_CORE_TESTS)
         test/persistent_link_store_test.cpp
         persistent_link_store_tests)
 
+    add_executable(avm_vertical_slice_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/vertical_slice_test.cpp")
+    target_include_directories(avm_vertical_slice_test PRIVATE
+        "${CMAKE_CURRENT_SOURCE_DIR}/include"
+        "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+    avm_apply_quality(avm_vertical_slice_test)
+    avm_enable_test_assertions(avm_vertical_slice_test)
+    add_test(NAME vertical_slice_tests COMMAND avm_vertical_slice_test)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -227,7 +236,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_projection_test
         avm_raw_carrier_test
         avm_protocol_adapter_boundary_test
-        avm_persistent_link_store_test)
+        avm_persistent_link_store_test
+        avm_vertical_slice_test)
 endif()
 
 if(AVM_BUILD_JSON_COMPAT_TESTS)

--- a/docs/avm-1.0-vertical-slice.md
+++ b/docs/avm-1.0-vertical-slice.md
@@ -1,0 +1,78 @@
+# AVM 1.0 execution vertical slice
+
+This document describes the executable path exercised by `vertical_slice_tests`.
+
+## One semantic path
+
+```text
+JSON expression
+    |
+    v
+JsonProgramImporter
+    |
+    v
+LinkStore (InMemoryLinkStore or PersistentLinkStore)
+    |
+    v
+root LinkId
+    |
+    v
+BootstrapRuntime / Executor
+    |
+    v
+result LinkId
+```
+
+JSON is used only by the importer. `Executor` receives a `LinkId`; it does not receive or retain a JSON AST.
+
+The same materialized program entities are executable through the abstract `LinkStore` contract. The test covers NOT/AND/OR, lazy `If`, `Def`/`Call`, and a representative recursive call.
+
+## Persistent reopen
+
+The persistent scenario has two distinct phases.
+
+### Initial process/store lifetime
+
+1. Open an empty `PersistentLinkStore`.
+2. Create `BootstrapRuntime`; this introduces a bootstrap vocabulary with explicit `LinkId` identities.
+3. Import JSON expressions into links.
+4. Execute the imported roots and verify their observable results.
+5. Retain only structural identities needed to reopen the runtime: `BootstrapVocabulary` and root `LinkId` values.
+6. Close the store.
+
+### Reopened store lifetime
+
+1. Reopen the same `PersistentLinkStore`.
+2. Construct `BootstrapRuntime(store, saved_vocabulary)`.
+3. Verify runtime restoration does not change `store.size()`; truth-table materialization must reuse canonical links already present.
+4. Execute the saved root `LinkId` values directly.
+5. Repeat a second reopen to catch accidental one-reopen-only behavior.
+
+No JSON parse or import is performed in the reopen phase. The persisted executable graph is therefore the program state being executed, rather than an external AST being reconstructed on every start.
+
+## Bootstrap identity is persistent state
+
+A bootstrap vocabulary is not recreated on reopen. Relation identities such as `and_relation`, `if_relation`, `function_relation`, and `call_relation` are part of the materialized program's semantic address space.
+
+`BootstrapRuntime` therefore has two construction modes:
+
+```cpp
+BootstrapRuntime(store);              // create a new vocabulary
+BootstrapRuntime(store, vocabulary);  // restore an existing vocabulary
+```
+
+The restore path validates that every vocabulary `LinkId` exists and that all bootstrap identities are distinct. Invalid restored metadata is rejected before execution.
+
+A future production persistence layer may store a named/rooted reference to bootstrap metadata. The reference backend intentionally does not invent that policy: issue #59 proves stable link identity, while this vertical slice proves that the runtime can be restored when the correct structural identities are supplied.
+
+## Backend-neutral invariant
+
+`BootstrapRuntime`, `Executor`, Relations Model helpers and `ProgramBuilder` depend on `LinkStore`, not on `PersistentLinkStore` internals. Persistence format, index rebuild and filesystem behavior remain behind the backend boundary.
+
+The vertical slice is compiled into `avm_core_tests`, so it participates in:
+
+- C++20 warnings-as-errors;
+- ASan + UBSan on Linux;
+- Release portable runs on Linux, Windows and macOS.
+
+This is a correctness/conformance test, not a durability or performance claim. Crash consistency, WAL/journaling and production backend tuning remain separate work.

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -67,11 +67,16 @@ class BootstrapRuntime
 {
 public:
 	explicit BootstrapRuntime(LinkStore &store, std::size_t max_call_depth = 1000)
-	    : store_(store), vocabulary_(BootstrapVocabulary::create(store)), executor_(store),
-	      max_call_depth_(max_call_depth)
+	    : BootstrapRuntime(store, BootstrapVocabulary::create(store), max_call_depth)
+	{
+	}
+
+	BootstrapRuntime(LinkStore &store, BootstrapVocabulary vocabulary, std::size_t max_call_depth = 1000)
+	    : store_(store), vocabulary_(std::move(vocabulary)), executor_(store), max_call_depth_(max_call_depth)
 	{
 		if (max_call_depth_ == 0)
 			throw std::invalid_argument("maximum call depth must be greater than zero");
+		validate_vocabulary();
 		materialize_truth_tables();
 		register_handlers();
 	}
@@ -87,6 +92,26 @@ public:
 	LinkId execute(LinkId root) { return executor_.execute(root); }
 
 private:
+	void validate_vocabulary() const
+	{
+		const std::vector<LinkId> ids{
+		    vocabulary_.unit,            vocabulary_.nil,              vocabulary_.true_value,
+		    vocabulary_.false_value,     vocabulary_.quote_relation,   vocabulary_.parameter_relation,
+		    vocabulary_.sequence_relation, vocabulary_.not_relation,    vocabulary_.and_relation,
+		    vocabulary_.or_relation,     vocabulary_.if_relation,      vocabulary_.function_relation,
+		    vocabulary_.call_relation,   vocabulary_.binding_relation, vocabulary_.frame_relation,
+		};
+
+		std::set<LinkId> unique;
+		for (const LinkId id : ids)
+		{
+			if (!store_.contains(id))
+				throw std::invalid_argument("bootstrap vocabulary contains an unknown LinkId");
+			if (!unique.insert(id).second)
+				throw std::invalid_argument("bootstrap vocabulary identities must be distinct");
+		}
+	}
+
 	static void require_expression_subject(const ExecutionContext &context, LinkId unit)
 	{
 		if (context.subject != unit)

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -95,11 +95,21 @@ private:
 	void validate_vocabulary() const
 	{
 		const std::vector<LinkId> ids{
-		    vocabulary_.unit,            vocabulary_.nil,              vocabulary_.true_value,
-		    vocabulary_.false_value,     vocabulary_.quote_relation,   vocabulary_.parameter_relation,
-		    vocabulary_.sequence_relation, vocabulary_.not_relation,    vocabulary_.and_relation,
-		    vocabulary_.or_relation,     vocabulary_.if_relation,      vocabulary_.function_relation,
-		    vocabulary_.call_relation,   vocabulary_.binding_relation, vocabulary_.frame_relation,
+		    vocabulary_.unit,
+		    vocabulary_.nil,
+		    vocabulary_.true_value,
+		    vocabulary_.false_value,
+		    vocabulary_.quote_relation,
+		    vocabulary_.parameter_relation,
+		    vocabulary_.sequence_relation,
+		    vocabulary_.not_relation,
+		    vocabulary_.and_relation,
+		    vocabulary_.or_relation,
+		    vocabulary_.if_relation,
+		    vocabulary_.function_relation,
+		    vocabulary_.call_relation,
+		    vocabulary_.binding_relation,
+		    vocabulary_.frame_relation,
 		};
 
 		std::set<LinkId> unique;

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -15,8 +15,7 @@ using Json = nlohmann::json;
 std::filesystem::path temporary_path()
 {
 	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-	return std::filesystem::temp_directory_path() /
-	       ("avm-vertical-slice-" + std::to_string(nonce) + ".bin");
+	return std::filesystem::temp_directory_path() / ("avm-vertical-slice-" + std::to_string(nonce) + ".bin");
 }
 
 struct FileCleanup
@@ -56,8 +55,7 @@ ImportedProgram import_and_execute(avm::LinkStore &store)
 	const avm::LinkId lazy_if_root = importer.import_program(lazy_if_program);
 	assert(runtime.execute(lazy_if_root) == vocabulary.true_value);
 
-	const Json identity_definition = {
-	    {"Def", Json::array({"identity", Json::array({"x"}), "x"})}};
+	const Json identity_definition = {{"Def", Json::array({"identity", Json::array({"x"}), "x"})}};
 	const avm::LinkId identity_definition_root = importer.import_program(identity_definition);
 	assert(runtime.execute(identity_definition_root) == vocabulary.nil);
 
@@ -65,10 +63,10 @@ ImportedProgram import_and_execute(avm::LinkStore &store)
 	const avm::LinkId call_root = importer.import_program(identity_call);
 	assert(runtime.execute(call_root) == vocabulary.true_value);
 
+	const Json recursive_body = {
+	    {"If", Json::array({"x", true, Json{{"Call", Json::array({"eventually_true", true})}}})}};
 	const Json recursive_definition = {
-	    {"Def",
-	     Json::array({"eventually_true", Json::array({"x"}),
-	                  Json{{"If", Json::array({"x", true, Json{{"Call", Json::array({"eventually_true", true})}}})}}})}};
+	    {"Def", Json::array({"eventually_true", Json::array({"x"}), recursive_body})}};
 	const avm::LinkId recursive_definition_root = importer.import_program(recursive_definition);
 	assert(runtime.execute(recursive_definition_root) == vocabulary.nil);
 
@@ -80,14 +78,7 @@ ImportedProgram import_and_execute(avm::LinkStore &store)
 	assert(decoded_boolean.relation == vocabulary.and_relation);
 	assert(decoded_boolean.subject == vocabulary.unit);
 
-	return ImportedProgram{
-	    vocabulary,
-	    sequence_relation,
-	    boolean_root,
-	    lazy_if_root,
-	    call_root,
-	    recursive_call_root,
-	};
+	return ImportedProgram{vocabulary, sequence_relation, boolean_root, lazy_if_root, call_root, recursive_call_root};
 }
 
 void assert_program_executes(avm::LinkStore &store, const ImportedProgram &program)

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -1,0 +1,168 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/json_compat.h"
+#include "avm/persistent_link_store.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <string>
+
+namespace
+{
+
+using Json = nlohmann::json;
+
+std::filesystem::path temporary_path()
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() /
+	       ("avm-vertical-slice-" + std::to_string(nonce) + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+struct ImportedProgram
+{
+	avm::BootstrapVocabulary vocabulary;
+	avm::LinkId sequence_relation;
+	avm::LinkId boolean_root;
+	avm::LinkId lazy_if_root;
+	avm::LinkId call_root;
+	avm::LinkId recursive_call_root;
+};
+
+ImportedProgram import_and_execute(avm::LinkStore &store)
+{
+	avm::BootstrapRuntime runtime(store);
+	const avm::BootstrapVocabulary vocabulary = runtime.vocabulary();
+	const avm::LinkId sequence_relation = store.create_point();
+	avm::JsonProgramImporter importer(store, vocabulary, sequence_relation);
+
+	const Json boolean_program = {
+	    {"And", Json::array({Json{{"Not", Json::array({false})}}, Json{{"Or", Json::array({false, true})}}})}};
+	const avm::LinkId boolean_root = importer.import_program(boolean_program);
+	assert(runtime.execute(boolean_root) == vocabulary.true_value);
+
+	const Json lazy_if_program = {
+	    {"If", Json::array({true, Json{{"Not", Json::array({false})}}, Json{{"Call", Json::array({"missing"})}}})}};
+	const avm::LinkId lazy_if_root = importer.import_program(lazy_if_program);
+	assert(runtime.execute(lazy_if_root) == vocabulary.true_value);
+
+	const Json identity_definition = {
+	    {"Def", Json::array({"identity", Json::array({"x"}), "x"})}};
+	const avm::LinkId identity_definition_root = importer.import_program(identity_definition);
+	assert(runtime.execute(identity_definition_root) == vocabulary.nil);
+
+	const Json identity_call = {{"Call", Json::array({"identity", true})}};
+	const avm::LinkId call_root = importer.import_program(identity_call);
+	assert(runtime.execute(call_root) == vocabulary.true_value);
+
+	const Json recursive_definition = {
+	    {"Def",
+	     Json::array({"eventually_true", Json::array({"x"}),
+	                  Json{{"If", Json::array({"x", true, Json{{"Call", Json::array({"eventually_true", true})}}})}}})}};
+	const avm::LinkId recursive_definition_root = importer.import_program(recursive_definition);
+	assert(runtime.execute(recursive_definition_root) == vocabulary.nil);
+
+	const Json recursive_call = {{"Call", Json::array({"eventually_true", false})}};
+	const avm::LinkId recursive_call_root = importer.import_program(recursive_call);
+	assert(runtime.execute(recursive_call_root) == vocabulary.true_value);
+
+	const avm::RelationEntity decoded_boolean = avm::decode_relation_entity(store, boolean_root);
+	assert(decoded_boolean.relation == vocabulary.and_relation);
+	assert(decoded_boolean.subject == vocabulary.unit);
+
+	return ImportedProgram{
+	    vocabulary,
+	    sequence_relation,
+	    boolean_root,
+	    lazy_if_root,
+	    call_root,
+	    recursive_call_root,
+	};
+}
+
+void assert_program_executes(avm::LinkStore &store, const ImportedProgram &program)
+{
+	const std::size_t before_restore = store.size();
+	avm::BootstrapRuntime runtime(store, program.vocabulary);
+	assert(store.size() == before_restore);
+
+	assert(store.contains(program.boolean_root));
+	assert(store.contains(program.lazy_if_root));
+	assert(store.contains(program.call_root));
+	assert(store.contains(program.recursive_call_root));
+
+	assert(runtime.execute(program.boolean_root) == program.vocabulary.true_value);
+	assert(runtime.execute(program.lazy_if_root) == program.vocabulary.true_value);
+	assert(runtime.execute(program.call_root) == program.vocabulary.true_value);
+	assert(runtime.execute(program.recursive_call_root) == program.vocabulary.true_value);
+}
+
+void test_in_memory_vertical_slice()
+{
+	avm::InMemoryLinkStore store;
+	const ImportedProgram program = import_and_execute(store);
+	assert_program_executes(store, program);
+}
+
+void test_persistent_reopen_vertical_slice()
+{
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	ImportedProgram program{};
+
+	{
+		avm::PersistentLinkStore store(path);
+		program = import_and_execute(store);
+		assert(store.contains(program.boolean_root));
+	}
+
+	{
+		avm::PersistentLinkStore reopened(path);
+		assert_program_executes(reopened, program);
+	}
+
+	{
+		avm::PersistentLinkStore reopened_again(path);
+		assert_program_executes(reopened_again, program);
+	}
+}
+
+void test_invalid_restored_vocabulary_rejected()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::BootstrapVocabulary invalid = runtime.vocabulary();
+	invalid.frame_relation = invalid.binding_relation;
+
+	bool rejected = false;
+	try
+	{
+		avm::BootstrapRuntime restored(store, invalid);
+		static_cast<void>(restored);
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+}
+
+} // namespace
+
+int main()
+{
+	test_in_memory_vertical_slice();
+	test_persistent_reopen_vertical_slice();
+	test_invalid_restored_vocabulary_rejected();
+	return 0;
+}

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -65,8 +65,8 @@ ImportedProgram import_and_execute(avm::LinkStore &store)
 
 	const Json recursive_body = {
 	    {"If", Json::array({"x", true, Json{{"Call", Json::array({"eventually_true", true})}}})}};
-	const Json recursive_definition = {
-	    {"Def", Json::array({"eventually_true", Json::array({"x"}), recursive_body})}};
+	const Json recursive_definition_arguments = Json::array({"eventually_true", Json::array({"x"}), recursive_body});
+	const Json recursive_definition = {{"Def", recursive_definition_arguments}};
 	const avm::LinkId recursive_definition_root = importer.import_program(recursive_definition);
 	assert(runtime.execute(recursive_definition_root) == vocabulary.nil);
 


### PR DESCRIPTION
Closes #60. Parent #27 / Epic #31.

## Runtime restore
Adds an explicit `BootstrapRuntime(LinkStore&, BootstrapVocabulary, ...)` restore path. A reopened runtime reuses the original bootstrap relation/value LinkIds instead of silently allocating a second vocabulary. Restore validates that every vocabulary LinkId exists and that bootstrap identities are distinct.

## Vertical slice
Adds `vertical_slice_tests` that exercise the same semantic path over `InMemoryLinkStore` and `PersistentLinkStore`:

`JSON -> JsonProgramImporter -> materialized links -> root LinkId -> BootstrapRuntime/Executor -> result LinkId`.

The test covers:
- NOT/AND/OR;
- lazy If with an invalid unselected branch;
- Def/Call;
- representative recursion;
- direct structural proof that imported roots are Relations Model entities.

For the persistent backend the test closes and reopens the store twice, restores the original bootstrap vocabulary, and executes previously saved root LinkIds without reparsing or reimporting JSON. Runtime restoration is asserted not to mutate store size.

## CI
`vertical_slice_tests` is part of `avm_core_tests`, therefore it runs under strict C++20 warnings-as-errors, ASan+UBSan, and portable Linux/Windows/macOS. The quality gate also clang-format checks the new suite.

## Documentation
Adds `docs/avm-1.0-vertical-slice.md` documenting the single semantic path, persistent reopen phases, bootstrap identity requirements, and backend-neutral boundary.

A later small documentation cleanup will align the historical README/analysis/plan wording with the now-current AVM 1.0 architecture; this PR focuses on executable proof of the vertical slice.