### PR TITLE
AVM 1.1: add constrained Relations Model queries

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           set -euo pipefail
           head -n 1 avm-benchmark.tsv | grep -F $'name\toperations\telapsed_ns\tns_per_op'
-          for name in intern_new_pair intern_existing_pair find_hit find_miss outgoing_query incoming_query relations_model_encode relations_model_decode execute_minimal_relation persistent_reopen_index_rebuild; do
+          for name in intern_new_pair intern_existing_pair find_hit find_miss outgoing_query incoming_query relations_model_encode relations_model_decode relations_query_relation relations_query_subject relations_query_object relations_query_subject_object execute_minimal_relation persistent_reopen_index_rebuild; do
             grep -F "${name}" avm-benchmark.tsv >/dev/null
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,19 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce read-only Relations query layer
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E '(intern|create_point)[[:space:]]*\(|store\.size[[:space:]]*\(' include/avm/relations_query.h; then
+            echo "ERROR: Relations queries must not materialize links or guess full-store enumeration"
+            exit 1
+          fi
+          if grep -n -E 'PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num' include/avm/relations_query.h; then
+            echo "ERROR: Relations query layer must depend only on the LinkStore/Relations Model contracts"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |
@@ -132,7 +145,7 @@ jobs:
             test "v${project_version}" = "${GITHUB_REF_NAME}"
           fi
 
-      - name: Check AVM 1.0 formatting
+      - name: Check AVM formatting
         shell: bash
         run: |
           set -euo pipefail
@@ -144,6 +157,7 @@ jobs:
             test/assertions_enabled_test.cpp \
             test/link_store_test.cpp \
             test/relations_model_test.cpp \
+            test/relations_query_test.cpp \
             test/executor_test.cpp \
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 message("Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_PROJECT_VERSION 1.0.0)
+set(CMAKE_PROJECT_VERSION 1.1.0)
 
 project(avm
     VERSION ${CMAKE_PROJECT_VERSION}
@@ -35,6 +35,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/projection.h
     include/avm/raw_carrier.h
     include/avm/relations_model.h
+    include/avm/relations_query.h
     include/avm/version.h)
 
 install(TARGETS avm_core EXPORT avmTargets)
@@ -58,7 +59,7 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/avm)
 
 option(AVM_BUILD_CLI "Build the AVM JSON CLI" ON)
-option(AVM_BUILD_CORE_TESTS "Build AVM 1.0 core tests" ON)
+option(AVM_BUILD_CORE_TESTS "Build AVM core tests" ON)
 option(AVM_BUILD_JSON_COMPAT_TESTS "Build JSON projection/session tests" ON)
 option(AVM_BUILD_ANUM_ADAPTER_TESTS "Build canonical Anum denotation adapter tests" ON)
 option(AVM_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
@@ -146,6 +147,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_assertions_enabled_test test/assertions_enabled_test.cpp assertions_enabled_tests)
     avm_add_core_test(avm_link_store_test test/link_store_test.cpp link_store_tests)
     avm_add_core_test(avm_relations_model_test test/relations_model_test.cpp relations_model_tests)
+    avm_add_core_test(avm_relations_query_test test/relations_query_test.cpp relations_query_tests)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
@@ -176,6 +178,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_assertions_enabled_test
         avm_link_store_test
         avm_relations_model_test
+        avm_relations_query_test
         avm_executor_test
         avm_program_model_test
         avm_boolean_runtime_test

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 AVM is an experimental C++20 virtual machine built on the Relations Model and a canonical store of directed links.
 
-**Current public version: 1.0.0.**
+**Current public version: 1.1.0.**
 
-## AVM 1.0 semantic path
+## Semantic path
 
 There is one production semantic path:
 
@@ -20,7 +20,7 @@ external representation
   -> result LinkId
 ```
 
-JSON is an external projection and compatibility protocol. It is not the VM AST or the execution core. Execution dispatches by relation `LinkId`, not by textual operator names.
+JSON is an external projection and compatibility protocol. Anum/MTS grammar and contextual denotation remain canonical in `netkeep80/anum_docs`; AVM consumes only the storage-neutral structural denotation handoff. Neither format is the VM AST or execution core.
 
 The physical primitive is a canonical directed dyad:
 
@@ -30,25 +30,47 @@ LinkId -> (begin: LinkId, end: LinkId)
 
 `LinkId` is opaque. Reads do not materialize missing links, and `intern(a,b)` returns the canonical identity for an exact pair inside one logical store.
 
-## Current foundation
+## AVM 1.0 foundation — complete
 
-AVM 1.0 currently provides:
+AVM 1.0 established and validated:
 
 - `LinkStore` as the storage contract, with in-memory and persistent reference implementations;
-- Relations Model encoding `(relation, subject, object) = (relation, (subject, object))`;
+- canonical Relations Model encoding `(relation, subject, object) = (relation, (subject, object))`;
 - explicit bootstrap vocabulary identity;
 - link-native execution through `BootstrapRuntime` and `Executor`;
 - associative program structures, bindings and call frames represented by links;
-- a neutral protocol-adapter boundary that keeps parsing/context semantics outside the VM core;
-- separate JSON value and JSON program/session adapters at the projection boundary;
-- persistent reopen/identity conformance tests independent from VM semantics;
-- CI on Linux, Windows and macOS, warnings-as-errors lanes, sanitizers, quality guards and benchmark baselines.
+- parser-independent protocol projection boundary;
+- canonical structural Anum L3→L4 bridge with no grammar duplication in AVM;
+- separate JSON value and JSON program/session adapters;
+- persistent reopen/identity conformance independent from VM semantics;
+- installed-package consumer validation on Linux, Windows and macOS;
+- warnings-as-errors, sanitizers, architecture quality guards and benchmark baselines.
 
-The former pointer-based `rel_t` universe and its legacy execution/data-codec path have been removed. Git history preserves that implementation; AVM does not keep a second semantic path for compatibility.
+The former pointer-based `rel_t` universe, JSON semantic interpreter and temporary protocol-value-only Anum bridge have been removed. Git history preserves them; AVM keeps one semantic path.
+
+## AVM 1.1 — read-only associative queries
+
+AVM 1.1 begins with a dependency-free Relations Model query layer:
+
+```cpp
+avm::RelationQuery query{
+    .relation = relation,
+    .subject = std::nullopt,
+    .object = object,
+};
+
+const auto matches = avm::query_relation_entities(store, query);
+```
+
+At least one relation/subject/object field must be constrained. Queries use only the existing `LinkStore` `find/outgoing/incoming/get/contains` contract; they never call `intern` or `create_point`, and they do not introduce a second index universe.
+
+Relations Model querying is structural rather than registry-based. AVM does not track a hidden list of links "created as entities"; domain restrictions must themselves be represented through links/relations.
+
+See [Relations Model query contract](docs/relations-query.md).
 
 ## Supported core library API
 
-The supported dependency-free C++ core surface is available through:
+The dependency-free C++ core surface is available through:
 
 ```cpp
 #include <avm/avm.h>
@@ -73,7 +95,7 @@ int main()
 }
 ```
 
-The umbrella header intentionally does not include JSON adapters. JSON remains an optional projection layer and is not part of the dependency-free `avm::core` execution contract.
+The umbrella header intentionally does not include JSON adapters. JSON remains optional and is not part of the dependency-free `avm::core` execution contract.
 
 ## Install and consume with CMake
 
@@ -88,30 +110,28 @@ cmake -S . -B build-install \
 cmake --install build-install
 ```
 
-A consuming CMake project can require the AVM 1.x package:
+A consuming CMake project can require the current AVM 1.1 package:
 
 ```cmake
-find_package(avm 1.0 CONFIG REQUIRED)
+find_package(avm 1.1 CONFIG REQUIRED)
 target_link_libraries(my_program PRIVATE avm::core)
 ```
 
