### PR TITLE
AVM 1.2: add read-only structural runtime primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,7 @@ jobs:
             test/executor_test.cpp \
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
+            test/structural_runtime_test.cpp \
             test/function_runtime_test.cpp \
             test/frame_runtime_test.cpp \
             test/deferred_definition_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 message("Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_PROJECT_VERSION 1.1.0)
+set(CMAKE_PROJECT_VERSION 1.2.0)
 
 project(avm
     VERSION ${CMAKE_PROJECT_VERSION}
@@ -151,6 +151,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
+    avm_add_core_test(avm_structural_runtime_test test/structural_runtime_test.cpp structural_runtime_tests)
     avm_add_core_test(avm_function_runtime_test test/function_runtime_test.cpp function_runtime_tests)
     avm_add_core_test(avm_frame_runtime_test test/frame_runtime_test.cpp frame_runtime_tests)
     avm_add_core_test(avm_deferred_definition_test test/deferred_definition_test.cpp deferred_definition_tests)
@@ -182,6 +183,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_executor_test
         avm_program_model_test
         avm_boolean_runtime_test
+        avm_structural_runtime_test
         avm_function_runtime_test
         avm_frame_runtime_test
         avm_deferred_definition_test

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -110,6 +110,10 @@ private:
 		    vocabulary_.call_relation,
 		    vocabulary_.binding_relation,
 		    vocabulary_.frame_relation,
+		    vocabulary_.begin_relation,
+		    vocabulary_.end_relation,
+		    vocabulary_.same_relation,
+		    vocabulary_.link_exists_relation,
 		};
 
 		std::set<LinkId> unique;
@@ -266,6 +270,44 @@ private:
 				                          result = executor.execute(expression, context.entity, context.frame);
 			                          return result;
 		                          });
+
+		executor_.register_native(
+		    vocabulary_.begin_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 1);
+			    const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
+			    return store_.get(value).begin;
+		    });
+
+		executor_.register_native(
+		    vocabulary_.end_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 1);
+			    const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
+			    return store_.get(value).end;
+		    });
+
+		executor_.register_native(
+		    vocabulary_.same_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			    const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+			    const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
+			    return left == right ? vocabulary_.true_value : vocabulary_.false_value;
+		    });
+
+		executor_.register_native(
+		    vocabulary_.link_exists_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			    const LinkId begin = executor.execute(arguments[0], context.entity, context.frame);
+			    const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
+			    return store_.find(begin, end) ? vocabulary_.true_value : vocabulary_.false_value;
+		    });
 
 		executor_.register_native(
 		    vocabulary_.not_relation,

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -318,7 +318,8 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			                          const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId value =
+			                              executor.execute(arguments[0], context.entity, context.frame);
 			                          return store_.get(value).begin;
 		                          });
 
@@ -326,7 +327,8 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			                          const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId value =
+			                              executor.execute(arguments[0], context.entity, context.frame);
 			                          return store_.get(value).end;
 		                          });
 
@@ -335,7 +337,8 @@ private:
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
 			                          const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
-			                          const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
+			                          const LinkId right =
+			                              executor.execute(arguments[1], context.entity, context.frame);
 			                          return left == right ? vocabulary_.true_value : vocabulary_.false_value;
 		                          });
 
@@ -343,7 +346,8 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
-			                          const LinkId begin = executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId begin =
+			                              executor.execute(arguments[0], context.entity, context.frame);
 			                          const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
 			                          return store_.find(begin, end) ? vocabulary_.true_value : vocabulary_.false_value;
 		                          });

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -292,43 +292,46 @@ private:
 			                          return result;
 		                          });
 
-		executor_.register_native(
-		    vocabulary_.begin_relation,
-		    [this](const ExecutionContext &context, Executor &executor)
-		    {
-			    const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			    const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
-			    return store_.get(value).begin;
-		    });
+		executor_.register_native(vocabulary_.begin_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
+			                          const LinkId value =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          return store_.get(value).begin;
+		                          });
 
-		executor_.register_native(
-		    vocabulary_.end_relation,
-		    [this](const ExecutionContext &context, Executor &executor)
-		    {
-			    const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			    const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
-			    return store_.get(value).end;
-		    });
+		executor_.register_native(vocabulary_.end_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
+			                          const LinkId value =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          return store_.get(value).end;
+		                          });
 
