### PR TITLE
AVM 1.0: add performance baseline workflow and artifacts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,51 @@
+name: Benchmark
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    name: Performance baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y clang-format
+
+      - name: Check benchmark formatting
+        run: clang-format --dry-run --Werror benchmark/avm_benchmark.cpp
+
+      - name: Configure benchmark
+        run: cmake -S benchmark -B build-benchmark -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build benchmark
+        run: cmake --build build-benchmark --config Release --parallel
+
+      - name: Run benchmark smoke
+        run: ./build-benchmark/avm_benchmark > avm-benchmark.tsv
+
+      - name: Validate TSV output
+        shell: bash
+        run: |
+          set -euo pipefail
+          head -n 1 avm-benchmark.tsv | grep -F $'name\toperations\telapsed_ns\tns_per_op'
+          for name in intern_new_pair intern_existing_pair find_hit find_miss outgoing_query incoming_query relations_model_encode relations_model_decode execute_minimal_relation persistent_reopen_index_rebuild; do
+            grep -F "${name}" avm-benchmark.tsv >/dev/null
+          done
+
+      - name: Upload benchmark result
+        uses: actions/upload-artifact@v4
+        with:
+          name: avm-benchmark-${{ github.sha }}
+          path: avm-benchmark.tsv
+          if-no-files-found: error

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+
+project(avm_benchmark LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(avm_benchmark avm_benchmark.cpp)
+target_include_directories(avm_benchmark PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/../include")
+
+if(MSVC)
+    target_compile_options(avm_benchmark PRIVATE /W4 /WX)
+else()
+    target_compile_options(avm_benchmark PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -33,27 +33,22 @@ struct FileCleanup
 	}
 };
 
-template <class Function>
-Measurement measure(std::string_view name, std::size_t operations, Function &&function)
+Measurement measure(std::string_view name, std::size_t operations, auto &&function)
 {
 	const auto started = Clock::now();
 	for (std::size_t i = 0; i < operations; ++i)
 		function(i);
 	const auto finished = Clock::now();
-	return Measurement{
-	    name,
-	    operations,
-	    static_cast<std::uint64_t>(
-	        std::chrono::duration_cast<std::chrono::nanoseconds>(finished - started).count()),
-	};
+	const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(finished - started).count();
+	return Measurement{name, operations, static_cast<std::uint64_t>(elapsed)};
 }
 
 void print(const Measurement &measurement)
 {
-	const double ns_per_op = measurement.operations == 0
-	                             ? 0.0
-	                             : static_cast<double>(measurement.elapsed_ns) /
-	                                   static_cast<double>(measurement.operations);
+	double ns_per_op = 0.0;
+	if (measurement.operations != 0)
+		ns_per_op = static_cast<double>(measurement.elapsed_ns) / static_cast<double>(measurement.operations);
+
 	std::cout << measurement.name << '\t' << measurement.operations << '\t' << measurement.elapsed_ns << '\t'
 	          << ns_per_op << '\n';
 }
@@ -81,58 +76,61 @@ int main()
 
 	std::vector<avm::LinkId> pairs;
 	pairs.reserve(sample_size);
-	print(measure("intern_new_pair", sample_size,
-	              [&](std::size_t i) { pairs.push_back(store.intern(points[i], points[i + 1])); }));
+	const auto intern_new = [&](std::size_t i) { pairs.push_back(store.intern(points[i], points[i + 1])); };
+	print(measure("intern_new_pair", sample_size, intern_new));
 
 	std::size_t sink = 0;
-	print(measure("intern_existing_pair", query_iterations,
-	              [&](std::size_t i)
-	              {
-		              sink ^= static_cast<std::size_t>(
-		                  store.intern(points[i % sample_size], points[(i % sample_size) + 1]));
-	              }));
+	const auto intern_existing = [&](std::size_t i)
+	{
+		const avm::LinkId id = store.intern(points[i % sample_size], points[(i % sample_size) + 1]);
+		sink ^= static_cast<std::size_t>(id);
+	};
+	print(measure("intern_existing_pair", query_iterations, intern_existing));
 
-	print(measure("find_hit", query_iterations,
-	              [&](std::size_t i)
-	              {
-		              const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 1]);
-		              sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
-	              }));
+	const auto find_hit = [&](std::size_t i)
+	{
+		const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 1]);
+		sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
+	};
+	print(measure("find_hit", query_iterations, find_hit));
 
