### PR TITLE
AVM 1.1: measure Relations query fan-out scaling

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,9 +39,18 @@ jobs:
         run: |
           set -euo pipefail
           head -n 1 avm-benchmark.tsv | grep -F $'name\toperations\telapsed_ns\tns_per_op'
-          for name in intern_new_pair intern_existing_pair find_hit find_miss outgoing_query incoming_query relations_model_encode relations_model_decode relations_query_relation relations_query_subject relations_query_object relations_query_subject_object execute_minimal_relation persistent_reopen_index_rebuild; do
+          for name in intern_new_pair intern_existing_pair find_hit find_miss outgoing_query incoming_query relations_model_encode relations_model_decode execute_minimal_relation persistent_reopen_index_rebuild; do
             grep -F "${name}" avm-benchmark.tsv >/dev/null
           done
+          for fanout in 1 8 64 256; do
+            for kind in relation subject object subject_object; do
+              grep -F "relations_query_${kind}_fanout_${fanout}" avm-benchmark.tsv >/dev/null
+            done
+          done
+          grep -F $'# query_scale\t1\t10000\t2\t3\t5\t1' avm-benchmark.tsv >/dev/null
+          grep -F $'# query_scale\t8\t5000\t9\t17\t26\t8' avm-benchmark.tsv >/dev/null
+          grep -F $'# query_scale\t64\t2000\t65\t129\t194\t64' avm-benchmark.tsv >/dev/null
+          grep -F $'# query_scale\t256\t500\t257\t513\t770\t256' avm-benchmark.tsv >/dev/null
 
       - name: Upload benchmark result
         uses: actions/upload-artifact@v4

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -12,6 +12,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace
@@ -90,27 +91,27 @@ void assert_match_count(const avm::LinkStore &store, const avm::RelationQuery &q
 
 void benchmark_relation_query_scale(std::size_t fanout, std::size_t &sink)
 {
-	avm::InMemoryLinkStore query_store;
-	const avm::LinkId relation = query_store.create_point();
-	const avm::LinkId subject = query_store.create_point();
-	const avm::LinkId object = query_store.create_point();
+	avm::InMemoryLinkStore qs;
+	const avm::LinkId relation = qs.create_point();
+	const avm::LinkId subject = qs.create_point();
+	const avm::LinkId object = qs.create_point();
 
 	for (std::size_t i = 0; i < fanout; ++i)
 	{
-		const avm::LinkId relation_subject = query_store.create_point();
-		const avm::LinkId relation_object = query_store.create_point();
-		static_cast<void>(avm::encode_relation_entity(query_store, {relation, relation_subject, relation_object}));
+		const avm::LinkId relation_subject = qs.create_point();
+		const avm::LinkId relation_object = qs.create_point();
+		static_cast<void>(avm::encode_relation_entity(qs, {relation, relation_subject, relation_object}));
 
-		const avm::LinkId subject_relation = query_store.create_point();
-		const avm::LinkId subject_object = query_store.create_point();
-		static_cast<void>(avm::encode_relation_entity(query_store, {subject_relation, subject, subject_object}));
+		const avm::LinkId subject_relation = qs.create_point();
+		const avm::LinkId subject_object = qs.create_point();
+		static_cast<void>(avm::encode_relation_entity(qs, {subject_relation, subject, subject_object}));
 
-		const avm::LinkId object_relation = query_store.create_point();
-		const avm::LinkId object_subject = query_store.create_point();
-		static_cast<void>(avm::encode_relation_entity(query_store, {object_relation, object_subject, object}));
+		const avm::LinkId object_relation = qs.create_point();
+		const avm::LinkId object_subject = qs.create_point();
+		static_cast<void>(avm::encode_relation_entity(qs, {object_relation, object_subject, object}));
 
-		const avm::LinkId exact_relation = query_store.create_point();
-		static_cast<void>(avm::encode_relation_entity(query_store, {exact_relation, subject, object}));
+		const avm::LinkId exact_relation = qs.create_point();
+		static_cast<void>(avm::encode_relation_entity(qs, {exact_relation, subject, object}));
 	}
 
 	const avm::RelationQuery relation_query{.relation = relation};
@@ -123,28 +124,26 @@ void benchmark_relation_query_scale(std::size_t fanout, std::size_t &sink)
 	const std::size_t object_matches = 3 * fanout + 2;
 	const std::size_t subject_object_matches = fanout;
 
-	assert_match_count(query_store, relation_query, relation_matches, "relation");
-	assert_match_count(query_store, subject_query, subject_matches, "subject");
-	assert_match_count(query_store, object_query, object_matches, "object");
-	assert_match_count(query_store, subject_object_query, subject_object_matches, "subject+object");
+	assert_match_count(qs, relation_query, relation_matches, "relation");
+	assert_match_count(qs, subject_query, subject_matches, "subject");
+	assert_match_count(qs, object_query, object_matches, "object");
+	assert_match_count(qs, subject_object_query, subject_object_matches, "subject+object");
 
 	const std::size_t iterations = scale_iterations(fanout);
 	std::cout << "# query_scale\t" << fanout << '\t' << iterations << '\t' << relation_matches << '\t'
 	          << subject_matches << '\t' << object_matches << '\t' << subject_object_matches << '\n';
 
 	const std::string suffix = "_fanout_" + std::to_string(fanout);
-	const auto relation_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, relation_query).size(); };
+	const auto relation_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(qs, relation_query).size(); };
 	print(measure("relations_query_relation" + suffix, iterations, relation_bench));
 