-		executor_.register_native(
-		    vocabulary_.same_relation,
-		    [this](const ExecutionContext &context, Executor &executor)
-		    {
-			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
-			    const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
-			    const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
-			    return left == right ? vocabulary_.true_value : vocabulary_.false_value;
-		    });
+		executor_.register_native(vocabulary_.same_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			                          const LinkId left =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId right =
+			                              executor.execute(arguments[1], context.entity, context.frame);
+			                          return left == right ? vocabulary_.true_value : vocabulary_.false_value;
+		                          });
 
-		executor_.register_native(
-		    vocabulary_.link_exists_relation,
-		    [this](const ExecutionContext &context, Executor &executor)
-		    {
-			    const std::vector<LinkId> arguments = expression_arguments(context, 2);
-			    const LinkId begin = executor.execute(arguments[0], context.entity, context.frame);
-			    const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
-			    return store_.find(begin, end) ? vocabulary_.true_value : vocabulary_.false_value;
-		    });
+		executor_.register_native(vocabulary_.link_exists_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			                          const LinkId begin =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId end =
+			                              executor.execute(arguments[1], context.entity, context.frame);
+			                          return store_.find(begin, end) ? vocabulary_.true_value
+			                                                         : vocabulary_.false_value;
+		                          });
 
 		executor_.register_native(
 		    vocabulary_.not_relation,

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -76,6 +76,7 @@ public:
 	{
 		if (max_call_depth_ == 0)
 			throw std::invalid_argument("maximum call depth must be greater than zero");
+		upgrade_structural_vocabulary_if_needed();
 		validate_vocabulary();
 		materialize_truth_tables();
 		register_handlers();
@@ -92,6 +93,26 @@ public:
 	LinkId execute(LinkId root) { return executor_.execute(root); }
 
 private:
+	void upgrade_structural_vocabulary_if_needed()
+	{
+		const bool begin_missing = vocabulary_.begin_relation == invalid_link_id;
+		const bool end_missing = vocabulary_.end_relation == invalid_link_id;
+		const bool same_missing = vocabulary_.same_relation == invalid_link_id;
+		const bool exists_missing = vocabulary_.link_exists_relation == invalid_link_id;
+		const unsigned missing = static_cast<unsigned>(begin_missing) + static_cast<unsigned>(end_missing) +
+		                         static_cast<unsigned>(same_missing) + static_cast<unsigned>(exists_missing);
+
+		if (missing == 0)
+			return;
+		if (missing != 4)
+			throw std::invalid_argument("bootstrap structural vocabulary must be fully present or fully absent");
+
+		vocabulary_.begin_relation = store_.create_point();
+		vocabulary_.end_relation = store_.create_point();
+		vocabulary_.same_relation = store_.create_point();
+		vocabulary_.link_exists_relation = store_.create_point();
+	}
+
 	void validate_vocabulary() const
 	{
 		const std::vector<LinkId> ids{

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -3,6 +3,7 @@
 #include "avm/executor.h"
 #include "avm/program_model.h"
 
+#include <initializer_list>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -93,6 +94,18 @@ public:
 	LinkId execute(LinkId root) { return executor_.execute(root); }
 
 private:
+	void validate_vocabulary_ids(std::initializer_list<LinkId> ids) const
+	{
+		std::set<LinkId> unique;
+		for (const LinkId id : ids)
+		{
+			if (!store_.contains(id))
+				throw std::invalid_argument("bootstrap vocabulary contains an unknown LinkId");
+			if (!unique.insert(id).second)
+				throw std::invalid_argument("bootstrap vocabulary identities must be distinct");
+		}
+	}
+
 	void upgrade_structural_vocabulary_if_needed()
 	{
 		const bool begin_missing = vocabulary_.begin_relation == invalid_link_id;
@@ -107,6 +120,24 @@ private:
 		if (missing != 4)
 			throw std::invalid_argument("bootstrap structural vocabulary must be fully present or fully absent");
 
+		validate_vocabulary_ids({
+		    vocabulary_.unit,
+		    vocabulary_.nil,
+		    vocabulary_.true_value,
+		    vocabulary_.false_value,
+		    vocabulary_.quote_relation,
+		    vocabulary_.parameter_relation,
+		    vocabulary_.sequence_relation,
+		    vocabulary_.not_relation,
+		    vocabulary_.and_relation,
+		    vocabulary_.or_relation,
+		    vocabulary_.if_relation,
+		    vocabulary_.function_relation,
+		    vocabulary_.call_relation,
+		    vocabulary_.binding_relation,
+		    vocabulary_.frame_relation,
+		});
+
 		vocabulary_.begin_relation = store_.create_point();
 		vocabulary_.end_relation = store_.create_point();
 		vocabulary_.same_relation = store_.create_point();
@@ -115,7 +146,7 @@ private:
 
 	void validate_vocabulary() const
 	{
-		const std::vector<LinkId> ids{
+		validate_vocabulary_ids({
 		    vocabulary_.unit,
 		    vocabulary_.nil,
 		    vocabulary_.true_value,
@@ -135,16 +166,7 @@ private:
 		    vocabulary_.end_relation,
 		    vocabulary_.same_relation,
 		    vocabulary_.link_exists_relation,
-		};
-
-		std::set<LinkId> unique;
-		for (const LinkId id : ids)
-		{
-			if (!store_.contains(id))
-				throw std::invalid_argument("bootstrap vocabulary contains an unknown LinkId");
-			if (!unique.insert(id).second)
-				throw std::invalid_argument("bootstrap vocabulary identities must be distinct");
-		}
+		});
 	}
 
 	static void require_expression_subject(const ExecutionContext &context, LinkId unit)

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -296,8 +296,7 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			                          const LinkId value =
-			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
 			                          return store_.get(value).begin;
 		                          });
 
@@ -305,8 +304,7 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 1);
-			                          const LinkId value =
-			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId value = executor.execute(arguments[0], context.entity, context.frame);
 			                          return store_.get(value).end;
 		                          });
 