-	print(measure("find_miss", query_iterations,
-	              [&](std::size_t i)
-	              {
-		              const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 2]);
-		              sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
-	              }));
+	const auto find_miss = [&](std::size_t i)
+	{
+		const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 2]);
+		sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
+	};
+	print(measure("find_miss", query_iterations, find_miss));
 
-	print(measure("outgoing_query", query_iterations,
-	              [&](std::size_t i) { sink ^= store.outgoing(points[i % sample_size]).size(); }));
-	print(measure("incoming_query", query_iterations,
-	              [&](std::size_t i) { sink ^= store.incoming(points[(i % sample_size) + 1]).size(); }));
+	const auto outgoing_query = [&](std::size_t i) { sink ^= store.outgoing(points[i % sample_size]).size(); };
+	print(measure("outgoing_query", query_iterations, outgoing_query));
+
+	const auto incoming_query = [&](std::size_t i) { sink ^= store.incoming(points[(i % sample_size) + 1]).size(); };
+	print(measure("incoming_query", query_iterations, incoming_query));
 
 	const avm::LinkId relation = store.create_point();
 	const avm::LinkId subject = store.create_point();
 	const avm::LinkId object = store.create_point();
 	avm::LinkId entity = avm::invalid_link_id;
-	print(measure("relations_model_encode", query_iterations,
-	              [&](std::size_t)
-	              {
-		              entity = avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
-		              sink ^= static_cast<std::size_t>(entity);
-	              }));
-	print(measure("relations_model_decode", query_iterations,
-	              [&](std::size_t)
-	              {
-		              const avm::RelationEntity decoded = avm::decode_relation_entity(store, entity);
-		              sink ^= static_cast<std::size_t>(decoded.object);
-	              }));
+
+	const auto encode_entity = [&](std::size_t)
+	{
+		entity = avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+		sink ^= static_cast<std::size_t>(entity);
+	};
+	print(measure("relations_model_encode", query_iterations, encode_entity));
+
+	const auto decode_entity = [&](std::size_t)
+	{
+		const avm::RelationEntity decoded = avm::decode_relation_entity(store, entity);
+		sink ^= static_cast<std::size_t>(decoded.object);
+	};
+	print(measure("relations_model_decode", query_iterations, decode_entity));
 
 	avm::BootstrapRuntime runtime(store);
 	avm::ProgramBuilder builder = runtime.builder();
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
-	print(measure("execute_minimal_relation", query_iterations,
-	              [&](std::size_t) { sink ^= static_cast<std::size_t>(runtime.execute(expression)); }));
+	const auto execute_minimal = [&](std::size_t) { sink ^= static_cast<std::size_t>(runtime.execute(expression)); };
+	print(measure("execute_minimal_relation", query_iterations, execute_minimal));
 
 	const std::filesystem::path persistent_path = temporary_store_path();
 	FileCleanup cleanup{persistent_path};
@@ -146,12 +144,12 @@ int main()
 			static_cast<void>(persistent.intern(persistent_points[i], persistent_points[i + 1]));
 	}
 