-`avm::core` is a header-only C++20 target. Its installed interface points only at the install prefix; it does not depend on repository-relative source or `3p` include paths.
+`avm::core` is a header-only C++20 target. Its installed interface points only at the install prefix and does not depend on repository-relative source or `3p` include paths.
 
 ## Version and compatibility policy
 
-AVM uses Semantic Versioning for the documented public core contracts. The project version in CMake and `include/avm/version.h` must match exactly; CI also rejects tagged builds unless the tag is exactly `v<project-version>`.
+AVM uses Semantic Versioning for documented public core contracts. CMake and `include/avm/version.h` must match exactly; CI also rejects tagged builds unless the tag is exactly `v<project-version>`.
 
-Compatibility within AVM 1.x applies to the documented public contracts exposed through `<avm/avm.h>` and `avm::core`. Header-only implementation details, private layout and incidental helpers are not an ABI promise. See [AVM 1.x release policy](docs/release-policy.md).
+Compatibility within AVM 1.x applies to documented public contracts exposed through `<avm/avm.h>` and `avm::core`. Header-only implementation details, private layout and incidental helpers are not an ABI promise. See [AVM 1.x release policy](docs/release-policy.md).
 
 ## Backends
 
-`InMemoryLinkStore` is the reference backend. `PersistentLinkStore` proves reopen and identity semantics. Additional physical backends are replaceable implementations of the same `LinkStore` contract. LinksPlatform/PMM integrations are follow-up backend work, not prerequisites for VM semantics.
+`InMemoryLinkStore` is the reference backend. `PersistentLinkStore` proves reopen and identity semantics. Additional physical backends are replaceable implementations of the same `LinkStore` contract.
 
-Backend code must not define VM relations, JSON rules, protocol grammar or execution semantics.
+Backend code must not define VM relations, query semantics, JSON rules, protocol grammar or execution semantics.
 
 ## Reproducible repository validation
-
-Build and run the test suite:
 
 ```bash
 git clone https://github.com/netkeep80/avm.git
@@ -121,28 +141,30 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-The link-native vertical-slice tests exercise the intended flow: bootstrap a canonical store, encode program entities as Relations Model links, execute them by `LinkId`, and verify the resulting canonical identities. JSON/CLI tests exercise projection compatibility separately. CI also installs the public package into a staging prefix and builds an external consumer using only `find_package(avm 1.0 CONFIG REQUIRED)` and `avm::core`.
+CI installs the package into a staging prefix and builds an external consumer on Linux, Windows and macOS using only `find_package` and `avm::core`.
 
 ## Architecture documents
 
-- [AVM 1.0 architecture contract](docs/architecture.md)
+- [AVM architecture contract](docs/architecture.md)
 - [Execution kernel](docs/execution-kernel.md)
 - [External protocol adapter contract](docs/protocol-adapter-contract.md)
+- [Anum L3→L4 bridge](docs/anum-l3-l4-bridge.md)
+- [Relations Model query contract](docs/relations-query.md)
 - [Persistent LinkStore contract](docs/persistent-link-store.md)
 - [AVM 1.x release policy](docs/release-policy.md)
 - [Project analysis](analysis.md)
-- [AVM 1.0 roadmap](plan.md)
+- [Roadmap](plan.md)
 
 ## Project status
 
-Architecture Foundation gates 1–7 are complete. The public/install contract and AVM 1.0.0 version policy are defined. The remaining release-readiness gate is portable installed-package validation on Linux, Windows and macOS before post-1.0 feature work takes priority.
+Architecture Foundation / AVM 1.0 gates are complete. AVM 1.1 now develops read-only associative query facilities while preserving the same canonical `LinkStore -> Relations Model -> Executor` foundation. New physical indexes are considered only after the existing-index query baselines demonstrate a measured need.
 
 ## Dependencies
 
 Core library:
 
 - C++20 compiler
-- CMake 3.20+ for the provided package/build system
+- CMake 3.20+
 
 Optional JSON boundary/CLI:
 

--- a/analysis.md
+++ b/analysis.md
@@ -2,7 +2,7 @@
 
 ## Текущее архитектурное состояние
 
-AVM 1.0 больше не является JSON-интерпретатором вокруг pointer-based `rel_t`. После Architecture Foundation 2.0 ядро строится вокруг одного канонического пространства ссылок и исполняет программы по `LinkId`.
+AVM завершил Architecture Foundation / AVM 1.0 и перешёл к развитию совместимых 1.x facilities. Ядро строится вокруг одного канонического пространства ссылок и исполняет программы по `LinkId`:
 
 ```text
 external representation
@@ -14,15 +14,15 @@ external representation
   -> result LinkId
 ```
 
-Это единственный целевой semantic path. Удалённый `rel_t` runtime, глобальный словарь и старый `eval()`/`interpret()` путь не являются совместимым вторым ядром и не должны возвращаться.
+Это единственный semantic path. Удалённые `rel_t`, JSON-interpreter и protocol-only Anum bridge не являются compatibility-ядрами и не должны возвращаться.
 
-## Слои
+## Foundation, который уже закрыт
 
 ### Link model и LinkStore
 
-Физический примитив — направленная диада `LinkId -> (begin,end)`. `LinkId` непрозрачен для семантического кода. `LinkStore` разделяет наблюдение и материализацию: `find()`/`get()`/queries не создают ссылки, а `intern()` явно возвращает каноническую идентичность пары.
+Физический примитив — направленная диада `LinkId -> (begin,end)`. `LinkId` непрозрачен. `find/get/outgoing/incoming` наблюдают существующую структуру; `intern/create_point` являются явными mutation operations.
 
-`InMemoryLinkStore` служит reference implementation. Persistent backends обязаны сохранять те же наблюдаемые свойства и проверяются conformance-тестами.
+`InMemoryLinkStore` — reference backend. `PersistentLinkStore` доказал reopen/identity semantics и индексный rebuild; одинаковые observable contracts проверяются в CI.
 
 ### Relations Model
 
@@ -32,17 +32,17 @@ external representation
 (relation, subject, object) = (relation, (subject, object))
 ```
 
-Storage layer не знает значения relation/subject/object; это ответственность Relations Model codec и верхних слоёв.
+Никакого внешнего type registry для «entity links» нет: принадлежность Relations Model определяется структурой ссылок.
 
 ### Execution
 
-`BootstrapRuntime` формирует явную bootstrap vocabulary identity. `Executor` принимает entity `LinkId`, декодирует Relations Model entity, создаёт явный execution context и dispatch-ит по relation `LinkId`.
+`BootstrapRuntime` создаёт bootstrap vocabulary identity. `Executor` принимает entity `LinkId`, декодирует Relations Model entity и dispatch-ит по relation `LinkId`.
 
-Пользовательские структуры программы, bindings и call frames представлены ассоциативными структурами, а не отдельной JSON AST или скрытым C++ окружением.
+Program structures, bindings и call frames представлены ссылками, а не JSON AST или скрытым C++ environment.
 
 ### Projection boundary
 
-JSON, Anum и другие форматы находятся вне execution kernel. Внешний adapter владеет grammar, parsing, validation и context resolution, после чего предоставляет structural projection над существующими anchors.
+JSON, Anum и другие форматы находятся вне execution kernel. Конкретный внешний протокол владеет grammar/parsing/context semantics и передаёт AVM только structural projection/denotation.
 
 Ключевая граница:
 
