### PR TITLE
AVM 1.0: validate installed package on Linux Windows and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,10 +162,14 @@ jobs:
         run: ctest --test-dir build-core --output-on-failure
 
   package-consumer:
-    name: Installed package consumer / Linux
+    name: Installed package consumer / ${{ matrix.os }}
     needs: quality
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 7
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -180,7 +184,7 @@ jobs:
           -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
 
       - name: Install public package
-        run: cmake --install build-install
+        run: cmake --install build-install --config Release
 
       - name: Configure external consumer
         run: >-
@@ -190,10 +194,10 @@ jobs:
           -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF
 
       - name: Build external consumer
-        run: cmake --build build-consumer --parallel
+        run: cmake --build build-consumer --config Release --parallel
 
       - name: Run external consumer
-        run: ./build-consumer/avm_package_consumer
+        run: ctest --test-dir build-consumer -C Release --output-on-failure
 
   json-compat:
     name: JSON projection + session / warnings-as-errors

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 project(avm_package_consumer LANGUAGES CXX)
 
+enable_testing()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -16,3 +18,5 @@ if(MSVC)
 else()
     target_compile_options(avm_package_consumer PRIVATE -Wall -Wextra -Wpedantic -Werror)
 endif()
+
+add_test(NAME installed_package_consumer COMMAND avm_package_consumer)


### PR DESCRIPTION
Closes #74. Parent #71.

Promotes the installed-package consumer gate from a Linux-only smoke to a required Linux/Windows/macOS matrix.

## Cross-platform consumer contract
The external consumer fixture is now a CTest project. This avoids hard-coded executable paths and correctly handles both single-config generators and Windows multi-config output.

The package matrix performs, on each supported OS:
1. configure AVM with only the installable core enabled;
2. install to an isolated staging prefix;
3. configure the separate consumer with package registries disabled and only that prefix supplied;
4. `find_package(avm 1.0 CONFIG REQUIRED)`;
5. build with strict warnings;
6. run the installed LinkId execution smoke through CTest.

The release-artifact job already depends on the `package-consumer` job, so the dependency now covers the entire three-OS matrix automatically.

No runtime, storage or projection semantics are changed.