-	print(measure("persistent_reopen_index_rebuild", 1,
-	              [&](std::size_t)
-	              {
-		              avm::PersistentLinkStore reopened(persistent_path);
-		              sink ^= reopened.size();
-	              }));
+	const auto reopen_persistent = [&](std::size_t)
+	{
+		avm::PersistentLinkStore reopened(persistent_path);
+		sink ^= reopened.size();
+	};
+	print(measure("persistent_reopen_index_rebuild", 1, reopen_persistent));
 
 	std::cout << "# sink\t" << sink << '\n';
 	return 0;

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -1,0 +1,118 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/relations_model.h"
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string_view>
+#include <vector>
+
+namespace
+{
+
+using Clock = std::chrono::steady_clock;
+
+struct Measurement
+{
+	std::string_view name;
+	std::size_t operations;
+	std::uint64_t elapsed_ns;
+};
+
+template <class Function>
+Measurement measure(std::string_view name, std::size_t operations, Function &&function)
+{
+	const auto started = Clock::now();
+	for (std::size_t i = 0; i < operations; ++i)
+		function(i);
+	const auto finished = Clock::now();
+	return Measurement{
+	    name,
+	    operations,
+	    static_cast<std::uint64_t>(
+	        std::chrono::duration_cast<std::chrono::nanoseconds>(finished - started).count()),
+	};
+}
+
+void print(const Measurement &measurement)
+{
+	const double ns_per_op = measurement.operations == 0
+	                             ? 0.0
+	                             : static_cast<double>(measurement.elapsed_ns) /
+	                                   static_cast<double>(measurement.operations);
+	std::cout << measurement.name << '\t' << measurement.operations << '\t' << measurement.elapsed_ns << '\t'
+	          << ns_per_op << '\n';
+}
+
+} // namespace
+
+int main()
+{
+	constexpr std::size_t sample_size = 20000;
+	constexpr std::size_t query_iterations = 100000;
+
+	avm::InMemoryLinkStore store;
+	std::vector<avm::LinkId> points;
+	points.reserve(sample_size + 2);
+	for (std::size_t i = 0; i < sample_size + 2; ++i)
+		points.push_back(store.create_point());
+
+	std::vector<avm::LinkId> pairs;
+	pairs.reserve(sample_size);
+	print(measure("intern_new_pair", sample_size,
+	              [&](std::size_t i) { pairs.push_back(store.intern(points[i], points[i + 1])); }));
+
+	std::size_t sink = 0;
+	print(measure("intern_existing_pair", query_iterations,
+	              [&](std::size_t i)
+	              {
+		              sink ^= static_cast<std::size_t>(
+		                  store.intern(points[i % sample_size], points[(i % sample_size) + 1]));
+	              }));
+
+	print(measure("find_hit", query_iterations,
+	              [&](std::size_t i)
+	              {
+		              const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 1]);
+		              sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
+	              }));
+
+	print(measure("find_miss", query_iterations,
+	              [&](std::size_t i)
+	              {
+		              const auto found = store.find(points[i % sample_size], points[(i % sample_size) + 2]);
+		              sink ^= static_cast<std::size_t>(found.value_or(avm::invalid_link_id));
+	              }));
+
+	print(measure("outgoing_query", query_iterations,
+	              [&](std::size_t i) { sink ^= store.outgoing(points[i % sample_size]).size(); }));
+	print(measure("incoming_query", query_iterations,
+	              [&](std::size_t i) { sink ^= store.incoming(points[(i % sample_size) + 1]).size(); }));
+
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	avm::LinkId entity = avm::invalid_link_id;
+	print(measure("relations_model_encode", query_iterations,
+	              [&](std::size_t)
+	              {
+		              entity = avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+		              sink ^= static_cast<std::size_t>(entity);
+	              }));
+	print(measure("relations_model_decode", query_iterations,
+	              [&](std::size_t)
+	              {
+		              const avm::RelationEntity decoded = avm::decode_relation_entity(store, entity);
+		              sink ^= static_cast<std::size_t>(decoded.object);
+	              }));
+
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
+	print(measure("execute_minimal_relation", query_iterations,
+	              [&](std::size_t) { sink ^= static_cast<std::size_t>(runtime.execute(expression)); }));
+
+	std::cout << "# sink\t" << sink << '\n';
+	return 0;
+}

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -1,10 +1,13 @@
 #include "avm/bootstrap_runtime.h"
+#include "avm/persistent_link_store.h"
 #include "avm/relations_model.h"
 
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <iostream>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -18,6 +21,16 @@ struct Measurement
 	std::string_view name;
 	std::size_t operations;
 	std::uint64_t elapsed_ns;
+};
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
 };
 
 template <class Function>
@@ -45,12 +58,20 @@ void print(const Measurement &measurement)
 	          << ns_per_op << '\n';
 }
 