-	const auto subject_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, subject_query).size(); };
+	const auto subject_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(qs, subject_query).size(); };
 	print(measure("relations_query_subject" + suffix, iterations, subject_bench));
 
-	const auto object_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, object_query).size(); };
+	const auto object_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(qs, object_query).size(); };
 	print(measure("relations_query_object" + suffix, iterations, object_bench));
 
-	const auto pair_bench = [&](std::size_t) {
-		sink ^= avm::query_relation_entities(query_store, subject_object_query).size();
-	};
+	const auto pair_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(qs, subject_object_query).size(); };
 	print(measure("relations_query_subject_object" + suffix, iterations, pair_bench));
 }
 

--- a/benchmark/avm_benchmark.cpp
+++ b/benchmark/avm_benchmark.cpp
@@ -3,11 +3,13 @@
 #include "avm/relations_model.h"
 #include "avm/relations_query.h"
 
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <filesystem>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -19,7 +21,7 @@ using Clock = std::chrono::steady_clock;
 
 struct Measurement
 {
-	std::string_view name;
+	std::string name;
 	std::size_t operations;
 	std::uint64_t elapsed_ns;
 };
@@ -34,14 +36,14 @@ struct FileCleanup
 	}
 };
 
-Measurement measure(std::string_view name, std::size_t operations, auto &&function)
+Measurement measure(std::string name, std::size_t operations, auto &&function)
 {
 	const auto started = Clock::now();
 	for (std::size_t i = 0; i < operations; ++i)
 		function(i);
 	const auto finished = Clock::now();
 	const auto elapsed = std::chrono::duration_cast<std::chrono::nanoseconds>(finished - started).count();
-	return Measurement{name, operations, static_cast<std::uint64_t>(elapsed)};
+	return Measurement{std::move(name), operations, static_cast<std::uint64_t>(elapsed)};
 }
 
 void print(const Measurement &measurement)
@@ -60,15 +62,100 @@ std::filesystem::path temporary_store_path()
 	return std::filesystem::temp_directory_path() / ("avm-benchmark-" + std::to_string(nonce) + ".bin");
 }
 
