### PR TITLE
Anum: bridge canonical L3 projection results into AVM L4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
               echo "ERROR: $file has $lines lines (max: $MAX_LINES)"
               FAILED=1
             fi
-          done < <(find src include -type f \( -name '*.cpp' -o -name '*.h' \) -print)
+          done < <(find src include adapters -type f \( -name '*.cpp' -o -name '*.h' \) -print)
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
@@ -91,6 +91,15 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce projection-only Anum adapter
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -R -n -E 'parse_raw_quaternary|validate_anum|project_anum|IncrementalQuaternaryDecoder' adapters; then
+            echo "ERROR: AVM Anum adapter must consume canonical L3 results, not duplicate the L3 parser/protocol"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |
@@ -117,6 +126,7 @@ jobs:
           clang-format --version
           clang-format --dry-run --Werror \
             include/avm/*.h \
+            adapters/*.h \
             src/cli.cpp \
             test/assertions_enabled_test.cpp \
             test/link_store_test.cpp \
@@ -135,6 +145,7 @@ jobs:
             test/json_value_codec_test.cpp \
             test/json_projection_test.cpp \
             test/json_session_test.cpp \
+            test/anum_projection_bridge_test.cpp \
             test/package_consumer/main.cpp
 
   core:
@@ -146,19 +157,20 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Configure core-only build
+      - name: Configure core and adapter build
         run: >-
           cmake -S . -B build-core
           -DCMAKE_BUILD_TYPE=Debug
           -DAVM_BUILD_CLI=OFF
           -DAVM_BUILD_CORE_TESTS=ON
           -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=ON
           -DAVM_WARNINGS_AS_ERRORS=ON
 
-      - name: Build core tests
-        run: cmake --build build-core --target avm_core_tests --parallel
+      - name: Build core and adapter tests
+        run: cmake --build build-core --target avm_core_tests avm_anum_adapter_tests --parallel
 
-      - name: Run core tests
+      - name: Run core and adapter tests
         run: ctest --test-dir build-core --output-on-failure
 
   package-consumer:
@@ -182,6 +194,7 @@ jobs:
           -DAVM_BUILD_CLI=OFF
           -DAVM_BUILD_CORE_TESTS=OFF
           -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=OFF
 
       - name: Install public package
         run: cmake --install build-install --config Release
@@ -215,6 +228,7 @@ jobs:
           -DAVM_BUILD_CLI=OFF
           -DAVM_BUILD_CORE_TESTS=OFF
           -DAVM_BUILD_JSON_COMPAT_TESTS=ON
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=OFF
           -DAVM_WARNINGS_AS_ERRORS=ON
 
       - name: Build JSON compatibility tests
@@ -239,6 +253,7 @@ jobs:
           -DAVM_BUILD_CLI=ON
           -DAVM_BUILD_CORE_TESTS=OFF
           -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=OFF
           -DAVM_WARNINGS_AS_ERRORS=ON
 
       - name: Build CLI
@@ -248,7 +263,7 @@ jobs:
         run: ctest --test-dir build-cli --output-on-failure
 
   sanitizers:
-    name: Core + JSON ASan + UBSan
+    name: Core + JSON + adapter ASan + UBSan
     needs: quality
     runs-on: ubuntu-latest
     timeout-minutes: 7
@@ -263,11 +278,12 @@ jobs:
           -DAVM_BUILD_CLI=OFF
           -DAVM_BUILD_CORE_TESTS=ON
           -DAVM_BUILD_JSON_COMPAT_TESTS=ON
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=ON
           -DAVM_WARNINGS_AS_ERRORS=ON
           -DAVM_ENABLE_SANITIZERS=ON
 
       - name: Build sanitizer tests
-        run: cmake --build build-sanitizers --target avm_core_tests avm_json_compat_tests --parallel
+        run: cmake --build build-sanitizers --target avm_core_tests avm_json_compat_tests avm_anum_adapter_tests --parallel
 
       - name: Run sanitizer tests
         env:
@@ -295,6 +311,7 @@ jobs:
           -DAVM_BUILD_CLI=ON
           -DAVM_BUILD_CORE_TESTS=ON
           -DAVM_BUILD_JSON_COMPAT_TESTS=ON
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=ON
 
       - name: Build
         run: cmake --build build --config Release --parallel
@@ -319,6 +336,7 @@ jobs:
           -DAVM_BUILD_CLI=ON
           -DAVM_BUILD_CORE_TESTS=OFF
           -DAVM_BUILD_JSON_COMPAT_TESTS=OFF
+          -DAVM_BUILD_ANUM_ADAPTER_TESTS=OFF
 
       - name: Build AVM executable
         run: cmake --build build-release --target avm --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ install(FILES
 option(AVM_BUILD_CLI "Build the AVM JSON CLI" ON)
 option(AVM_BUILD_CORE_TESTS "Build AVM 1.0 core tests" ON)
 option(AVM_BUILD_JSON_COMPAT_TESTS "Build JSON projection/session tests" ON)
+option(AVM_BUILD_ANUM_ADAPTER_TESTS "Build external Anum L3/L4 adapter tests" ON)
 option(AVM_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 option(AVM_ENABLE_SANITIZERS "Enable AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 
@@ -203,4 +204,15 @@ if(AVM_BUILD_JSON_COMPAT_TESTS)
     add_test(NAME json_session_tests COMMAND avm_json_session_test)
 
     add_custom_target(avm_json_compat_tests DEPENDS avm_json_projection_test avm_json_session_test)
+endif()
+
+if(AVM_BUILD_ANUM_ADAPTER_TESTS)
+    add_executable(avm_anum_projection_bridge_test "${CMAKE_CURRENT_SOURCE_DIR}/test/anum_projection_bridge_test.cpp")
+    target_link_libraries(avm_anum_projection_bridge_test PRIVATE avm_core)
+    target_include_directories(avm_anum_projection_bridge_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+    avm_apply_quality(avm_anum_projection_bridge_test)
+    avm_enable_test_assertions(avm_anum_projection_bridge_test)
+    add_test(NAME anum_projection_bridge_tests COMMAND avm_anum_projection_bridge_test)
+
+    add_custom_target(avm_anum_adapter_tests DEPENDS avm_anum_projection_bridge_test)
 endif()

--- a/adapters/anum_projection_bridge.h
+++ b/adapters/anum_projection_bridge.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "avm/projection.h"
+
+#include <optional>
+#include <stdexcept>
+
+namespace avm::adapters
+{
+
+enum class AnumProjectionKind
+{
+	ProtocolValue,
+	BoundaryForm,
+	QuotedRaw,
+	Raw,
+};
+
+enum class AnumProtocolValue
+{
+	Zero,
+	One,
+};
+
+struct AnumL3Projection
+{
+	AnumProjectionKind kind;
+	std::optional<AnumProtocolValue> protocol_value;
+};
+
+struct AnumL4Anchors
+{
+	LinkId zero;
+	LinkId one;
+};
+
+inline std::optional<ProjectionDescription> to_avm_projection(const AnumL3Projection &projection,
+                                                              const AnumL4Anchors &anchors)
+{
+	if (projection.kind != AnumProjectionKind::ProtocolValue)
+	{
+		if (projection.protocol_value)
+			throw std::invalid_argument("non-protocol Anum projection cannot carry a protocol value");
+		return std::nullopt;
+	}
+
+	if (!projection.protocol_value)
+		throw std::invalid_argument("protocol-value Anum projection requires a protocol value");
+	if (anchors.zero == invalid_link_id || anchors.one == invalid_link_id)
+		throw std::invalid_argument("Anum protocol-value anchors must be valid LinkIds");
+	if (anchors.zero == anchors.one)
+		throw std::invalid_argument("Anum protocol-value anchors must be distinct");
+
+	const LinkId root = *projection.protocol_value == AnumProtocolValue::Zero ? anchors.zero : anchors.one;
+	return ProjectionDescription{{}, ProjectionRef::anchor(root)};
+}
+
+} // namespace avm::adapters

--- a/docs/anum-l3-l4-bridge.md
+++ b/docs/anum-l3-l4-bridge.md
@@ -1,0 +1,101 @@
+# Anum L3 -> AVM L4 bridge
+
+## Scope
+
+This adapter is the integration boundary between the canonical Anum/MTS L3 protocol and AVM L4 storage/projection. It deliberately does **not** implement Anum syntax, validation, context selection or protocol projection.
+
+The canonical L3 pipeline lives in `netkeep80/anum_docs`:
+
+```text
+raw [ ] 1 0 carrier
+  -> parse_raw_quaternary
+  -> validate_anum(explicit context)
+  -> project_anum(explicit context)
+  -> typed L3 projection result
+```
+
+AVM begins only after that typed result exists:
+
+```text
+typed L3 projection result
+  -> Anum projection bridge
+  -> optional ProjectionDescription
+  -> find_projection | realize_projection
+  -> LinkStore
+```
+
+This keeps grammar/context semantics out of the VM and preserves the AVM rule that `find` is observational while `realize` is the explicit materializing operation.
+
+## Canonical L3 result categories
+
+The current Anum protocol v0.1 distinguishes four projection kinds:
+
+```text
+protocol-value
+boundary-form
+quoted-raw
+raw
+```
+
+The bridge mirrors these categories only as a typed handoff contract. It does not derive them from `[`, `]`, `1` or `0` and does not inspect a raw carrier.
+
+## Defined L4 mapping
+
+Only the currently defined protocol values have an AVM L4 mapping:
+
+```text
+protocol-value 0 -> caller supplied zero LinkId anchor
+protocol-value 1 -> caller supplied one LinkId anchor
+```
+
+The caller resolves those identities in the target logical `LinkStore`. The adapter does not create point identities and does not guess that an AVM Boolean vocabulary identity is the same thing as an Anum protocol value.
+
+The result is an anchor-only `ProjectionDescription`. Therefore:
+
+- bridge construction does not mutate the store;
+- `find_projection` succeeds only when the selected anchor is already present;
+- `find_projection` never creates the anchor;
+- `realize_projection` validates that the anchor exists but creates no new projection nodes for this mapping.
+
+## Unresolved L3 results
+
+These current L3 result kinds have no general L4 denotation in the canonical v0.1 protocol:
+
+```text
+boundary-form
+quoted-raw
+raw
+```
+
+The bridge returns no `ProjectionDescription` for them. It does not replace an unresolved denotation with a synthetic link.
+
+In particular, the canonical protocol currently treats `[[` and `]]` as boundary forms without a protocol value, preserves relative-context carriers as raw, and returns typed raw results when no general root denotation is assigned.
+
+## Experimental root projection
+
+The current canonical L3 implementation contains the experimental root-context candidates:
+
+```text
+[] -> protocol value 0
+][ -> protocol value 1
+```
+
+The AVM adapter does not encode those character patterns. It accepts only the already projected typed result. Consequently a future change in the L3 grammar or context rules does not require a second parser inside AVM.
+
+The bridge also makes no claim that the experimental protocol projection is a normative L1 identity or formula.
+
+## Validation
+
+Malformed handoff data is rejected before it reaches `find_projection` or `realize_projection`:
+
+- a `protocol-value` result without a value is invalid;
+- a non-protocol result carrying a protocol value is invalid;
+- zero/one anchors must be valid and distinct `LinkId` values.
+
+Whether an otherwise valid anchor actually exists in a particular store remains the responsibility of the existing AVM projection operations.
+
+## General anum deserialization is intentionally not implemented
+
+AVM issue #79 records the remaining theory dependency. A recursive transformation of arbitrary raw `[ ] 1 0` carriers into link structures cannot be implemented correctly until the canonical MTS/Anum specification defines that denotation, including any boundary/relative rules and inverse serialization requirements.
+
+Until then, preserving a typed unresolved result is part of correctness. Inventing a link structure would create an undocumented semantic path and violate the L3/L4 boundary.

--- a/test/anum_projection_bridge_test.cpp
+++ b/test/anum_projection_bridge_test.cpp
@@ -1,0 +1,157 @@
+#include "adapters/anum_projection_bridge.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace
+{
+
+using avm::adapters::AnumL3Projection;
+using avm::adapters::AnumL4Anchors;
+using avm::adapters::AnumProjectionKind;
+using avm::adapters::AnumProtocolValue;
+
+void test_protocol_values_map_to_explicit_anchors()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId zero = store.create_point();
+	const avm::LinkId one = store.create_point();
+	const AnumL4Anchors anchors{zero, one};
+	const std::size_t before = store.size();
+
+	const auto zero_description = avm::adapters::to_avm_projection(
+	    AnumL3Projection{AnumProjectionKind::ProtocolValue, AnumProtocolValue::Zero}, anchors);
+	const auto one_description = avm::adapters::to_avm_projection(
+	    AnumL3Projection{AnumProjectionKind::ProtocolValue, AnumProtocolValue::One}, anchors);
+
+	assert(zero_description);
+	assert(one_description);
+	assert(store.size() == before);
+
+	const auto found_zero = avm::find_projection(store, *zero_description);
+	const auto found_one = avm::find_projection(store, *one_description);
+	assert(found_zero && found_zero->root == zero);
+	assert(found_one && found_one->root == one);
+	assert(store.size() == before);
+
+	const avm::ProjectionResult realized_zero = avm::realize_projection(store, *zero_description);
+	const avm::ProjectionResult realized_one = avm::realize_projection(store, *one_description);
+	assert(realized_zero.root == zero);
+	assert(realized_one.root == one);
+	assert(realized_zero.nodes.empty());
+	assert(realized_one.nodes.empty());
+	assert(store.size() == before);
+}
+
+void test_unresolved_projection_kinds_remain_without_denotation()
+{
+	avm::InMemoryLinkStore store;
+	const AnumL4Anchors anchors{store.create_point(), store.create_point()};
+	const std::size_t before = store.size();
+
+	for (const AnumProjectionKind kind : {
+	         AnumProjectionKind::BoundaryForm,
+	         AnumProjectionKind::QuotedRaw,
+	         AnumProjectionKind::Raw,
+	     })
+	{
+		const auto description = avm::adapters::to_avm_projection(AnumL3Projection{kind, std::nullopt}, anchors);
+		assert(!description);
+		assert(store.size() == before);
+	}
+}
+
+void test_missing_anchor_stays_non_mutating()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId zero = store.create_point();
+	const avm::LinkId absent_one = zero + 100;
+	const AnumL4Anchors anchors{zero, absent_one};
+	const auto description = avm::adapters::to_avm_projection(
+	    AnumL3Projection{AnumProjectionKind::ProtocolValue, AnumProtocolValue::One}, anchors);
+	assert(description);
+
+	const std::size_t before_find = store.size();
+	assert(!avm::find_projection(store, *description));
+	assert(store.size() == before_find);
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, *description));
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == before_find);
+}
+
+void test_malformed_external_results_are_rejected()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId zero = store.create_point();
+	const avm::LinkId one = store.create_point();
+	const AnumL4Anchors anchors{zero, one};
+
+	bool missing_value_rejected = false;
+	try
+	{
+		static_cast<void>(avm::adapters::to_avm_projection(
+		    AnumL3Projection{AnumProjectionKind::ProtocolValue, std::nullopt}, anchors));
+	}
+	catch (const std::invalid_argument &)
+	{
+		missing_value_rejected = true;
+	}
+	assert(missing_value_rejected);
+
+	bool extra_value_rejected = false;
+	try
+	{
+		static_cast<void>(avm::adapters::to_avm_projection(
+		    AnumL3Projection{AnumProjectionKind::Raw, AnumProtocolValue::Zero}, anchors));
+	}
+	catch (const std::invalid_argument &)
+	{
+		extra_value_rejected = true;
+	}
+	assert(extra_value_rejected);
+
+	bool invalid_anchor_rejected = false;
+	try
+	{
+		static_cast<void>(avm::adapters::to_avm_projection(
+		    AnumL3Projection{AnumProjectionKind::ProtocolValue, AnumProtocolValue::Zero},
+		    AnumL4Anchors{avm::invalid_link_id, one}));
+	}
+	catch (const std::invalid_argument &)
+	{
+		invalid_anchor_rejected = true;
+	}
+	assert(invalid_anchor_rejected);
+
+	bool duplicate_anchor_rejected = false;
+	try
+	{
+		static_cast<void>(avm::adapters::to_avm_projection(
+		    AnumL3Projection{AnumProjectionKind::ProtocolValue, AnumProtocolValue::One}, AnumL4Anchors{zero, zero}));
+	}
+	catch (const std::invalid_argument &)
+	{
+		duplicate_anchor_rejected = true;
+	}
+	assert(duplicate_anchor_rejected);
+}
+
+} // namespace
+
+int main()
+{
+	test_protocol_values_map_to_explicit_anchors();
+	test_unresolved_projection_kinds_remain_without_denotation();
+	test_missing_anchor_stays_non_mutating();
+	test_malformed_external_results_are_rejected();
+	return 0;
+}


### PR DESCRIPTION
Closes #78. Parent #3. General raw denotation remains explicitly blocked by #79.

## Canonical boundary
Adds a thin adapter outside `include/avm` that consumes an already parsed/validated/projected Anum L3 result. It does not parse `[ ] 1 0`, choose root/quote/relative context, normalize carriers, or duplicate `anum_docs` protocol logic.

The bridge maps only currently defined L3 protocol values to caller-resolved L4 anchors:
- protocol value `0` -> zero `LinkId` anchor;
- protocol value `1` -> one `LinkId` anchor.

`boundary-form`, `quoted-raw` and `raw` return no `ProjectionDescription`; AVM does not invent a denotation that the canonical protocol has not defined.

## L4 behavior
The result is an anchor-only existing `ProjectionDescription` and is consumed by the existing `find_projection` / `realize_projection` path. The bridge itself never mutates `LinkStore`. Missing anchors remain non-mutating on find and are rejected by realize.

## Tests and CI
Adds tests for 0/1 mapping, observational find, explicit realize, unresolved projection kinds, missing anchors, and malformed handoff data. The adapter participates in strict warnings-as-errors, ASan+UBSan and portable Linux/Windows/macOS builds.

Adds a quality guard forbidding `parse_raw_quaternary`, `validate_anum`, `project_anum` and `IncrementalQuaternaryDecoder` in `adapters/`, preserving the rule that canonical L3 parsing/projection remains external.

## Documentation
`docs/anum-l3-l4-bridge.md` documents the exact supported mapping and the theory boundary. It explicitly does not promote the experimental `[] -> 0` / `][ -> 1` L3 projection into a normative AVM/L1 formula.