### PR TITLE
AVM 1.0: publish stable installed core API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
             test/vertical_slice_test.cpp \
             test/json_value_codec_test.cpp \
             test/json_projection_test.cpp \
-            test/json_session_test.cpp
+            test/json_session_test.cpp \
+            test/package_consumer/main.cpp
 
   core:
     name: Core C++20 / warnings-as-errors
@@ -140,6 +141,40 @@ jobs:
 
       - name: Run core tests
         run: ctest --test-dir build-core --output-on-failure
+
+  package-consumer:
+    name: Installed package consumer / Linux
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Configure install tree
+        run: >-
+          cmake -S . -B build-install
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/stage
+          -DAVM_BUILD_CLI=OFF
+          -DAVM_BUILD_CORE_TESTS=OFF
+          -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
+
+      - name: Install public package
+        run: cmake --install build-install
+
+      - name: Configure external consumer
+        run: >-
+          cmake -S test/package_consumer -B build-consumer
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/stage
+          -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF
+
+      - name: Build external consumer
+        run: cmake --build build-consumer --parallel
+
+      - name: Run external consumer
+        run: ./build-consumer/avm_package_consumer
 
   json-compat:
     name: JSON projection + session / warnings-as-errors
@@ -247,7 +282,7 @@ jobs:
   release-artifact:
     name: Tagged Linux artifact
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [core, json-compat, cli-roundtrip, sanitizers]
+    needs: [core, package-consumer, json-compat, cli-roundtrip, sanitizers]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,54 @@ project(avm
     DESCRIPTION "Associative virtual machine"
     LANGUAGES CXX)
 
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_library(avm_core INTERFACE)
+add_library(avm::core ALIAS avm_core)
+set_target_properties(avm_core PROPERTIES EXPORT_NAME core)
+target_compile_features(avm_core INTERFACE cxx_std_20)
+target_include_directories(avm_core INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set(AVM_CORE_PUBLIC_HEADERS
+    include/avm/avm.h
+    include/avm/bootstrap_runtime.h
+    include/avm/executor.h
+    include/avm/link_store.h
+    include/avm/persistent_link_store.h
+    include/avm/program_model.h
+    include/avm/projection.h
+    include/avm/raw_carrier.h
+    include/avm/relations_model.h
+    include/avm/version.h)
+
+install(TARGETS avm_core EXPORT avmTargets)
+install(FILES ${AVM_CORE_PUBLIC_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/avm)
+install(EXPORT avmTargets
+    FILE avmTargets.cmake
+    NAMESPACE avm::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/avm)
+
+configure_package_config_file(
+    cmake/avmConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/avmConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/avm)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/avmConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/avmConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/avmConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/avm)
 
 option(AVM_BUILD_CLI "Build the AVM JSON CLI" ON)
 option(AVM_BUILD_CORE_TESTS "Build AVM 1.0 core tests" ON)
@@ -51,9 +94,8 @@ function(avm_enable_test_assertions target)
 endfunction()
 
 function(avm_add_json_includes target)
-    target_include_directories(${target} PRIVATE
-        "${CMAKE_CURRENT_SOURCE_DIR}/include"
-        "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+    target_link_libraries(${target} PRIVATE avm_core)
+    target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/3p")
 endfunction()
 
 if(AVM_BUILD_CLI)
@@ -94,7 +136,7 @@ endif()
 if(AVM_BUILD_CORE_TESTS)
     function(avm_add_core_test target source test_name)
         add_executable(${target} "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
-        target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+        target_link_libraries(${target} PRIVATE avm_core)
         avm_apply_quality(${target})
         avm_enable_test_assertions(${target})
         add_test(NAME ${test_name} COMMAND ${target})

--- a/README.md
+++ b/README.md
@@ -32,25 +32,76 @@ LinkId -> (begin: LinkId, end: LinkId)
 
 AVM 1.0 currently provides:
 
-- `LinkStore` as the storage contract, with an in-memory reference implementation;
+- `LinkStore` as the storage contract, with in-memory and persistent reference implementations;
 - Relations Model encoding `(relation, subject, object) = (relation, (subject, object))`;
 - explicit bootstrap vocabulary identity;
 - link-native execution through `BootstrapRuntime` and `Executor`;
 - associative program structures, bindings and call frames represented by links;
 - a neutral protocol-adapter boundary that keeps parsing/context semantics outside the VM core;
 - separate JSON value and JSON program/session adapters at the projection boundary;
-- persistent-store contracts and conformance tests independent from VM semantics;
-- CI on Linux, Windows and macOS, warnings-as-errors lanes, sanitizers, quality guards and benchmark regression gates.
+- persistent reopen/identity conformance tests independent from VM semantics;
+- CI on Linux, Windows and macOS, warnings-as-errors lanes, sanitizers, quality guards and benchmark baselines.
 
 The former pointer-based `rel_t` universe and its legacy execution/data-codec path have been removed. Git history preserves that implementation; AVM does not keep a second semantic path for compatibility.
 
+## Supported core library API
+
+The supported dependency-free C++ core surface is available through:
+
+```cpp
+#include <avm/avm.h>
+```
+
+A minimal link-native execution looks like this:
+
+```cpp
+#include <avm/avm.h>
+
+int main()
+{
+    avm::InMemoryLinkStore store;
+    avm::BootstrapRuntime runtime(store);
+    avm::ProgramBuilder builder = runtime.builder();
+
+    const avm::LinkId expression =
+        builder.logical_not(builder.literal(runtime.vocabulary().false_value));
+    const avm::LinkId result = runtime.execute(expression);
+
+    return result == runtime.vocabulary().true_value ? 0 : 1;
+}
+```
+
+The umbrella header intentionally does not include JSON adapters. JSON remains an optional projection layer and is not part of the dependency-free `avm::core` execution contract.
+
+## Install and consume with CMake
+
+Install AVM into a prefix:
+
+```bash
+cmake -S . -B build-install \
+  -DAVM_BUILD_CLI=OFF \
+  -DAVM_BUILD_CORE_TESTS=OFF \
+  -DAVM_BUILD_JSON_COMPAT_TESTS=OFF \
+  -DCMAKE_INSTALL_PREFIX=/path/to/prefix
+cmake --install build-install
+```
+
+A consuming CMake project can then use:
+
+```cmake
+find_package(avm CONFIG REQUIRED)
+target_link_libraries(my_program PRIVATE avm::core)
+```
+
+`avm::core` is a header-only C++20 target. Its installed interface points only at the install prefix; it does not depend on repository-relative source or `3p` include paths.
+
 ## Backends
 
-`InMemoryLinkStore` is the reference backend. Persistent backends are replaceable implementations of the same `LinkStore` contract. LinksPlatform/PMM integrations are follow-up backend work, not prerequisites for VM semantics.
+`InMemoryLinkStore` is the reference backend. `PersistentLinkStore` proves reopen and identity semantics. Additional physical backends are replaceable implementations of the same `LinkStore` contract. LinksPlatform/PMM integrations are follow-up backend work, not prerequisites for VM semantics.
 
 Backend code must not define VM relations, JSON rules, protocol grammar or execution semantics.
 
-## Reproducible vertical slice
+## Reproducible repository validation
 
 Build and run the test suite:
 
@@ -62,7 +113,7 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-The link-native vertical-slice tests exercise the intended flow: bootstrap a canonical store, encode program entities as Relations Model links, execute them by `LinkId`, and verify the resulting canonical identities. JSON/CLI tests exercise projection compatibility separately.
+The link-native vertical-slice tests exercise the intended flow: bootstrap a canonical store, encode program entities as Relations Model links, execute them by `LinkId`, and verify the resulting canonical identities. JSON/CLI tests exercise projection compatibility separately. CI also installs the public package into a staging prefix and builds an external consumer using only `find_package(avm CONFIG REQUIRED)` and `avm::core`.
 
 ## Architecture documents
 
@@ -75,13 +126,18 @@ The link-native vertical-slice tests exercise the intended flow: bootstrap a can
 
 ## Project status
 
-The active roadmap is **Architecture Foundation 2.0 / AVM 1.0**. Feature expansion such as GUI, a broad standard library or additional frontends follows completion of foundation gates and must reuse the single link-native semantic path.
+Architecture Foundation gates 1–7 are complete. The active gate is **AVM 1.0 release readiness**: stable public/install contracts, versioning/release policy and portable installed-package validation. Feature expansion such as additional protocol adapters, a broader standard library, GUI or distributed experiments follows this gate and must reuse the single link-native semantic path.
 
 ## Dependencies
 
+Core library:
+
 - C++20 compiler
-- CMake 3.20+
-- `nlohmann/json` for the JSON boundary
+- CMake 3.20+ for the provided package/build system
+
+Optional JSON boundary/CLI:
+
+- bundled `nlohmann/json`
 
 ## License
 

--- a/cmake/avmConfig.cmake.in
+++ b/cmake/avmConfig.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/avmTargets.cmake")
+
+check_required_components(avm)

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "avm/bootstrap_runtime.h"
+#include "avm/executor.h"
+#include "avm/link_store.h"
+#include "avm/persistent_link_store.h"
+#include "avm/program_model.h"
+#include "avm/projection.h"
+#include "avm/raw_carrier.h"
+#include "avm/relations_model.h"
+#include "avm/version.h"

--- a/include/avm/version.h
+++ b/include/avm/version.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string_view>
+
+namespace avm
+{
+
+inline constexpr int version_major = 0;
+inline constexpr int version_minor = 0;
+inline constexpr int version_patch = 5;
+inline constexpr std::string_view version_string = "0.0.5";
+
+} // namespace avm

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
+
+project(avm_package_consumer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+find_package(avm CONFIG REQUIRED)
+
+add_executable(avm_package_consumer main.cpp)
+target_link_libraries(avm_package_consumer PRIVATE avm::core)
+
+if(MSVC)
+    target_compile_options(avm_package_consumer PRIVATE /W4 /WX)
+else()
+    target_compile_options(avm_package_consumer PRIVATE -Wall -Wextra -Wpedantic -Werror)
+endif()

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -1,7 +1,5 @@
 #include <avm/avm.h>
 
-#include <cassert>
-
 int main()
 {
 	static_assert(avm::version_major == 0);
@@ -15,6 +13,5 @@ int main()
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
 	const avm::LinkId result = runtime.execute(expression);
 
-	assert(result == runtime.vocabulary().true_value);
-	return 0;
+	return result == runtime.vocabulary().true_value ? 0 : 1;
 }

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -1,0 +1,20 @@
+#include <avm/avm.h>
+
+#include <cassert>
+
+int main()
+{
+	static_assert(avm::version_major == 0);
+	static_assert(avm::version_minor == 0);
+	static_assert(avm::version_patch == 5);
+
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
+	const avm::LinkId result = runtime.execute(expression);
+
+	assert(result == runtime.vocabulary().true_value);
+	return 0;
+}


### PR DESCRIPTION
Closes #72. Parent #71.

## Public core contract
Adds dependency-free public umbrella `include/avm/avm.h` and compile-time version metadata. The umbrella exports the canonical LinkStore / Relations Model / projection / BootstrapRuntime / persistent reference contracts only; JSON adapters remain outside `avm::core`.

## CMake package
Adds header-only `avm_core` with exported name `avm::core`, BUILD_INTERFACE/INSTALL_INTERFACE include directories, explicit public-header installation, relocatable `avmConfig.cmake`, `avmConfigVersion.cmake`, and exported targets.

Existing repository core targets are migrated to link the same `avm_core` interface target rather than carrying a separate include-path convention.

## External consumer proof
Adds `test/package_consumer`, a separate CMake project that knows AVM only through `find_package(avm CONFIG REQUIRED)` and `avm::core`. CI installs AVM into a staging prefix, configures the consumer against that prefix with the package registry disabled, builds it under warnings-as-errors, and runs a link-native `Not(False)` program through `BootstrapRuntime` using only installed headers.

## Documentation
README now documents the supported core umbrella, install/consume commands, minimal LinkId execution example and active release-readiness gate.

No semantic handlers, JSON execution rules or storage identities are added by this PR.