@@ -314,10 +312,8 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
-			                          const LinkId left =
-			                              executor.execute(arguments[0], context.entity, context.frame);
-			                          const LinkId right =
-			                              executor.execute(arguments[1], context.entity, context.frame);
+			                          const LinkId left = executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId right = executor.execute(arguments[1], context.entity, context.frame);
 			                          return left == right ? vocabulary_.true_value : vocabulary_.false_value;
 		                          });
 
@@ -325,12 +321,9 @@ private:
 		                          [this](const ExecutionContext &context, Executor &executor)
 		                          {
 			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
-			                          const LinkId begin =
-			                              executor.execute(arguments[0], context.entity, context.frame);
-			                          const LinkId end =
-			                              executor.execute(arguments[1], context.entity, context.frame);
-			                          return store_.find(begin, end) ? vocabulary_.true_value
-			                                                         : vocabulary_.false_value;
+			                          const LinkId begin = executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
+			                          return store_.find(begin, end) ? vocabulary_.true_value : vocabulary_.false_value;
 		                          });
 
 		executor_.register_native(

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -30,10 +30,10 @@ struct BootstrapVocabulary
 	LinkId call_relation;
 	LinkId binding_relation;
 	LinkId frame_relation;
-	LinkId begin_relation;
-	LinkId end_relation;
-	LinkId same_relation;
-	LinkId link_exists_relation;
+	LinkId begin_relation = invalid_link_id;
+	LinkId end_relation = invalid_link_id;
+	LinkId same_relation = invalid_link_id;
+	LinkId link_exists_relation = invalid_link_id;
 
 	static BootstrapVocabulary create(LinkStore &store)
 	{

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -30,10 +30,15 @@ struct BootstrapVocabulary
 	LinkId call_relation;
 	LinkId binding_relation;
 	LinkId frame_relation;
+	LinkId begin_relation;
+	LinkId end_relation;
+	LinkId same_relation;
+	LinkId link_exists_relation;
 
 	static BootstrapVocabulary create(LinkStore &store)
 	{
 		return BootstrapVocabulary{
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
@@ -218,6 +223,14 @@ public:
 
 	LinkId logical_or(LinkId left, LinkId right) { return binary(vocabulary_.or_relation, left, right); }
 
+	LinkId link_begin(LinkId argument) { return unary(vocabulary_.begin_relation, argument, "begin argument"); }
+
+	LinkId link_end(LinkId argument) { return unary(vocabulary_.end_relation, argument, "end argument"); }
+
+	LinkId identity_equal(LinkId left, LinkId right) { return binary(vocabulary_.same_relation, left, right); }
+
+	LinkId link_exists(LinkId begin, LinkId end) { return binary(vocabulary_.link_exists_relation, begin, end); }
+
 	LinkId conditional(LinkId condition, LinkId then_branch, LinkId else_branch)
 	{
 		require(condition, "If condition");
@@ -266,6 +279,12 @@ private:
 		require(relation, "expression relation");
 		require(object, "expression object");
 		return encode_relation_entity(store_, RelationEntity{relation, vocabulary_.unit, object});
+	}
+
+	LinkId unary(LinkId relation, LinkId argument, const char *what)
+	{
+		require(argument, what);
+		return expression(relation, encode_link_list(store_, vocabulary_.nil, {argument}));
 	}
 
 	LinkId binary(LinkId relation, LinkId left, LinkId right)

--- a/include/avm/version.h
+++ b/include/avm/version.h
@@ -6,8 +6,8 @@ namespace avm
 {
 
 inline constexpr int version_major = 1;
-inline constexpr int version_minor = 1;
+inline constexpr int version_minor = 2;
 inline constexpr int version_patch = 0;
-inline constexpr std::string_view version_string = "1.1.0";
+inline constexpr std::string_view version_string = "1.2.0";
 
 } // namespace avm

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(avm 1.1 CONFIG REQUIRED)
+find_package(avm 1.2 CONFIG REQUIRED)
 
 add_executable(avm_package_consumer main.cpp)
 target_link_libraries(avm_package_consumer PRIVATE avm::core)

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -3,9 +3,9 @@
 int main()
 {
 	static_assert(avm::version_major == 1);
-	static_assert(avm::version_minor == 1);
+	static_assert(avm::version_minor == 2);
 	static_assert(avm::version_patch == 0);
-	static_assert(avm::version_string == "1.1.0");
+	static_assert(avm::version_string == "1.2.0");
 
 	avm::InMemoryLinkStore store;
 	avm::BootstrapRuntime runtime(store);
@@ -26,6 +26,14 @@ int main()
 	if (matches.size() != 1 || matches.front().entity_id != entity ||
 	    matches.front().entity != avm::RelationEntity{relation, subject, object})
 		return 2;
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId pair = store.intern(begin, end);
+	const avm::LinkId begin_expression = builder.link_begin(builder.literal(pair));
+	const std::size_t size_before = store.size();
+	if (runtime.execute(begin_expression) != begin || store.size() != size_before)
+		return 3;
 
 	return 0;
 }

--- a/test/structural_runtime_test.cpp
+++ b/test/structural_runtime_test.cpp
@@ -1,0 +1,155 @@
+#include "avm/bootstrap_runtime.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <string_view>
+
+namespace
+{
+
+void assert_execution_does_not_mutate(avm::BootstrapRuntime &runtime, avm::InMemoryLinkStore &store,
+                                      avm::LinkId expression, avm::LinkId expected)
+{
+	const std::size_t size_before = store.size();
+	assert(runtime.execute(expression) == expected);
+	assert(store.size() == size_before);
+}
+
+void verify_begin_and_end()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId pair = store.intern(begin, end);
+
+	const avm::LinkId begin_expression = builder.link_begin(builder.literal(pair));
+	const avm::LinkId end_expression = builder.link_end(builder.literal(pair));
+
+	assert_execution_does_not_mutate(runtime, store, begin_expression, begin);
+	assert_execution_does_not_mutate(runtime, store, end_expression, end);
+}
+
+void verify_point_projections_are_self()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId point = store.create_point();
+	const avm::LinkId begin_expression = builder.link_begin(builder.literal(point));
+	const avm::LinkId end_expression = builder.link_end(builder.literal(point));
+
+	assert_execution_does_not_mutate(runtime, store, begin_expression, point);
+	assert_execution_does_not_mutate(runtime, store, end_expression, point);
+}
+
+void verify_nested_structural_composition()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId a = store.create_point();
+	const avm::LinkId b = store.create_point();
+	const avm::LinkId c = store.create_point();
+	const avm::LinkId inner = store.intern(a, b);
+	const avm::LinkId outer = store.intern(c, inner);
+
+	const avm::LinkId expression = builder.link_begin(builder.link_end(builder.literal(outer)));
+	assert_execution_does_not_mutate(runtime, store, expression, a);
+}
+
+void verify_identity_comparison()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId left = store.create_point();
+	const avm::LinkId right = store.create_point();
+
+	const avm::LinkId same = builder.identity_equal(builder.literal(left), builder.literal(left));
+	const avm::LinkId different = builder.identity_equal(builder.literal(left), builder.literal(right));
+
+	assert_execution_does_not_mutate(runtime, store, same, runtime.vocabulary().true_value);
+	assert_execution_does_not_mutate(runtime, store, different, runtime.vocabulary().false_value);
+}
+
+void verify_link_existence_is_observational()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId missing_end = store.create_point();
+	static_cast<void>(store.intern(begin, end));
+	assert(!store.find(begin, missing_end).has_value());
+
+	const avm::LinkId existing = builder.link_exists(builder.literal(begin), builder.literal(end));
+	const avm::LinkId missing = builder.link_exists(builder.literal(begin), builder.literal(missing_end));
+
+	assert_execution_does_not_mutate(runtime, store, existing, runtime.vocabulary().true_value);
+	const std::size_t size_before_missing = store.size();
+	assert(runtime.execute(missing) == runtime.vocabulary().false_value);
+	assert(store.size() == size_before_missing);
+	assert(!store.find(begin, missing_end).has_value());
+}
+
+void verify_nil_nil_exists_without_missing_sentinel_ambiguity()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId nil = runtime.vocabulary().nil;
+	assert(store.find(nil, nil) == nil);
+
+	const avm::LinkId expression = builder.link_exists(builder.literal(nil), builder.literal(nil));
+	assert_execution_does_not_mutate(runtime, store, expression, runtime.vocabulary().true_value);
+}
+
+void verify_arity_validation()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+
+	const avm::LinkId value = store.create_point();
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::LinkId first = builder.literal(value);
+	const avm::LinkId second = builder.literal(value);
+	const avm::LinkId arguments = avm::encode_link_list(store, vocabulary.nil, {first, second});
+	const avm::LinkId malformed = avm::encode_relation_entity(
+	    store, avm::RelationEntity{vocabulary.begin_relation, vocabulary.unit, arguments});
+
+	bool thrown = false;
+	try
+	{
+		static_cast<void>(runtime.execute(malformed));
+	}
+	catch (const std::runtime_error &error)
+	{
+		thrown = true;
+		assert(std::string_view(error.what()).find("argument count") != std::string_view::npos);
+	}
+	assert(thrown);
+}
+
+} // namespace
+
+int main()
+{
+	verify_begin_and_end();
+	verify_point_projections_are_self();
+	verify_nested_structural_composition();
+	verify_identity_comparison();
+	verify_link_existence_is_observational();
+	verify_nil_nil_exists_without_missing_sentinel_ambiguity();
+	verify_arity_validation();
+	return 0;
+}