@@ -53,60 +53,122 @@ find(A) is observational
 realize(A) explicitly materializes denotation
 ```
 
-JSON value codec и JSON program/session adapter — boundary-компоненты. Они не определяют семантику VM.
+Canonical Anum semantics находятся в `netkeep80/anum_docs`; AVM structural bridge не содержит Anum parser или recursive grammar.
 
-## Что уже является сильной стороной
+### Release/package validation
 
-1. **Один physical/semantic core.** Нет двух конкурирующих identity universes.
-2. **Каноническая идентичность ссылок.** Семантика не зависит от адресов C++ объектов или layout backend-а.
-3. **Наблюдение отделено от записи.** Read/query API не материализует отсутствующие связи.
-4. **Явная архитектурная граница проекций.** JSON и будущий Anum adapter не проникают в executor.
-5. **Backend replaceability.** In-memory и persistent реализации разделяют один контракт.
-6. **Миграционная дисциплина.** Legacy-код удаляется после миграции consumers; Git хранит историю.
-7. **CI как архитектурный gate.** Кроссплатформенные сборки, warnings-as-errors, sanitizers, quality guards и benchmark regression checks защищают фундамент.
+AVM 1.0 public package прошёл installed-consumer и portable validation на Linux, Windows и macOS, а также strict warnings, sanitizers и benchmark gates. Поэтому package portability больше не является незакрытым foundation-risk.
 
-## Оставшиеся риски AVM 1.0
+## AVM 1.1: read-only associative query layer
 
-### 1. Persistent production backend
+Первое post-1.0 направление — запросы поверх уже существующей Relations Model структуры.
 
-Persistent contract существует отдельно от семантики VM, но production-grade backend и его crash/reopen guarantees ещё должны пройти полный conformance и end-to-end цикл.
+Новая граница:
 
-### 2. Bootstrap/native boundary
+```text
+RelationQuery(relation?, subject?, object?)
+-> existing LinkStore indexes
+-> decode/filter
+-> deterministic RelationMatch[]
+```
 
-Native handlers допустимы как bootstrap механизм, однако registry не должен становиться вторым хранилищем программы. Новая функциональность обязана расширять link-native representation, а не обходить её.
+Запросы принципиально не создают отдельный индексный universe. Используются только `find`, `outgoing`, `incoming`, `get`, `contains`.
 
-### 3. Protocol integrations
+### Почему нет hidden entity registry
 
-Конкретные Anum/MTS, JSON и другие adapters должны оставаться тонкими projection layers. Особая опасность — незаметно вернуть string-dispatch или external AST как второй execution path.
+`decode_relation_entity` структурен. Если существует point:
 
-### 4. Performance
+```text
+x = (x,x)
+```
 
-Производительность должна оцениваться на link-native вертикальном срезе и backend operations. Оптимизации допустимы только при сохранении identity/query semantics и должны проходить benchmark gates.
+то он также структурно читается как:
+
+```text
+(x, x, x)
+```
+
+Промежуточный `(subject,object)` link тоже может одновременно удовлетворять более широкому Relations Model query. Это следствие универсальности Link primitive, а не ошибка типов.
+
+Если поверх этого создать C++-набор «только те LinkId, которые когда-то вернул encode_relation_entity», возникнет второе понятие identity/classification, которого нет в Relations Model. Поэтому AVM 1.1 queries остаются структурными. Более узкие домены должны выражаться дополнительными relations/constraints в самой асети.
+
+### Query strategies
+
+Без нового storage API доступны четыре индексных пути:
+
+```text
+relation constrained
+  -> outgoing(relation)
+
+subject + object constrained
+  -> find(subject,object)
+  -> incoming(pair)
+
+subject constrained
+  -> outgoing(subject)
+  -> incoming(pair)
+
+object constrained
+  -> incoming(object)
+  -> incoming(pair)
+```
+
+Все candidates затем структурно декодируются и фильтруются. Missing pair не материализуется.
+
+All-wildcard query пока запрещён: `LinkStore` не имеет public enumeration contract. Сканирование guessed диапазона `1..size()` было бы нарушением opaque LinkId semantics.
+
+## Сильные стороны текущей архитектуры
+
+1. **Один physical/semantic core.** Нет конкурирующих identity universes.
+2. **Canonical link identity.** Семантика не зависит от адресов C++ объектов.
+3. **Read/write separation.** Queries и projection-find не материализуют данные.
+4. **External protocol boundary.** JSON/Anum не проникают в executor.
+5. **Backend replaceability.** In-memory/persistent проверяются одним observable contract.
+6. **Structural Relations Model.** Entity semantics не требуют side registry.
+7. **CI as architecture gate.** Cross-platform builds, package consumer, sanitizers, static guards and benchmarks защищают фундамент.
+
+## Текущие риски AVM 1.1
+
+### 1. Query cost growth
+
+Subject/object queries могут проходить через fan-out существующих `outgoing/incoming` indexes. До добавления новых physical indexes нужна измеряемая проблема, подтверждённая benchmark/workload.
+
+### 2. Enumeration contract
+
+Полностью unconstrained queries нельзя корректно реализовать через `size()` и предположение о contiguous IDs как semantic API. Если enumeration понадобится, её следует добавить отдельным explicit `LinkStore` contract и проверить на всех backends.
+
+### 3. Bootstrap/native boundary
+
+Native handlers остаются допустимым bootstrap mechanism, но registry не должен становиться вторым program store.
+
+### 4. Protocol integrations
+
+Новые adapters должны оставаться thin projection layers. String dispatch, external AST или protocol-specific query semantics не должны создавать второй runtime path.
 
 ## Что больше не является актуальной проблемой
 
-Следующие утверждения относились к старой реализации и удалены из текущей оценки:
-
-- `src/main.cpp` как монолитное semantic core;
-- singleton/global `rel_t` storage как архитектура AVM;
-- pointer identity как представление сущностей;
-- `eval()`/relative addressing как вычислительное ядро;
+- `src/main.cpp` как semantic core;
+- singleton/global `rel_t` storage;
+- pointer identity;
 - JSON expression interpreter как VM execution model;
-- LinksPlatform как обязательная зависимость для самой семантики VM;
-- hard-coded количество тестов как показатель зрелости.
+- LinksPlatform как обязательная semantic dependency;
+- protocol-value-only Anum bridge;
+- portable installed-package validation как незавершённый AVM 1.0 gate.
 
 ## Приоритет
 
-До AVM 1.0 приоритет имеют только foundation gates: единый storage/execution path, persistence conformance, protocol boundaries, end-to-end vertical slice, performance/quality regressions и согласованная документация. GUI, широкая stdlib, дополнительные frontends и packaging идут после них.
+Текущий приоритет — #83/#84: доказать полезный read-only Relations Model query layer на существующих индексах, получить backend/reopen conformance и performance baselines. Только после измерений решать, нужен ли новый явный LinkStore index/enumeration contract.
 
 ## Основная документация
 
-- `docs/architecture.md` — архитектурный контракт AVM 1.0;
+- `docs/architecture.md` — базовый архитектурный контракт;
 - `docs/execution-kernel.md` — execution kernel;
 - `docs/protocol-adapter-contract.md` — внешний protocol boundary;
+- `docs/anum-l3-l4-bridge.md` — canonical Anum structural bridge;
+- `docs/relations-query.md` — AVM 1.1 query contract;
 - `docs/persistent-link-store.md` — persistent backend contract;
 - `plan.md` — dependency-ordered roadmap.
 
 ## Вывод
 
-AVM перешёл от исторического JSON/`rel_t` прототипа к более строгому link-native фундаменту. Главный критерий дальнейшей разработки — не количество новых features, а сохранение одного канонического пути `projection -> LinkStore -> Relations Model -> Executor` при расширении persistence, adapters и языка программ.
+AVM 1.0 сформировал устойчивый link-native фундамент. AVM 1.1 расширяет его не новым runtime, а наблюдаемыми facilities поверх тех же canonical links. Критерий дальнейшего развития остаётся прежним: новые возможности должны сохранять единый путь `LinkStore -> Relations Model -> Executor` и не вводить скрытые identity/storage semantics.

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -143,25 +143,22 @@ int main()
 		static_cast<void>(avm::encode_relation_entity(store, {points[5000 + i], query_subject, query_object}));
 	}
 
-	const auto relation_driven_query = [&](std::size_t) {
-		sink ^= avm::query_relation_entities(store, {.relation = query_relation}).size();
-	};
-	print(measure("relations_query_relation", relation_query_iterations, relation_driven_query));
+	const avm::RelationQuery relation_q{.relation = query_relation};
+	const avm::RelationQuery subject_q{.subject = query_subject};
+	const avm::RelationQuery object_q{.object = query_object};
+	const avm::RelationQuery pair_q{.subject = query_subject, .object = query_object};
 
-	const auto subject_driven_query = [&](std::size_t) {
-		sink ^= avm::query_relation_entities(store, {.subject = query_subject}).size();
-	};
-	print(measure("relations_query_subject", relation_query_iterations, subject_driven_query));
+	const auto relation_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, relation_q).size(); };
+	print(measure("relations_query_relation", relation_query_iterations, relation_bench));
 
-	const auto object_driven_query = [&](std::size_t) {
-		sink ^= avm::query_relation_entities(store, {.object = query_object}).size();
-	};
-	print(measure("relations_query_object", relation_query_iterations, object_driven_query));
+	const auto subject_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, subject_q).size(); };
+	print(measure("relations_query_subject", relation_query_iterations, subject_bench));
 
-	const auto subject_object_query = [&](std::size_t) {
-		sink ^= avm::query_relation_entities(store, {.subject = query_subject, .object = query_object}).size();
-	};
-	print(measure("relations_query_subject_object", relation_query_iterations, subject_object_query));
+	const auto object_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, object_q).size(); };
+	print(measure("relations_query_object", relation_query_iterations, object_bench));
+
+	const auto pair_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, pair_q).size(); };
+	print(measure("relations_query_subject_object", relation_query_iterations, pair_bench));
 
 	avm::BootstrapRuntime runtime(store);
 	avm::ProgramBuilder builder = runtime.builder();

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -1,6 +1,7 @@
 #include "avm/bootstrap_runtime.h"
 #include "avm/persistent_link_store.h"
 #include "avm/relations_model.h"
+#include "avm/relations_query.h"
 
 #include <chrono>
 #include <cstddef>
@@ -65,6 +66,8 @@ int main()
 {
 	constexpr std::size_t sample_size = 20000;
 	constexpr std::size_t query_iterations = 100000;
+	constexpr std::size_t relation_query_sample_size = 64;
+	constexpr std::size_t relation_query_iterations = 5000;
 	constexpr std::size_t persistent_sample_size = 256;
 
 	std::cout << "name\toperations\telapsed_ns\tns_per_op\n";
@@ -126,6 +129,43 @@ int main()
 		sink ^= static_cast<std::size_t>(decoded.object);
 	};
 	print(measure("relations_model_decode", query_iterations, decode_entity));
+
+	const avm::LinkId query_relation = store.create_point();
+	const avm::LinkId query_subject = store.create_point();
+	const avm::LinkId query_object = store.create_point();
+	for (std::size_t i = 0; i < relation_query_sample_size; ++i)
+	{
+		const avm::LinkId varying_subject = points[1000 + i];
+		const avm::LinkId varying_object = points[2000 + i];
+		static_cast<void>(avm::encode_relation_entity(store, {query_relation, varying_subject, varying_object}));
+		static_cast<void>(avm::encode_relation_entity(store, {points[3000 + i], query_subject, varying_object}));
+		static_cast<void>(avm::encode_relation_entity(store, {points[4000 + i], varying_subject, query_object}));
+		static_cast<void>(avm::encode_relation_entity(store, {points[5000 + i], query_subject, query_object}));
+	}
+
+	const auto relation_driven_query = [&](std::size_t)
+	{
+		sink ^= avm::query_relation_entities(store, {.relation = query_relation}).size();
+	};
+	print(measure("relations_query_relation", relation_query_iterations, relation_driven_query));
+
+	const auto subject_driven_query = [&](std::size_t)
+	{
+		sink ^= avm::query_relation_entities(store, {.subject = query_subject}).size();
+	};
+	print(measure("relations_query_subject", relation_query_iterations, subject_driven_query));
+
+	const auto object_driven_query = [&](std::size_t)
+	{
+		sink ^= avm::query_relation_entities(store, {.object = query_object}).size();
+	};
+	print(measure("relations_query_object", relation_query_iterations, object_driven_query));
+
+	const auto subject_object_query = [&](std::size_t)
+	{
+		sink ^= avm::query_relation_entities(store, {.subject = query_subject, .object = query_object}).size();
+	};
+	print(measure("relations_query_subject_object", relation_query_iterations, subject_object_query));
 
 	avm::BootstrapRuntime runtime(store);
 	avm::ProgramBuilder builder = runtime.builder();

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -143,26 +143,22 @@ int main()
 		static_cast<void>(avm::encode_relation_entity(store, {points[5000 + i], query_subject, query_object}));
 	}
 
-	const auto relation_driven_query = [&](std::size_t)
-	{
+	const auto relation_driven_query = [&](std::size_t) {
 		sink ^= avm::query_relation_entities(store, {.relation = query_relation}).size();
 	};
 	print(measure("relations_query_relation", relation_query_iterations, relation_driven_query));
 
-	const auto subject_driven_query = [&](std::size_t)
-	{
+	const auto subject_driven_query = [&](std::size_t) {
 		sink ^= avm::query_relation_entities(store, {.subject = query_subject}).size();
 	};
 	print(measure("relations_query_subject", relation_query_iterations, subject_driven_query));
 
-	const auto object_driven_query = [&](std::size_t)
-	{
+	const auto object_driven_query = [&](std::size_t) {
 		sink ^= avm::query_relation_entities(store, {.object = query_object}).size();
 	};
 	print(measure("relations_query_object", relation_query_iterations, object_driven_query));
 
-	const auto subject_object_query = [&](std::size_t)
-	{
+	const auto subject_object_query = [&](std::size_t) {
 		sink ^= avm::query_relation_entities(store, {.subject = query_subject, .object = query_object}).size();
 	};
 	print(measure("relations_query_subject_object", relation_query_iterations, subject_object_query));

--- a/docs/relations-query.md
+++ b/docs/relations-query.md
@@ -1,0 +1,155 @@
+# Relations Model query contract
+
+## Status
+
+This document defines the public AVM 1.1 read-only query layer over canonical Relations Model entities.
+
+The physical and semantic foundations remain unchanged:
+
+```text
+LinkId -> (begin, end)
+(relation, subject, object) = (relation, (subject, object))
+```
+
+Queries are a derived read-only view over the existing `LinkStore` contract. They do not introduce a second database, index universe, entity registry or execution path.
+
+## Public API
+
+```cpp
+#include <avm/relations_query.h>
+
+avm::RelationQuery query{
+    .relation = relation_or_nullopt,
+    .subject = subject_or_nullopt,
+    .object = object_or_nullopt,
+};
+
+std::vector<avm::RelationMatch> matches =
+    avm::query_relation_entities(store, query);
+```
+
+A `RelationMatch` contains:
+
+```text
+entity_id  canonical LinkId of the outer relation link
+entity     decoded RelationEntity {relation, subject, object}
+```
+
+At least one field must be constrained. An all-wildcard query is rejected because `LinkStore` deliberately exposes no full-store enumeration contract.
+
+## Existing-index strategies
+
+The query layer uses exactly the indexes already implied by the `LinkStore` API.
+
+### Relation constrained
+
+```text
+outgoing(relation)
+-> outer candidate links
+-> decode + filter remaining fields
+```
+
+### Subject and object constrained, relation wildcard
+
+```text
+find(subject, object)
+-> canonical subject/object pair, if already present
+-> incoming(pair)
+-> decode + filter
+```
+
+The query never calls `intern(subject, object)`. A missing pair produces an empty result without mutation.
+
+### Subject constrained
+
+```text
+outgoing(subject)
+-> candidate pair links
+-> incoming(pair)
+-> outer candidate links
+-> decode + filter
+```
+
+### Object constrained
+
+```text
+incoming(object)
+-> candidate pair links
+-> incoming(pair)
+-> outer candidate links
+-> decode + filter
+```
+
+No backend-specific containers are visible to this layer.
+
+## Structural totality
+
+AVM does not maintain a hidden registry of links previously created through `encode_relation_entity`.
+
+`decode_relation_entity(store, id)` is structural: for any existing outer link, its `end` is itself an existing link and therefore supplies the subject/object pair. Consequently a point:
+
+```text
+x = (x, x)
+```
+
+also structurally represents:
+
+```text
+relation = x
+subject  = x
+object   = x
+```
+
+Likewise, intermediate pair links may themselves satisfy a broader structural query. This is intentional. Introducing an external "this LinkId is an entity" registry would create a second semantic identity universe and contradict the Relations Model representation.
+
+Applications that need a narrower domain should express that domain through additional relations/constraints rather than hidden C++ classification state.
+
+## Result semantics
+
+Results are:
+
+- observational: the store size and canonical identities do not change;
+- deterministic: sorted by ascending `entity_id`;
+- defensively deduplicated by `entity_id`;
+- structurally verified: every returned `entity` equals `decode_relation_entity(store, entity_id)`.
+
+Unknown constrained LinkIds yield an empty result. Querying does not materialize missing links.
+
+## Backend equivalence
+
+The same query fixture is required to return equivalent results for:
+
+```text
+InMemoryLinkStore
+PersistentLinkStore before close
+PersistentLinkStore after reopen
+```
+
+This keeps query semantics above the backend boundary.
+
+## Explicit non-goals
+
+AVM 1.1 query v1 does not add:
+
+```text
+full-store enumeration
+SQL/query-language parsing
+planner statistics
+secondary persistent indexes
+hidden entity registries
+mutation through queries
+JSON or Anum query semantics
+```
+
+A future index extension must first demonstrate a measured need against the benchmark baselines and then extend the `LinkStore` contract explicitly rather than inspecting backend internals.
+
+## Quality gates
+
+CI rejects production `relations_query.h` if it introduces:
+
+- `intern()` or `create_point()`;
+- guessed enumeration through `store.size()`;
+- direct dependency on `InMemoryLinkStore` or `PersistentLinkStore`;
+- JSON/Anum dependencies.
+
+Benchmark baselines cover relation-, subject-, object- and exact subject+object-driven queries.

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -8,4 +8,5 @@
 #include "avm/projection.h"
 #include "avm/raw_carrier.h"
 #include "avm/relations_model.h"
+#include "avm/relations_query.h"
 #include "avm/version.h"

--- a/include/avm/relations_query.h
+++ b/include/avm/relations_query.h
@@ -12,9 +12,9 @@ namespace avm
 
 struct RelationQuery
 {
-	std::optional<LinkId> relation;
-	std::optional<LinkId> subject;
-	std::optional<LinkId> object;
+	std::optional<LinkId> relation = std::nullopt;
+	std::optional<LinkId> subject = std::nullopt;
+	std::optional<LinkId> object = std::nullopt;
 };
 
 struct RelationMatch

--- a/include/avm/relations_query.h
+++ b/include/avm/relations_query.h
@@ -57,7 +57,7 @@ inline void append_entities_for_pair(const LinkStore &store, const RelationQuery
                                      std::vector<RelationMatch> &matches)
 {
 	for (const LinkId entity_id : store.incoming(pair_id))
-		append_relation_candidate(store, query, entity_id, matches);
+		detail::append_relation_candidate(store, query, entity_id, matches);
 }
 
 } // namespace detail
@@ -94,8 +94,8 @@ inline std::vector<RelationMatch> query_relation_entities(const LinkStore &store
 			detail::append_entities_for_pair(store, query, pair_id, matches);
 	}
 
-	std::sort(matches.begin(), matches.end(), [](const RelationMatch &left, const RelationMatch &right)
-	          { return left.entity_id < right.entity_id; });
+	std::sort(matches.begin(), matches.end(),
+	          [](const RelationMatch &left, const RelationMatch &right) { return left.entity_id < right.entity_id; });
 	matches.erase(std::unique(matches.begin(), matches.end(), [](const RelationMatch &left, const RelationMatch &right)
 	                          { return left.entity_id == right.entity_id; }),
 	              matches.end());

--- a/include/avm/relations_query.h
+++ b/include/avm/relations_query.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "avm/relations_model.h"
+
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace avm
+{
+
+struct RelationQuery
+{
+	std::optional<LinkId> relation;
+	std::optional<LinkId> subject;
+	std::optional<LinkId> object;
+};
+
+struct RelationMatch
+{
+	LinkId entity_id;
+	RelationEntity entity;
+
+	bool operator==(const RelationMatch &) const = default;
+};
+
+namespace detail
+{
+
+inline bool relation_query_matches(const RelationQuery &query, const RelationEntity &entity)
+{
+	return (!query.relation || entity.relation == *query.relation) &&
+	       (!query.subject || entity.subject == *query.subject) && (!query.object || entity.object == *query.object);
+}
+
+inline bool relation_query_constraints_exist(const LinkStore &store, const RelationQuery &query)
+{
+	if (query.relation && !store.contains(*query.relation))
+		return false;
+	if (query.subject && !store.contains(*query.subject))
+		return false;
+	if (query.object && !store.contains(*query.object))
+		return false;
+	return true;
+}
+
+inline void append_relation_candidate(const LinkStore &store, const RelationQuery &query, LinkId entity_id,
+                                      std::vector<RelationMatch> &matches)
+{
+	const RelationEntity entity = decode_relation_entity(store, entity_id);
+	if (relation_query_matches(query, entity))
+		matches.push_back(RelationMatch{entity_id, entity});
+}
+
+inline void append_entities_for_pair(const LinkStore &store, const RelationQuery &query, LinkId pair_id,
+                                     std::vector<RelationMatch> &matches)
+{
+	for (const LinkId entity_id : store.incoming(pair_id))
+		append_relation_candidate(store, query, entity_id, matches);
+}
+
+} // namespace detail
+
+inline std::vector<RelationMatch> query_relation_entities(const LinkStore &store, const RelationQuery &query)
+{
+	if (!query.relation && !query.subject && !query.object)
+		throw std::invalid_argument("Relations Model query requires at least one constraint");
+
+	if (!detail::relation_query_constraints_exist(store, query))
+		return {};
+
+	std::vector<RelationMatch> matches;
+
+	if (query.relation)
+	{
+		for (const LinkId entity_id : store.outgoing(*query.relation))
+			detail::append_relation_candidate(store, query, entity_id, matches);
+	}
+	else if (query.subject && query.object)
+	{
+		const std::optional<LinkId> pair_id = store.find(*query.subject, *query.object);
+		if (pair_id)
+			detail::append_entities_for_pair(store, query, *pair_id, matches);
+	}
+	else if (query.subject)
+	{
+		for (const LinkId pair_id : store.outgoing(*query.subject))
+			detail::append_entities_for_pair(store, query, pair_id, matches);
+	}
+	else
+	{
+		for (const LinkId pair_id : store.incoming(*query.object))
+			detail::append_entities_for_pair(store, query, pair_id, matches);
+	}
+
+	std::sort(matches.begin(), matches.end(), [](const RelationMatch &left, const RelationMatch &right)
+	          { return left.entity_id < right.entity_id; });
+	matches.erase(std::unique(matches.begin(), matches.end(), [](const RelationMatch &left, const RelationMatch &right)
+	                          { return left.entity_id == right.entity_id; }),
+	              matches.end());
+	return matches;
+}
+
+} // namespace avm

--- a/include/avm/version.h
+++ b/include/avm/version.h
@@ -6,8 +6,8 @@ namespace avm
 {
 
 inline constexpr int version_major = 1;
-inline constexpr int version_minor = 0;
+inline constexpr int version_minor = 1;
 inline constexpr int version_patch = 0;
-inline constexpr std::string_view version_string = "1.0.0";
+inline constexpr std::string_view version_string = "1.1.0";
 
 } // namespace avm

--- a/plan.md
+++ b/plan.md
@@ -1,10 +1,10 @@
-# AVM 1.0 roadmap
+# AVM roadmap
 
-## Принцип планирования
+## Planning rule
 
-Текущий план — **Architecture Foundation 2.0 / AVM 1.0**. Работа идёт dependency-ordered gates: новый слой начинается только после того, как его зависимости имеют стабильный контракт и зелёные CI-gates.
+Work proceeds through dependency-ordered gates. A new layer starts only after its dependencies have a stable contract and green CI gates.
 
-Главный инвариант roadmap:
+The invariant remains:
 
 ```text
 external projection
