### PR TITLE
AVM 1.0: establish 1.0.0 version and release contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,25 @@ jobs:
             exit 1
           fi
 
+      - name: Verify public version contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_version=$(sed -nE 's/^set\(CMAKE_PROJECT_VERSION ([0-9]+\.[0-9]+\.[0-9]+)\)$/\1/p' CMakeLists.txt)
+          header_version=$(sed -nE 's/^inline constexpr std::string_view version_string = "([0-9]+\.[0-9]+\.[0-9]+)";$/\1/p' include/avm/version.h)
+          header_major=$(sed -nE 's/^inline constexpr int version_major = ([0-9]+);$/\1/p' include/avm/version.h)
+          header_minor=$(sed -nE 's/^inline constexpr int version_minor = ([0-9]+);$/\1/p' include/avm/version.h)
+          header_patch=$(sed -nE 's/^inline constexpr int version_patch = ([0-9]+);$/\1/p' include/avm/version.h)
+          header_numeric="${header_major}.${header_minor}.${header_patch}"
+
+          test -n "$project_version"
+          test "$project_version" = "$header_version"
+          test "$project_version" = "$header_numeric"
+
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            test "v${project_version}" = "${GITHUB_REF_NAME}"
+          fi
+
       - name: Check AVM 1.0 formatting
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 message("Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_PROJECT_VERSION 0.0.5)
+set(CMAKE_PROJECT_VERSION 1.0.0)
 
 project(avm
     VERSION ${CMAKE_PROJECT_VERSION}

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 AVM is an experimental C++20 virtual machine built on the Relations Model and a canonical store of directed links.
 
+**Current public version: 1.0.0.**
+
 ## AVM 1.0 semantic path
 
 There is one production semantic path:
@@ -86,14 +88,20 @@ cmake -S . -B build-install \
 cmake --install build-install
 ```
 
-A consuming CMake project can then use:
+A consuming CMake project can require the AVM 1.x package:
 
 ```cmake
-find_package(avm CONFIG REQUIRED)
+find_package(avm 1.0 CONFIG REQUIRED)
 target_link_libraries(my_program PRIVATE avm::core)
 ```
 
 `avm::core` is a header-only C++20 target. Its installed interface points only at the install prefix; it does not depend on repository-relative source or `3p` include paths.
+
+## Version and compatibility policy
+
+AVM uses Semantic Versioning for the documented public core contracts. The project version in CMake and `include/avm/version.h` must match exactly; CI also rejects tagged builds unless the tag is exactly `v<project-version>`.
+
+Compatibility within AVM 1.x applies to the documented public contracts exposed through `<avm/avm.h>` and `avm::core`. Header-only implementation details, private layout and incidental helpers are not an ABI promise. See [AVM 1.x release policy](docs/release-policy.md).
 
 ## Backends
 
@@ -113,7 +121,7 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-The link-native vertical-slice tests exercise the intended flow: bootstrap a canonical store, encode program entities as Relations Model links, execute them by `LinkId`, and verify the resulting canonical identities. JSON/CLI tests exercise projection compatibility separately. CI also installs the public package into a staging prefix and builds an external consumer using only `find_package(avm CONFIG REQUIRED)` and `avm::core`.
+The link-native vertical-slice tests exercise the intended flow: bootstrap a canonical store, encode program entities as Relations Model links, execute them by `LinkId`, and verify the resulting canonical identities. JSON/CLI tests exercise projection compatibility separately. CI also installs the public package into a staging prefix and builds an external consumer using only `find_package(avm 1.0 CONFIG REQUIRED)` and `avm::core`.
 
 ## Architecture documents
 
@@ -121,12 +129,13 @@ The link-native vertical-slice tests exercise the intended flow: bootstrap a can
 - [Execution kernel](docs/execution-kernel.md)
 - [External protocol adapter contract](docs/protocol-adapter-contract.md)
 - [Persistent LinkStore contract](docs/persistent-link-store.md)
+- [AVM 1.x release policy](docs/release-policy.md)
 - [Project analysis](analysis.md)
 - [AVM 1.0 roadmap](plan.md)
 
 ## Project status
 
-Architecture Foundation gates 1–7 are complete. The active gate is **AVM 1.0 release readiness**: stable public/install contracts, versioning/release policy and portable installed-package validation. Feature expansion such as additional protocol adapters, a broader standard library, GUI or distributed experiments follows this gate and must reuse the single link-native semantic path.
+Architecture Foundation gates 1–7 are complete. The public/install contract and AVM 1.0.0 version policy are defined. The remaining release-readiness gate is portable installed-package validation on Linux, Windows and macOS before post-1.0 feature work takes priority.
 
 ## Dependencies
 

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -1,0 +1,68 @@
+# AVM 1.x release policy
+
+## Version source contract
+
+AVM follows Semantic Versioning for the documented public library surface.
+
+The release version is recorded in two places that CI requires to match exactly:
+
+- `CMakeLists.txt` — `CMAKE_PROJECT_VERSION`;
+- `include/avm/version.h` — `version_major`, `version_minor`, `version_patch` and `version_string`.
+
+For a tagged build, the Git tag must be exactly `v<project-version>`. A tag/version mismatch is a release-blocking CI error.
+
+## Public compatibility surface
+
+The supported C++ core entry point is:
+
+```cpp
+#include <avm/avm.h>
+```
+
+The supported CMake target is:
+
+```cmake
+find_package(avm 1.0 CONFIG REQUIRED)
+target_link_libraries(app PRIVATE avm::core)
+```
+
+Within the 1.x line, compatibility promises apply to the documented contracts exposed by that umbrella header and used by the installed-package consumer test:
+
+- opaque `LinkId` and `Link` semantics;
+- `LinkStore` observable contract;
+- Relations Model encode/decode contract;
+- parser-independent projection boundary;
+- `BootstrapRuntime`/`Executor` LinkId execution path;
+- `ProgramBuilder` link-native construction contract;
+- reference in-memory and persistent backend observable semantics;
+- `avm::core` CMake package target.
+
+A change that intentionally breaks those supported contracts requires the next major version.
+
+## What is not an ABI promise
+
+AVM core is currently header-only. Version 1.x does not promise binary ABI stability for incidental implementation details, class layout, private members, helper functions that are not documented as public contracts, benchmark values, or repository-internal test/build structure.
+
+Clients should compile against the installed headers for the version they consume. SemVer compatibility concerns source-level/documented behavior unless a future release explicitly establishes an ABI policy.
+
+## JSON and protocol adapters
+
+JSON program/value support is an adapter layer, not the VM semantic core. Additional protocol adapters, including Anum/MTS work, must project into the existing canonical LinkStore/Relations Model boundary and may not introduce a second executor or storage identity universe.
+
+Adapter APIs can receive their own compatibility commitments when they are promoted into the installed public package. They are not implicitly part of `avm::core` merely because headers exist in the repository.
+
+## Release checklist
+
+A `vX.Y.Z` release is valid only when:
+
+1. CMake and public header versions both equal `X.Y.Z`;
+2. the tag is exactly `vX.Y.Z`;
+3. quality architecture guards are green;
+4. strict core, JSON/session and CLI lanes are green;
+5. ASan/UBSan is green;
+6. portable Linux/Windows/macOS tests are green;
+7. installed-package consumer validation is green;
+8. benchmark smoke completes and emits its validated artifact;
+9. release artifacts are produced only after their declared dependencies pass.
+
+A failed gate is a release veto, not a warning.

--- a/include/avm/version.h
+++ b/include/avm/version.h
@@ -5,9 +5,9 @@
 namespace avm
 {
 
-inline constexpr int version_major = 0;
+inline constexpr int version_major = 1;
 inline constexpr int version_minor = 0;
-inline constexpr int version_patch = 5;
-inline constexpr std::string_view version_string = "0.0.5";
+inline constexpr int version_patch = 0;
+inline constexpr std::string_view version_string = "1.0.0";
 
 } // namespace avm

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(avm CONFIG REQUIRED)
+find_package(avm 1.0 CONFIG REQUIRED)
 
 add_executable(avm_package_consumer main.cpp)
 target_link_libraries(avm_package_consumer PRIVATE avm::core)

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -2,9 +2,10 @@
 
 int main()
 {
-	static_assert(avm::version_major == 0);
+	static_assert(avm::version_major == 1);
 	static_assert(avm::version_minor == 0);
-	static_assert(avm::version_patch == 5);
+	static_assert(avm::version_patch == 0);
+	static_assert(avm::version_string == "1.0.0");
 
 	avm::InMemoryLinkStore store;
 	avm::BootstrapRuntime runtime(store);


### PR DESCRIPTION
Closes #73. Parent #71.

## Version contract
Promotes the now-tested public package contract to version `1.0.0` and synchronizes CMake metadata with `include/avm/version.h`. The installed consumer now explicitly requires `find_package(avm 1.0 CONFIG REQUIRED)` and compile-time checks the public version constants.

## CI release guard
Quality gates now parse CMake and public-header versions and require exact equality. Tagged builds additionally require the Git ref to be exactly `v<project-version>`; a version/tag mismatch is a release veto.

## SemVer scope
Adds `docs/release-policy.md` defining the compatibility surface for AVM 1.x: documented contracts exposed via `<avm/avm.h>` and `avm::core`, including LinkStore, Relations Model, projection and LinkId execution semantics. Header-only implementation details/private layout are explicitly not promised as binary ABI.

## Documentation
README publishes current version 1.0.0, requires AVM 1.0 in the CMake consumer example, links the release policy, and identifies portable installed-package validation (#74) as the remaining release-readiness gate.

No VM semantics or storage identities are changed.