+std::size_t scale_iterations(std::size_t fanout)
+{
+	switch (fanout)
+	{
+	case 1:
+		return 10000;
+	case 8:
+		return 5000;
+	case 64:
+		return 2000;
+	case 256:
+		return 500;
+	default:
+		throw std::invalid_argument("unsupported Relations query benchmark fan-out");
+	}
+}
+
+void assert_match_count(const avm::LinkStore &store, const avm::RelationQuery &query, std::size_t expected,
+                        std::string_view label)
+{
+	const std::size_t actual = avm::query_relation_entities(store, query).size();
+	if (actual != expected)
+		throw std::runtime_error(std::string(label) + " Relations query match-count mismatch: expected " +
+		                         std::to_string(expected) + ", got " + std::to_string(actual));
+}
+
+void benchmark_relation_query_scale(std::size_t fanout, std::size_t &sink)
+{
+	avm::InMemoryLinkStore query_store;
+	const avm::LinkId relation = query_store.create_point();
+	const avm::LinkId subject = query_store.create_point();
+	const avm::LinkId object = query_store.create_point();
+
+	for (std::size_t i = 0; i < fanout; ++i)
+	{
+		const avm::LinkId relation_subject = query_store.create_point();
+		const avm::LinkId relation_object = query_store.create_point();
+		static_cast<void>(avm::encode_relation_entity(query_store, {relation, relation_subject, relation_object}));
+
+		const avm::LinkId subject_relation = query_store.create_point();
+		const avm::LinkId subject_object = query_store.create_point();
+		static_cast<void>(avm::encode_relation_entity(query_store, {subject_relation, subject, subject_object}));
+
+		const avm::LinkId object_relation = query_store.create_point();
+		const avm::LinkId object_subject = query_store.create_point();
+		static_cast<void>(avm::encode_relation_entity(query_store, {object_relation, object_subject, object}));
+
+		const avm::LinkId exact_relation = query_store.create_point();
+		static_cast<void>(avm::encode_relation_entity(query_store, {exact_relation, subject, object}));
+	}
+
+	const avm::RelationQuery relation_query{.relation = relation};
+	const avm::RelationQuery subject_query{.subject = subject};
+	const avm::RelationQuery object_query{.object = object};
+	const avm::RelationQuery subject_object_query{.subject = subject, .object = object};
+
+	const std::size_t relation_matches = fanout + 1;
+	const std::size_t subject_matches = 2 * fanout + 1;
+	const std::size_t object_matches = 3 * fanout + 2;
+	const std::size_t subject_object_matches = fanout;
+
+	assert_match_count(query_store, relation_query, relation_matches, "relation");
+	assert_match_count(query_store, subject_query, subject_matches, "subject");
+	assert_match_count(query_store, object_query, object_matches, "object");
+	assert_match_count(query_store, subject_object_query, subject_object_matches, "subject+object");
+
+	const std::size_t iterations = scale_iterations(fanout);
+	std::cout << "# query_scale\t" << fanout << '\t' << iterations << '\t' << relation_matches << '\t'
+	          << subject_matches << '\t' << object_matches << '\t' << subject_object_matches << '\n';
+
+	const std::string suffix = "_fanout_" + std::to_string(fanout);
+	const auto relation_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, relation_query).size(); };
+	print(measure("relations_query_relation" + suffix, iterations, relation_bench));
+
+	const auto subject_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, subject_query).size(); };
+	print(measure("relations_query_subject" + suffix, iterations, subject_bench));
+
+	const auto object_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(query_store, object_query).size(); };
+	print(measure("relations_query_object" + suffix, iterations, object_bench));
+
+	const auto pair_bench = [&](std::size_t) {
+		sink ^= avm::query_relation_entities(query_store, subject_object_query).size();
+	};
+	print(measure("relations_query_subject_object" + suffix, iterations, pair_bench));
+}
+
 } // namespace
 
 int main()
 {
 	constexpr std::size_t sample_size = 20000;
 	constexpr std::size_t query_iterations = 100000;
-	constexpr std::size_t relation_query_sample_size = 64;
-	constexpr std::size_t relation_query_iterations = 5000;
 	constexpr std::size_t persistent_sample_size = 256;
+	constexpr std::array<std::size_t, 4> query_fanouts{1, 8, 64, 256};
 
 	std::cout << "name\toperations\telapsed_ns\tns_per_op\n";
 
@@ -130,35 +217,8 @@ int main()
 	};
 	print(measure("relations_model_decode", query_iterations, decode_entity));
 