--- a/test/structural_runtime_test.cpp
+++ b/test/structural_runtime_test.cpp
@@ -124,8 +124,8 @@ void verify_arity_validation()
 	const avm::LinkId first = builder.literal(value);
 	const avm::LinkId second = builder.literal(value);
 	const avm::LinkId arguments = avm::encode_link_list(store, vocabulary.nil, {first, second});
-	const avm::LinkId malformed = avm::encode_relation_entity(
-	    store, avm::RelationEntity{vocabulary.begin_relation, vocabulary.unit, arguments});
+	const avm::LinkId malformed =
+	    avm::encode_relation_entity(store, avm::RelationEntity{vocabulary.begin_relation, vocabulary.unit, arguments});
 
 	bool thrown = false;
 	try

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -209,6 +209,32 @@ void test_partially_missing_structural_vocabulary_rejected_without_mutation()
 	assert(store.size() == before);
 }
 
+void test_invalid_legacy_vocabulary_rejected_before_upgrade()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::BootstrapVocabulary invalid = runtime.vocabulary();
+	invalid.begin_relation = avm::invalid_link_id;
+	invalid.end_relation = avm::invalid_link_id;
+	invalid.same_relation = avm::invalid_link_id;
+	invalid.link_exists_relation = avm::invalid_link_id;
+	invalid.frame_relation = invalid.binding_relation;
+
+	const std::size_t before = store.size();
+	bool rejected = false;
+	try
+	{
+		avm::BootstrapRuntime restored(store, invalid);
+		static_cast<void>(restored);
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == before);
+}
+
 void test_invalid_restored_vocabulary_rejected()
 {
 	avm::InMemoryLinkStore store;
@@ -237,6 +263,7 @@ int main()
 	test_persistent_reopen_vertical_slice();
 	test_legacy_11_vocabulary_upgrades_once();
 	test_partially_missing_structural_vocabulary_rejected_without_mutation();
+	test_invalid_legacy_vocabulary_rejected_before_upgrade();
 	test_invalid_restored_vocabulary_rejected();
 	return 0;
 }

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -128,6 +128,87 @@ void test_persistent_reopen_vertical_slice()
 	}
 }
 