@@ -15,116 +15,124 @@ external projection
   -> result LinkId
 ```
 
-Не допускаются второй semantic path, отдельное legacy-хранилище или JSON AST как альтернативное execution core.
+No second semantic path, hidden program database, legacy storage universe or backend-specific semantic index is allowed.
 
-## Gate 1 — архитектурный контракт ✅
+## AVM 1.0 foundation — complete ✅
 
-- один physical primitive: directed dyad;
+### Gate 1 — architecture contract ✅
+
+- one physical primitive: directed dyad;
 - opaque `LinkId` identity;
 - canonical pair identity;
-- read/query operations не материализуют данные;
-- backend semantics отделены от VM semantics.
+- reads do not materialize data;
+- backend semantics separated from VM semantics.
 
-Основной документ: `docs/architecture.md`.
-
-## Gate 2 — canonical LinkStore ✅
+### Gate 2 — canonical LinkStore ✅
 
 - reference `InMemoryLinkStore`;
-- явное разделение `find` и `intern`;
-- conformance coverage для canonical identity и query behavior;
-- semantic code не зависит от pointer identity или layout backend-а.
+- explicit `find` vs `intern` separation;
+- canonical identity/query conformance;
+- semantic code independent of pointer identity/layout.
 
-## Gate 3 — Relations Model codec ✅
-
-Единственное представление triplet:
+### Gate 3 — Relations Model codec ✅
 
 ```text
 (relation, subject, object) = (relation, (subject, object))
 ```
 
-Codec отделён от storage contract.
+### Gate 4 — execution kernel ✅
 
-## Gate 4 — execution kernel ✅
+- `Executor` consumes entity `LinkId`;
+- relation dispatch by `LinkId`;
+- explicit execution context;
+- bootstrap native handlers are not a second program database.
 
-- `Executor` принимает entity `LinkId`;
-- relation dispatch выполняется по `LinkId`;
-- execution context явный;
-- bootstrap native handlers не являются второй program database.
+### Gate 5 — program-as-links ✅
 
-Документ: `docs/execution-kernel.md`.
+- programs, bindings and frames represented by links;
+- link-native vertical slice;
+- legacy pointer-based `rel_t` semantic/storage universe removed.
 
-## Gate 5 — program-as-links ✅
+### Gate 6 — external protocol boundary ✅
 
-- program structures представлены ссылками;
-- bindings/call frames находятся в ассоциативной модели;
-- link-native vertical slice покрывает наблюдаемую семантику;
-- старый pointer-based `rel_t` semantic/storage universe удалён после миграции consumers.
+- parser/grammar/context remain external;
+- AVM consumes structural projection/denotation;
+- `raw(A)` separated from `den(A)`;
+- `find` observational, `realize` explicit.
 
-## Gate 6 — external protocol boundary ✅
+The canonical Anum/MTS semantics are maintained in `netkeep80/anum_docs`; AVM contains only the structural L3→L4 bridge.
 
-- parser/grammar/context принадлежат внешнему adapter-у;
-- AVM core получает structural projection над `LinkId` anchors;
-- `raw(A)` отделён от `den(A)`;
-- `find` остаётся non-mutating, `realize` — явной материализацией.
+### Gate 7 — integration hardening ✅
 
-Документ: `docs/protocol-adapter-contract.md`.
+- persistent reopen/identity conformance;
+- end-to-end link-native vertical slice;
+- benchmark baselines;
+- documentation alignment;
+- warnings-as-errors, sanitizers and architecture guards.
 
-## Gate 7 — integration hardening (текущий)
+### Gate 8 — AVM 1.0 release readiness ✅
 
-### 7.1 Persistent LinkStore contract
+Validated on the same public package/core contracts:
 
-Persistent implementation должна быть взаимозаменяемой с in-memory backend по observable semantics. Reopen/crash guarantees и backend-specific behavior проверяются отдельно от VM semantics.
+- Linux, Windows and macOS portable builds/tests;
+- installed-package consumer on Linux, Windows and macOS;
+- stable public `avm::core` package;
+- one documented execution path;
+- no legacy semantic path.
 
-Документ: `docs/persistent-link-store.md`.
+## AVM 1.1 — associative query facilities
 
-### 7.2 End-to-end vertical slice
+Current epic: #83.
 
-Поддерживать короткий воспроизводимый путь от projection до result `LinkId`, не добавляя обходных execution routes.
+### Gate 9 — constrained Relations Model queries (current)
 
-### 7.3 Performance baseline
+Child: #84.
 
-Benchmark gates защищают от регрессий в canonical link operations и link-native execution. Производительность не может оправдывать нарушение identity/query invariants.
+Goal: read-only query facilities over the existing Relations Model and `LinkStore` indexes, without a second storage/index universe.
 
-### 7.4 Documentation alignment
+Public query shape:
 
-README, analysis и roadmap должны описывать только фактическую link-native архитектуру. Hard-coded test counts и исторические target claims не используются.
+```text
+relation? / subject? / object?
+-> existing find/outgoing/incoming paths
+-> structural decode/filter
+-> deterministic RelationMatch list
+```
 
-### 7.5 CI/quality hardening
+Requirements:
 
-Продолжать усиливать:
+- at least one constraint;
+- no `intern` / `create_point` in queries;
+- no guessed full-store enumeration;
+- deterministic ordering/deduplication;
+- InMemory/Persistent/reopen equivalence;
+- benchmark baselines for each lookup strategy;
+- installed public package consumption.
 
-- Linux/Windows/macOS builds;
-- warnings-as-errors;
-- sanitizers;
-- architecture quality guards;
-- benchmark regression gates;
-- persistent backend conformance.
+### Gate 10 — measured query/index evolution
 
-## Gate 8 — AVM 1.0 release readiness
+Only after Gate 9 benchmarks and real workloads show a need:
 
-После завершения integration hardening:
+- evaluate explicit LinkStore enumeration contract;
+- evaluate additional secondary/index operations;
+- preserve backend replaceability and read-only semantics;
+- require conformance across in-memory/persistent backends.
 
-- один документированный public execution path;
-- стабильные core contracts;
-- persistent backend с conformance/reopen coverage;
-- воспроизводимый vertical slice;
-- отсутствие legacy semantic paths;
-- release/versioning policy и минимальный public API.
+No backend-specific map is promoted into semantic code merely for convenience.
 
-## После AVM 1.0
+## Later AVM 1.x directions
 
-Только после foundation gates приоритет получают feature-направления:
+After the query foundation:
 
-1. расширение link-native стандартной библиотеки;
-2. дополнительные protocol/front-end adapters;
-3. query/indexing facilities поверх canonical store contracts;
-4. debugger/REPL и observability;
-5. packaging и integration tooling;
-6. visualization/GUI;
-7. distributed/persistent backend experiments.
+1. link-native standard library expansion;
+2. additional thin protocol/front-end adapters;
+3. debugger/REPL and observability;
+4. packaging/integration tooling;
+5. visualization/GUI;
+6. production physical backends and persistence experiments.
 
-Каждое расширение обязано использовать существующий `LinkStore -> Relations Model -> Executor` path и не создавать альтернативное runtime ядро.
+Every extension must reuse the existing `LinkStore -> Relations Model -> Executor` architecture.
 
 ## Dependency rule
 
-Если gate зависит от незавершённого PR, можно готовить следующий **независимый** шаг, но нельзя мержить зависимую работу раньше зелёного dependency-gate. Legacy-код после миграции consumers удаляется; Git является хранилищем истории.
+If a gate depends on an unfinished PR, independent preparation may proceed, but dependent code is not merged before the dependency is green. Legacy code is deleted after consumer migration; Git stores history.

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(avm 1.0 CONFIG REQUIRED)
+find_package(avm 1.1 CONFIG REQUIRED)
 
 add_executable(avm_package_consumer main.cpp)
 target_link_libraries(avm_package_consumer PRIVATE avm::core)

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -21,8 +21,8 @@ int main()
 	const avm::LinkId object = store.create_point();
 	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
 
-	const auto matches = avm::query_relation_entities(
-	    store, {.relation = relation, .subject = subject, .object = object});
+	const auto matches =
+	    avm::query_relation_entities(store, {.relation = relation, .subject = subject, .object = object});
 	if (matches.size() != 1 || matches.front().entity_id != entity ||
 	    matches.front().entity != avm::RelationEntity{relation, subject, object})
 		return 2;

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -3,9 +3,9 @@
 int main()
 {
 	static_assert(avm::version_major == 1);
-	static_assert(avm::version_minor == 0);
+	static_assert(avm::version_minor == 1);
 	static_assert(avm::version_patch == 0);
-	static_assert(avm::version_string == "1.0.0");
+	static_assert(avm::version_string == "1.1.0");
 
 	avm::InMemoryLinkStore store;
 	avm::BootstrapRuntime runtime(store);
@@ -13,6 +13,19 @@ int main()
 
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
 	const avm::LinkId result = runtime.execute(expression);
+	if (result != runtime.vocabulary().true_value)
+		return 1;
 
-	return result == runtime.vocabulary().true_value ? 0 : 1;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	const auto matches = avm::query_relation_entities(
+	    store, {.relation = relation, .subject = subject, .object = object});
+	if (matches.size() != 1 || matches.front().entity_id != entity ||
+	    matches.front().entity != avm::RelationEntity{relation, subject, object})
+		return 2;
+
+	return 0;
 }

--- a/test/relations_query_test.cpp
+++ b/test/relations_query_test.cpp
@@ -5,9 +5,8 @@
 #include <cassert>
 #include <chrono>
 #include <filesystem>
-#include <functional>
-#include <optional>
 #include <stdexcept>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -99,22 +98,25 @@ void assert_matches(const avm::LinkStore &store, const avm::RelationQuery &query
 
 void verify_all_constraint_combinations(const avm::LinkStore &store, const Fixture &fixture)
 {
+	const auto pair_s1_o1 = store.find(fixture.s1, fixture.o1);
+	const auto pair_s2_o1 = store.find(fixture.s2, fixture.o1);
+	assert(pair_s1_o1.has_value());
+	assert(pair_s2_o1.has_value());
+
 	assert_matches(store, {.relation = fixture.r1}, sorted({fixture.r1, fixture.e1, fixture.e2, fixture.e3}));
-	assert_matches(store, {.subject = fixture.s1}, sorted({fixture.s1, fixture.e1, fixture.e2, fixture.e4, fixture.e6}));
-	assert_matches(store, {.object = fixture.o1}, sorted({fixture.o1, fixture.e1, fixture.e3, fixture.e4}));
+	assert_matches(store, {.subject = fixture.s1},
+	               sorted({fixture.s1, fixture.e1, fixture.e2, fixture.e4, fixture.e6}));
+	assert_matches(store, {.object = fixture.o1},
+	               sorted({fixture.o1, *pair_s1_o1, *pair_s2_o1, fixture.e1, fixture.e3, fixture.e4}));
 	assert_matches(store, {.relation = fixture.r1, .subject = fixture.s1}, sorted({fixture.e1, fixture.e2}));
 	assert_matches(store, {.relation = fixture.r1, .object = fixture.o1}, sorted({fixture.e1, fixture.e3}));
 	assert_matches(store, {.subject = fixture.s1, .object = fixture.o1}, sorted({fixture.e1, fixture.e4}));
-	assert_matches(store,
-	               {.relation = fixture.r1, .subject = fixture.s1, .object = fixture.o1},
-	               sorted({fixture.e1}));
+	assert_matches(store, {.relation = fixture.r1, .subject = fixture.s1, .object = fixture.o1}, sorted({fixture.e1}));
 }
 
 void verify_point_endpoint_entity(const avm::LinkStore &store, const Fixture &fixture)
 {
-	assert_matches(store,
-	               {.relation = fixture.r2, .subject = fixture.s1, .object = fixture.s1},
-	               sorted({fixture.e6}));
+	assert_matches(store, {.relation = fixture.r2, .subject = fixture.s1, .object = fixture.s1}, sorted({fixture.e6}));
 }
 
 void verify_missing_constraints_are_empty_and_non_materializing(const avm::LinkStore &store, const Fixture &fixture)
@@ -149,8 +151,8 @@ void verify_unconstrained_query_is_rejected(const avm::LinkStore &store)
 void verify_noise_does_not_match_unrelated_constraints(const avm::LinkStore &store, const Fixture &fixture)
 {
 	const std::vector<avm::RelationMatch> matches = avm::query_relation_entities(store, {.relation = fixture.r1});
-	assert(std::none_of(matches.begin(), matches.end(), [&](const avm::RelationMatch &match)
-	                    { return match.entity_id == fixture.noise; }));
+	assert(std::none_of(matches.begin(), matches.end(),
+	                    [&](const avm::RelationMatch &match) { return match.entity_id == fixture.noise; }));
 }
 
 void verify_backend(avm::LinkStore &store, const Fixture &fixture)

--- a/test/relations_query_test.cpp
+++ b/test/relations_query_test.cpp
@@ -1,0 +1,187 @@
+#include "avm/persistent_link_store.h"
+#include "avm/relations_query.h"
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <functional>
+#include <optional>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+namespace
+{
+
+struct Fixture
+{
+	avm::LinkId r1;
+	avm::LinkId r2;
+	avm::LinkId s1;
+	avm::LinkId s2;
+	avm::LinkId o1;
+	avm::LinkId o2;
+	avm::LinkId e1;
+	avm::LinkId e2;
+	avm::LinkId e3;
+	avm::LinkId e4;
+	avm::LinkId e5;
+	avm::LinkId e6;
+	avm::LinkId noise;
+};
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+std::filesystem::path temporary_store_path()
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() / ("avm-relations-query-" + std::to_string(nonce) + ".bin");
+}
+
+Fixture populate(avm::LinkStore &store)
+{
+	Fixture fixture{};
+	fixture.r1 = store.create_point();
+	fixture.r2 = store.create_point();
+	fixture.s1 = store.create_point();
+	fixture.s2 = store.create_point();
+	fixture.o1 = store.create_point();
+	fixture.o2 = store.create_point();
+
+	fixture.e1 = avm::encode_relation_entity(store, {fixture.r1, fixture.s1, fixture.o1});
+	fixture.e2 = avm::encode_relation_entity(store, {fixture.r1, fixture.s1, fixture.o2});
+	fixture.e3 = avm::encode_relation_entity(store, {fixture.r1, fixture.s2, fixture.o1});
+	fixture.e4 = avm::encode_relation_entity(store, {fixture.r2, fixture.s1, fixture.o1});
+	fixture.e5 = avm::encode_relation_entity(store, {fixture.r2, fixture.s2, fixture.o2});
+	fixture.e6 = avm::encode_relation_entity(store, {fixture.r2, fixture.s1, fixture.s1});
+
+	const avm::LinkId noise_begin = store.create_point();
+	const avm::LinkId noise_end = store.create_point();
+	fixture.noise = store.intern(noise_begin, noise_end);
+	return fixture;
+}
+
+std::vector<avm::LinkId> sorted(std::initializer_list<avm::LinkId> ids)
+{
+	std::vector<avm::LinkId> result(ids);
+	std::sort(result.begin(), result.end());
+	return result;
+}
+
+void assert_matches(const avm::LinkStore &store, const avm::RelationQuery &query,
+                    const std::vector<avm::LinkId> &expected_ids)
+{
+	const std::size_t size_before = store.size();
+	const std::vector<avm::RelationMatch> matches = avm::query_relation_entities(store, query);
+	assert(store.size() == size_before);
+	assert(std::is_sorted(matches.begin(), matches.end(),
+	                      [](const avm::RelationMatch &left, const avm::RelationMatch &right)
+	                      { return left.entity_id < right.entity_id; }));
+
+	std::vector<avm::LinkId> actual_ids;
+	actual_ids.reserve(matches.size());
+	for (const avm::RelationMatch &match : matches)
+	{
+		actual_ids.push_back(match.entity_id);
+		assert(match.entity == avm::decode_relation_entity(store, match.entity_id));
+	}
+	assert(actual_ids == expected_ids);
+}
+
+void verify_all_constraint_combinations(const avm::LinkStore &store, const Fixture &fixture)
+{
+	assert_matches(store, {.relation = fixture.r1}, sorted({fixture.r1, fixture.e1, fixture.e2, fixture.e3}));
+	assert_matches(store, {.subject = fixture.s1}, sorted({fixture.s1, fixture.e1, fixture.e2, fixture.e4, fixture.e6}));
+	assert_matches(store, {.object = fixture.o1}, sorted({fixture.o1, fixture.e1, fixture.e3, fixture.e4}));
+	assert_matches(store, {.relation = fixture.r1, .subject = fixture.s1}, sorted({fixture.e1, fixture.e2}));
+	assert_matches(store, {.relation = fixture.r1, .object = fixture.o1}, sorted({fixture.e1, fixture.e3}));
+	assert_matches(store, {.subject = fixture.s1, .object = fixture.o1}, sorted({fixture.e1, fixture.e4}));
+	assert_matches(store,
+	               {.relation = fixture.r1, .subject = fixture.s1, .object = fixture.o1},
+	               sorted({fixture.e1}));
+}
+
+void verify_point_endpoint_entity(const avm::LinkStore &store, const Fixture &fixture)
+{
+	assert_matches(store,
+	               {.relation = fixture.r2, .subject = fixture.s1, .object = fixture.s1},
+	               sorted({fixture.e6}));
+}
+
+void verify_missing_constraints_are_empty_and_non_materializing(const avm::LinkStore &store, const Fixture &fixture)
+{
+	const std::size_t size_before = store.size();
+	assert(avm::query_relation_entities(store, {.subject = fixture.s2, .object = fixture.s1}).empty());
+	assert(store.size() == size_before);
+
+	const avm::LinkId unknown = static_cast<avm::LinkId>(store.size()) + 1000;
+	assert(!store.contains(unknown));
+	assert(avm::query_relation_entities(store, {.relation = unknown}).empty());
+	assert(avm::query_relation_entities(store, {.subject = unknown}).empty());
+	assert(avm::query_relation_entities(store, {.object = unknown}).empty());
+	assert(store.size() == size_before);
+}
+
+void verify_unconstrained_query_is_rejected(const avm::LinkStore &store)
+{
+	bool thrown = false;
+	try
+	{
+		static_cast<void>(avm::query_relation_entities(store, {}));
+	}
+	catch (const std::invalid_argument &error)
+	{
+		thrown = true;
+		assert(std::string_view(error.what()).find("constraint") != std::string_view::npos);
+	}
+	assert(thrown);
+}
+
+void verify_noise_does_not_match_unrelated_constraints(const avm::LinkStore &store, const Fixture &fixture)
+{
+	const std::vector<avm::RelationMatch> matches = avm::query_relation_entities(store, {.relation = fixture.r1});
+	assert(std::none_of(matches.begin(), matches.end(), [&](const avm::RelationMatch &match)
+	                    { return match.entity_id == fixture.noise; }));
+}
+
+void verify_backend(avm::LinkStore &store, const Fixture &fixture)
+{
+	verify_all_constraint_combinations(store, fixture);
+	verify_point_endpoint_entity(store, fixture);
+	verify_missing_constraints_are_empty_and_non_materializing(store, fixture);
+	verify_unconstrained_query_is_rejected(store);
+	verify_noise_does_not_match_unrelated_constraints(store, fixture);
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore memory;
+	const Fixture memory_fixture = populate(memory);
+	verify_backend(memory, memory_fixture);
+
+	const std::filesystem::path path = temporary_store_path();
+	FileCleanup cleanup{path};
+	Fixture persistent_fixture{};
+	{
+		avm::PersistentLinkStore persistent(path);
+		persistent_fixture = populate(persistent);
+		verify_backend(persistent, persistent_fixture);
+	}
+	{
+		avm::PersistentLinkStore reopened(path);
+		verify_backend(reopened, persistent_fixture);
+	}
+
+	return 0;
+}


### PR DESCRIPTION
Closes #84. Parent #83.

## Public AVM 1.1 API
Adds dependency-free read-only querying of canonical Relations Model entities:

```cpp
RelationQuery{relation?, subject?, object?}
query_relation_entities(const LinkStore&, const RelationQuery&)
```

`RelationMatch` returns both the matching entity LinkId and its decoded `RelationEntity`.

This is a backwards-compatible public feature, so the package version moves from 1.0.0 to 1.1.0 in CMake and `version.h`; the external install consumer now exercises the query API.

## Existing-index strategy only
No new storage/index universe is introduced. Exactly one current `LinkStore` lookup path drives each query:
- relation -> `outgoing(relation)`;
- subject+object -> exact `find(subject,object)` then `incoming(pair)`;
- subject -> `outgoing(subject)` pairs then `incoming(pair)`;
- object -> `incoming(object)` pairs then `incoming(pair)`.

Candidates are decoded and filtered, results are sorted by entity LinkId and defensively deduplicated. Unknown constraints return empty. An all-wildcard query is rejected because `LinkStore` intentionally has no enumeration contract.

## Important Relations Model property
The query layer does not maintain a hidden registry of links previously passed through `encode_relation_entity`. Relations Model decoding is structural and total for existing links, so a point `x=(x,x)` is also structurally the entity `(x,x,x)`. Conformance tests explicitly lock this behavior rather than inventing a second semantic identity/classification universe.

## Conformance
Tests cover all 7 non-empty relation/subject/object constraint combinations, equal subject/object point endpoints, unrelated noise, missing exact pairs, unknown LinkIds, all-wildcard rejection, deterministic order and no store-size mutation.

The same fixture is verified against:
- `InMemoryLinkStore`;
- `PersistentLinkStore` before close;
- the same persistent store after reopen.

## CI / performance
- `relations_query.h` is installed and included by `<avm/avm.h>`;
- CI rejects `intern`, `create_point`, guessed `store.size()` enumeration, backend-specific store classes and JSON/Anum coupling in the production query layer;
- query tests run through strict core, ASan+UBSan and portable Linux/Windows/macOS lanes;
- benchmark adds relation-, subject-, object- and exact subject+object-driven rows.

No persistence format or Relations Model encoding changes.