-	const avm::LinkId query_relation = store.create_point();
-	const avm::LinkId query_subject = store.create_point();
-	const avm::LinkId query_object = store.create_point();
-	for (std::size_t i = 0; i < relation_query_sample_size; ++i)
-	{
-		const avm::LinkId varying_subject = points[1000 + i];
-		const avm::LinkId varying_object = points[2000 + i];
-		static_cast<void>(avm::encode_relation_entity(store, {query_relation, varying_subject, varying_object}));
-		static_cast<void>(avm::encode_relation_entity(store, {points[3000 + i], query_subject, varying_object}));
-		static_cast<void>(avm::encode_relation_entity(store, {points[4000 + i], varying_subject, query_object}));
-		static_cast<void>(avm::encode_relation_entity(store, {points[5000 + i], query_subject, query_object}));
-	}
-
-	const avm::RelationQuery relation_q{.relation = query_relation};
-	const avm::RelationQuery subject_q{.subject = query_subject};
-	const avm::RelationQuery object_q{.object = query_object};
-	const avm::RelationQuery pair_q{.subject = query_subject, .object = query_object};
-
-	const auto relation_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, relation_q).size(); };
-	print(measure("relations_query_relation", relation_query_iterations, relation_bench));
-
-	const auto subject_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, subject_q).size(); };
-	print(measure("relations_query_subject", relation_query_iterations, subject_bench));
-
-	const auto object_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, object_q).size(); };
-	print(measure("relations_query_object", relation_query_iterations, object_bench));
-
-	const auto pair_bench = [&](std::size_t) { sink ^= avm::query_relation_entities(store, pair_q).size(); };
-	print(measure("relations_query_subject_object", relation_query_iterations, pair_bench));
+	for (const std::size_t fanout : query_fanouts)
+		benchmark_relation_query_scale(fanout, sink);
 
 	avm::BootstrapRuntime runtime(store);
 	avm::ProgramBuilder builder = runtime.builder();


### PR DESCRIPTION
Closes #86. Parent #83. Depends on merged #85.

## Purpose
This PR is measurement-only. It does not change `relations_query.h`, `LinkStore`, persistence, public API or query semantics.

The first AVM 1.1 benchmark measured one synthetic fan-out point (64) and showed subject/object-driven queries several times slower than relation/exact-pair paths. One point was not sufficient evidence for a new physical index, so this gate measures scaling before any storage redesign.

## Scale sweep
Each fan-out uses a fresh isolated `InMemoryLinkStore`:

```text
fan-out             1          8          64          256
relation ns/op      88.8       240.3      1,981       13,189
subject ns/op       171.5      681.8      7,798       43,292
object ns/op        221.4      838.3      9,564       50,514
subject+object      64.3       247.5      1,900       10,143
```

Iterations decrease with fan-out (`10000/5000/2000/500`) to keep CI runtime bounded.

These isolated scale numbers should not be compared as absolute values to the earlier mixed 20k-link baseline; this gate intentionally removes background-store-size contamination and isolates fan-out behavior.

## Structural metadata
The fixture checks exact match counts before measuring:

```text
relation        = f + 1
subject         = 2f + 1
object          = 3f + 2
subject+object  = f
```

At fan-out 256 that means `257 / 513 / 770 / 256` returned structural matches. The benchmark emits machine-readable `# query_scale` metadata and the workflow validates exact values for all four fan-outs, alongside 16 timing rows.

From fan-out 64 to 256, candidate/result counts grow ~4x while measured time grows about 5.3x–6.7x, consistent with linear candidate expansion plus decode/vector/sort overhead. Absolute cost at 256 remains about 10–51 microseconds/query on the GitHub Release runner.

## Decision
**Defer a new physical/persistent index.**

The data proves the existing-index strategies have visible fan-out cost, but no AVM workload SLA or production trace currently demonstrates that 10–51 us at fan-out 256 is unacceptable. Adding another LinkStore index now would expand persistence/rebuild/conformance complexity without a demonstrated requirement.

A future index proposal must be triggered by a concrete workload/latency target and should compare against these scale rows. Until then the canonical `find/outgoing/incoming` contract remains sufficient.

No index implementation is included in this PR.