+void test_legacy_11_vocabulary_upgrades_once()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime current(store);
+	const avm::BootstrapVocabulary current_vocabulary = current.vocabulary();
+
+	avm::BootstrapVocabulary legacy{
+	    current_vocabulary.unit,
+	    current_vocabulary.nil,
+	    current_vocabulary.true_value,
+	    current_vocabulary.false_value,
+	    current_vocabulary.quote_relation,
+	    current_vocabulary.parameter_relation,
+	    current_vocabulary.sequence_relation,
+	    current_vocabulary.not_relation,
+	    current_vocabulary.and_relation,
+	    current_vocabulary.or_relation,
+	    current_vocabulary.if_relation,
+	    current_vocabulary.function_relation,
+	    current_vocabulary.call_relation,
+	    current_vocabulary.binding_relation,
+	    current_vocabulary.frame_relation,
+	};
+	assert(legacy.begin_relation == avm::invalid_link_id);
+	assert(legacy.end_relation == avm::invalid_link_id);
+	assert(legacy.same_relation == avm::invalid_link_id);
+	assert(legacy.link_exists_relation == avm::invalid_link_id);
+
+	const std::size_t before_upgrade = store.size();
+	avm::BootstrapRuntime upgraded(store, legacy);
+	assert(store.size() == before_upgrade + 4);
+
+	const avm::BootstrapVocabulary upgraded_vocabulary = upgraded.vocabulary();
+	assert(upgraded_vocabulary.unit == legacy.unit);
+	assert(upgraded_vocabulary.nil == legacy.nil);
+	assert(upgraded_vocabulary.true_value == legacy.true_value);
+	assert(upgraded_vocabulary.false_value == legacy.false_value);
+	assert(upgraded_vocabulary.quote_relation == legacy.quote_relation);
+	assert(upgraded_vocabulary.parameter_relation == legacy.parameter_relation);
+	assert(upgraded_vocabulary.sequence_relation == legacy.sequence_relation);
+	assert(upgraded_vocabulary.not_relation == legacy.not_relation);
+	assert(upgraded_vocabulary.and_relation == legacy.and_relation);
+	assert(upgraded_vocabulary.or_relation == legacy.or_relation);
+	assert(upgraded_vocabulary.if_relation == legacy.if_relation);
+	assert(upgraded_vocabulary.function_relation == legacy.function_relation);
+	assert(upgraded_vocabulary.call_relation == legacy.call_relation);
+	assert(upgraded_vocabulary.binding_relation == legacy.binding_relation);
+	assert(upgraded_vocabulary.frame_relation == legacy.frame_relation);
+	assert(store.contains(upgraded_vocabulary.begin_relation));
+	assert(store.contains(upgraded_vocabulary.end_relation));
+	assert(store.contains(upgraded_vocabulary.same_relation));
+	assert(store.contains(upgraded_vocabulary.link_exists_relation));
+
+	const std::size_t after_upgrade = store.size();
+	avm::BootstrapRuntime restored(store, upgraded_vocabulary);
+	static_cast<void>(restored);
+	assert(store.size() == after_upgrade);
+}
+
+void test_partially_missing_structural_vocabulary_rejected_without_mutation()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::BootstrapVocabulary partial = runtime.vocabulary();
+	partial.begin_relation = avm::invalid_link_id;
+
+	const std::size_t before = store.size();
+	bool rejected = false;
+	try
+	{
+		avm::BootstrapRuntime restored(store, partial);
+		static_cast<void>(restored);
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == before);
+}
+
 void test_invalid_restored_vocabulary_rejected()
 {
 	avm::InMemoryLinkStore store;
@@ -154,6 +235,8 @@ int main()
 {
 	test_in_memory_vertical_slice();
 	test_persistent_reopen_vertical_slice();
+	test_legacy_11_vocabulary_upgrades_once();
+	test_partially_missing_structural_vocabulary_rejected_without_mutation();
 	test_invalid_restored_vocabulary_rejected();
 	return 0;
 }


### PR DESCRIPTION
Closes #89. Parent #88.

## Public AVM 1.2 capability
Adds four link-native executable relations to the existing bootstrap vocabulary, appended after all existing identities so the previous 15 vocabulary identities preserve their order:

```text
begin_relation
end_relation
same_relation
link_exists_relation
```

`ProgramBuilder` exposes:

```cpp
link_begin(expr)
link_end(expr)
identity_equal(left,right)
link_exists(begin,end)
```

The public package version moves consistently to 1.2.0 and the installed package consumer executes `link_begin` through `<avm/avm.h>`.

## Execution semantics
Arguments are ordinary AVM expressions and are evaluated through the existing `Executor` path.

- `link_begin` -> `LinkStore::get(value).begin`
- `link_end` -> `LinkStore::get(value).end`
- `identity_equal` -> canonical bootstrap true/false by opaque LinkId equality
- `link_exists` -> canonical bootstrap true/false by observational `LinkStore::find`

No structural primitive calls `intern` or `create_point` during execution. Expression construction remains the normal link-native ProgramBuilder materialization step shared by all AVM programs.

## BootstrapVocabulary compatibility
AVM already persists/restores `BootstrapVocabulary` across `PersistentLinkStore` reopen, so the new public fields are an explicit compatibility concern rather than an incidental struct edit.

The four 1.2 fields default to `invalid_link_id`, preserving source compatibility for existing 15-field aggregate initialization. `BootstrapRuntime(store, vocabulary)` handles exactly two valid states:

1. all four structural fields are present -> normal restore, no vocabulary mutation;
2. all four are absent -> one-time 1.1→1.2 upgrade allocating exactly four new relation identities while preserving every previous vocabulary LinkId.

A partially populated structural extension is rejected before mutation. The upgraded vocabulary returned by `runtime.vocabulary()` can be persisted; all subsequent restores are read-only again.

The vertical-slice regression covers 15-field aggregate construction, exact `+4` one-time upgrade, preservation of the old 15 identities, non-mutating second restore and partial-extension rejection.

## Why link_exists is Boolean
There is deliberately no `find(begin,end) -> LinkId-or-nil` primitive. Bootstrap `nil` is itself a valid point satisfying `(nil,nil)`, so it cannot also be an unambiguous missing sentinel. Conformance explicitly proves `link_exists(nil,nil) == true`.

## Conformance
New core tests cover:
- begin/end of a non-point pair;
- begin/end of a point returning itself;
- nested structural composition `begin(end(...))`;
- same/different opaque LinkId comparison;
- existing exact pair true;
- missing exact pair false without mutation/materialization;
- `(nil,nil)` existence;
- arity validation;
- store size unchanged by every read-only execution after expression construction;
- legacy 1.1 vocabulary upgrade/reopen compatibility.

The test is wired into strict core, ASan+UBSan and portable Linux/Windows/macOS through `avm_core_tests`; package consumer covers installed AVM 1.2 public usage.

## Non-goals
No explicit pair materialization primitive is added here. `intern` remains a separate future effect gate. No query/index, persistence format, JSON/Anum semantics or string opcode dispatch changes.