+std::filesystem::path temporary_store_path()
+{
+	const auto nonce = Clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() / ("avm-benchmark-" + std::to_string(nonce) + ".bin");
+}
+
 } // namespace
 
 int main()
 {
 	constexpr std::size_t sample_size = 20000;
 	constexpr std::size_t query_iterations = 100000;
+
+	std::cout << "name\toperations\telapsed_ns\tns_per_op\n";
 
 	avm::InMemoryLinkStore store;
 	std::vector<avm::LinkId> points;
@@ -112,6 +133,25 @@ int main()
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
 	print(measure("execute_minimal_relation", query_iterations,
 	              [&](std::size_t) { sink ^= static_cast<std::size_t>(runtime.execute(expression)); }));
+
+	const std::filesystem::path persistent_path = temporary_store_path();
+	FileCleanup cleanup{persistent_path};
+	{
+		avm::PersistentLinkStore persistent(persistent_path);
+		std::vector<avm::LinkId> persistent_points;
+		persistent_points.reserve(sample_size + 1);
+		for (std::size_t i = 0; i < sample_size + 1; ++i)
+			persistent_points.push_back(persistent.create_point());
+		for (std::size_t i = 0; i < sample_size; ++i)
+			static_cast<void>(persistent.intern(persistent_points[i], persistent_points[i + 1]));
+	}
+
+	print(measure("persistent_reopen_index_rebuild", 1,
+	              [&](std::size_t)
+	              {
+		              avm::PersistentLinkStore reopened(persistent_path);
+		              sink ^= reopened.size();
+	              }));
 
 	std::cout << "# sink\t" << sink << '\n';
 	return 0;

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -65,6 +65,7 @@ int main()
 {
 	constexpr std::size_t sample_size = 20000;
 	constexpr std::size_t query_iterations = 100000;
+	constexpr std::size_t persistent_sample_size = 256;
 
 	std::cout << "name\toperations\telapsed_ns\tns_per_op\n";
 
@@ -137,10 +138,10 @@ int main()
 	{
 		avm::PersistentLinkStore persistent(persistent_path);
 		std::vector<avm::LinkId> persistent_points;
-		persistent_points.reserve(sample_size + 1);
-		for (std::size_t i = 0; i < sample_size + 1; ++i)
+		persistent_points.reserve(persistent_sample_size + 1);
+		for (std::size_t i = 0; i < persistent_sample_size + 1; ++i)
 			persistent_points.push_back(persistent.create_point());
-		for (std::size_t i = 0; i < sample_size; ++i)
+		for (std::size_t i = 0; i < persistent_sample_size; ++i)
 			static_cast<void>(persistent.intern(persistent_points[i], persistent_points[i + 1]));
 	}
 

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -1,0 +1,45 @@
+# AVM performance baseline
+
+The AVM benchmark is an observation tool, not a correctness oracle.
+
+## Local run
+
+```bash
+cmake -S benchmark -B build-benchmark -DCMAKE_BUILD_TYPE=Release
+cmake --build build-benchmark --parallel
+./build-benchmark/avm_benchmark
+```
+
+The executable writes tab-separated data:
+
+```text
+name    operations    elapsed_ns    ns_per_op
+```
+
+Current measurements cover:
+
+- creating a new canonical pair with `intern`;
+- reusing an existing pair with `intern`;
+- exact `find` hit and miss;
+- outgoing and incoming index queries;
+- Relations Model encode/decode;
+- execution of a minimal bootstrap relation;
+- persistent snapshot reopen/index rebuild.
+
+## CI policy
+
+`.github/workflows/benchmark.yml` builds and runs the benchmark on Ubuntu and uploads `avm-benchmark.tsv` as a workflow artifact.
+
+CI validates only that:
+
+1. the benchmark builds with C++20 warnings-as-errors;
+2. the executable completes;
+3. every expected measurement is present in the TSV output.
+
+There is intentionally no hard nanosecond threshold on GitHub-hosted shared runners. Absolute timing there is too noisy to be a reliable merge veto.
+
+Performance comparisons should be made on the same machine and toolchain. The TSV artifact provides a historical observation trail for main/tag runs. If a future regression needs an automated veto, prefer a stable structural/complexity invariant or a dedicated controlled runner before introducing a wall-clock threshold.
+
+## Scope
+
+The benchmark does not claim that the current in-memory or persistent reference backend is production-optimal. Its purpose is to make algorithmic regressions visible while AVM 1.0 architecture is still being stabilized.


### PR DESCRIPTION
Closes #61. Parent #27 / Epic #31.

Adds a standalone C++20 microbenchmark executable and a separate GitHub Actions `Benchmark` workflow.

Measurements cover new/existing `intern`, exact find hit/miss, outgoing/incoming queries, Relations Model encode/decode, minimal relation execution, and persistent reopen/index rebuild.

The workflow deliberately treats benchmarks as observations rather than correctness SLA: it requires warnings-as-errors, successful completion, expected TSV rows, and uploads `avm-benchmark.tsv` as an artifact. It does not fail PRs on absolute nanosecond thresholds from shared hosted runners.

`docs/performance-baseline.md` documents the local command, output schema and regression policy.

This PR is independent of #60's runtime restore semantics and may run CI in parallel, but should not be used to claim performance superiority; it establishes a reproducible baseline only.