### PR TITLE
AVM 1.2: add explicit canonical pair intern effect

### DIFF
--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -77,7 +77,7 @@ public:
 	{
 		if (max_call_depth_ == 0)
 			throw std::invalid_argument("maximum call depth must be greater than zero");
-		upgrade_structural_vocabulary_if_needed();
+		upgrade_vocabulary_if_needed();
 		validate_vocabulary();
 		materialize_truth_tables();
 		register_handlers();
@@ -106,20 +106,8 @@ private:
 		}
 	}
 
-	void upgrade_structural_vocabulary_if_needed()
+	void validate_legacy_vocabulary() const
 	{
-		const bool begin_missing = vocabulary_.begin_relation == invalid_link_id;
-		const bool end_missing = vocabulary_.end_relation == invalid_link_id;
-		const bool same_missing = vocabulary_.same_relation == invalid_link_id;
-		const bool exists_missing = vocabulary_.link_exists_relation == invalid_link_id;
-		const unsigned missing = static_cast<unsigned>(begin_missing) + static_cast<unsigned>(end_missing) +
-		                         static_cast<unsigned>(same_missing) + static_cast<unsigned>(exists_missing);
-
-		if (missing == 0)
-			return;
-		if (missing != 4)
-			throw std::invalid_argument("bootstrap structural vocabulary must be fully present or fully absent");
-
 		validate_vocabulary_ids({
 		    vocabulary_.unit,
 		    vocabulary_.nil,
@@ -137,11 +125,65 @@ private:
 		    vocabulary_.binding_relation,
 		    vocabulary_.frame_relation,
 		});
+	}
 
-		vocabulary_.begin_relation = store_.create_point();
-		vocabulary_.end_relation = store_.create_point();
-		vocabulary_.same_relation = store_.create_point();
-		vocabulary_.link_exists_relation = store_.create_point();
+	void validate_read_only_structural_vocabulary() const
+	{
+		validate_vocabulary_ids({
+		    vocabulary_.unit,
+		    vocabulary_.nil,
+		    vocabulary_.true_value,
+		    vocabulary_.false_value,
+		    vocabulary_.quote_relation,
+		    vocabulary_.parameter_relation,
+		    vocabulary_.sequence_relation,
+		    vocabulary_.not_relation,
+		    vocabulary_.and_relation,
+		    vocabulary_.or_relation,
+		    vocabulary_.if_relation,
+		    vocabulary_.function_relation,
+		    vocabulary_.call_relation,
+		    vocabulary_.binding_relation,
+		    vocabulary_.frame_relation,
+		    vocabulary_.begin_relation,
+		    vocabulary_.end_relation,
+		    vocabulary_.same_relation,
+		    vocabulary_.link_exists_relation,
+		});
+	}
+
+	void upgrade_vocabulary_if_needed()
+	{
+		const bool begin_missing = vocabulary_.begin_relation == invalid_link_id;
+		const bool end_missing = vocabulary_.end_relation == invalid_link_id;
+		const bool same_missing = vocabulary_.same_relation == invalid_link_id;
+		const bool exists_missing = vocabulary_.link_exists_relation == invalid_link_id;
+		const bool intern_missing = vocabulary_.intern_relation == invalid_link_id;
+		const unsigned read_only_missing = static_cast<unsigned>(begin_missing) + static_cast<unsigned>(end_missing) +
+		                                   static_cast<unsigned>(same_missing) + static_cast<unsigned>(exists_missing);
+
+		if (read_only_missing == 0 && !intern_missing)
+			return;
+
+		if (read_only_missing == 4 && intern_missing)
+		{
+			validate_legacy_vocabulary();
+			vocabulary_.begin_relation = store_.create_point();
+			vocabulary_.end_relation = store_.create_point();
+			vocabulary_.same_relation = store_.create_point();
+			vocabulary_.link_exists_relation = store_.create_point();
+			vocabulary_.intern_relation = store_.create_point();
+			return;
+		}
+
+		if (read_only_missing == 0 && intern_missing)
+		{
+			validate_read_only_structural_vocabulary();
+			vocabulary_.intern_relation = store_.create_point();
+			return;
+		}
+
+		throw std::invalid_argument("bootstrap vocabulary extension state is not a supported complete generation");
 	}
 
 	void validate_vocabulary() const
@@ -166,6 +208,7 @@ private:
 		    vocabulary_.end_relation,
 		    vocabulary_.same_relation,
 		    vocabulary_.link_exists_relation,
+		    vocabulary_.intern_relation,
 		});
 	}
 
@@ -350,6 +393,16 @@ private:
 			                              executor.execute(arguments[0], context.entity, context.frame);
 			                          const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
 			                          return store_.find(begin, end) ? vocabulary_.true_value : vocabulary_.false_value;
+		                          });
+
+		executor_.register_native(vocabulary_.intern_relation,
+		                          [this](const ExecutionContext &context, Executor &executor)
+		                          {
+			                          const std::vector<LinkId> arguments = expression_arguments(context, 2);
+			                          const LinkId begin =
+			                              executor.execute(arguments[0], context.entity, context.frame);
+			                          const LinkId end = executor.execute(arguments[1], context.entity, context.frame);
+			                          return store_.intern(begin, end);
 		                          });
 
 		executor_.register_native(

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -34,6 +34,7 @@ struct BootstrapVocabulary
 	LinkId end_relation = invalid_link_id;
 	LinkId same_relation = invalid_link_id;
 	LinkId link_exists_relation = invalid_link_id;
+	LinkId intern_relation = invalid_link_id;
 
 	static BootstrapVocabulary create(LinkStore &store)
 	{
@@ -42,7 +43,7 @@ struct BootstrapVocabulary
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
-		    store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
 		};
 	}
 };
@@ -230,6 +231,8 @@ public:
 	LinkId identity_equal(LinkId left, LinkId right) { return binary(vocabulary_.same_relation, left, right); }
 
 	LinkId link_exists(LinkId begin, LinkId end) { return binary(vocabulary_.link_exists_relation, begin, end); }
+
+	LinkId pair_intern(LinkId begin, LinkId end) { return binary(vocabulary_.intern_relation, begin, end); }
 
 	LinkId conditional(LinkId condition, LinkId then_branch, LinkId else_branch)
 	{

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -29,11 +29,22 @@ int main()
 
 	const avm::LinkId begin = store.create_point();
 	const avm::LinkId end = store.create_point();
-	const avm::LinkId pair = store.intern(begin, end);
-	const avm::LinkId begin_expression = builder.link_begin(builder.literal(pair));
-	const std::size_t size_before = store.size();
-	if (runtime.execute(begin_expression) != begin || store.size() != size_before)
+	if (store.find(begin, end).has_value())
 		return 3;
+
+	const avm::LinkId begin_literal = builder.literal(begin);
+	const avm::LinkId end_literal = builder.literal(end);
+	const avm::LinkId materialize = builder.pair_intern(begin_literal, end_literal);
+	const avm::LinkId begin_expression = builder.link_begin(materialize);
+	const std::size_t size_before = store.size();
+
+	const avm::LinkId pair = runtime.execute(materialize);
+	if (store.size() != size_before + 1 || store.find(begin, end) != pair)
+		return 4;
+
+	const std::size_t size_after = store.size();
+	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin || store.size() != size_after)
+		return 5;
 
 	return 0;
 }

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -43,7 +43,8 @@ int main()
 		return 4;
 
 	const std::size_t size_after = store.size();
-	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin || store.size() != size_after)
+	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin ||
+	    store.size() != size_after)
 		return 5;
 
 	return 0;

--- a/test/structural_runtime_test.cpp
+++ b/test/structural_runtime_test.cpp
@@ -158,12 +158,14 @@ void verify_pair_intern_of_nonpoint_self_pair_is_new_identity()
 	const avm::LinkId left = store.create_point();
 	const avm::LinkId right = store.create_point();
 	const avm::LinkId nonpoint = store.intern(left, right);
-	assert(store.get(nonpoint) != avm::Link{nonpoint, nonpoint});
+	const avm::Link nonpoint_as_self{nonpoint, nonpoint};
+	assert(store.get(nonpoint) != nonpoint_as_self);
 
 	const avm::LinkId expression = builder.pair_intern(builder.literal(nonpoint), builder.literal(nonpoint));
 	const avm::LinkId self_pair = runtime.execute(expression);
+	const avm::Link expected{nonpoint, nonpoint};
 	assert(self_pair != nonpoint);
-	assert(store.get(self_pair) == avm::Link{nonpoint, nonpoint});
+	assert(store.get(self_pair) == expected);
 	assert(store.find(nonpoint, nonpoint) == self_pair);
 }
 

--- a/test/structural_runtime_test.cpp
+++ b/test/structural_runtime_test.cpp
@@ -100,6 +100,73 @@ void verify_link_existence_is_observational()
 	assert(!store.find(begin, missing_end).has_value());
 }
 
+void verify_pair_intern_is_explicit_and_idempotent()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	assert(!store.find(begin, end).has_value());
+
+	const avm::LinkId begin_literal = builder.literal(begin);
+	const avm::LinkId end_literal = builder.literal(end);
+	const avm::LinkId exists = builder.link_exists(begin_literal, end_literal);
+	const avm::LinkId materialize = builder.pair_intern(begin_literal, end_literal);
+	const avm::LinkId projected_begin = builder.link_begin(materialize);
+	const avm::LinkId projected_end = builder.link_end(materialize);
+
+	assert_execution_does_not_mutate(runtime, store, exists, runtime.vocabulary().false_value);
+	assert(!store.find(begin, end).has_value());
+
+	const std::size_t before_materialize = store.size();
+	const avm::LinkId pair = runtime.execute(materialize);
+	assert(store.size() == before_materialize + 1);
+	assert(store.find(begin, end) == pair);
+
+	const std::size_t after_materialize = store.size();
+	assert(runtime.execute(materialize) == pair);
+	assert(store.size() == after_materialize);
+	assert_execution_does_not_mutate(runtime, store, exists, runtime.vocabulary().true_value);
+	assert_execution_does_not_mutate(runtime, store, projected_begin, begin);
+	assert_execution_does_not_mutate(runtime, store, projected_end, end);
+}
+
+void verify_pair_intern_returns_preexisting_canonical_identity()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId existing = store.intern(begin, end);
+	const avm::LinkId expression = builder.pair_intern(builder.literal(begin), builder.literal(end));
+
+	const std::size_t before = store.size();
+	assert(runtime.execute(expression) == existing);
+	assert(store.size() == before);
+}
+
+void verify_pair_intern_of_nonpoint_self_pair_is_new_identity()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId left = store.create_point();
+	const avm::LinkId right = store.create_point();
+	const avm::LinkId nonpoint = store.intern(left, right);
+	assert(store.get(nonpoint) != avm::Link{nonpoint, nonpoint});
+
+	const avm::LinkId expression = builder.pair_intern(builder.literal(nonpoint), builder.literal(nonpoint));
+	const avm::LinkId self_pair = runtime.execute(expression);
+	assert(self_pair != nonpoint);
+	assert(store.get(self_pair) == avm::Link{nonpoint, nonpoint});
+	assert(store.find(nonpoint, nonpoint) == self_pair);
+}
+
 void verify_nil_nil_exists_without_missing_sentinel_ambiguity()
 {
 	avm::InMemoryLinkStore store;
@@ -149,6 +216,9 @@ int main()
 	verify_nested_structural_composition();
 	verify_identity_comparison();
 	verify_link_existence_is_observational();
+	verify_pair_intern_is_explicit_and_idempotent();
+	verify_pair_intern_returns_preexisting_canonical_identity();
+	verify_pair_intern_of_nonpoint_self_pair_is_new_identity();
 	verify_nil_nil_exists_without_missing_sentinel_ambiguity();
 	verify_arity_validation();
 	return 0;

--- a/test/vertical_slice_test.cpp
+++ b/test/vertical_slice_test.cpp
@@ -128,6 +128,41 @@ void test_persistent_reopen_vertical_slice()
 	}
 }
 
+void test_persistent_pair_intern_effect_reopens_idempotently()
+{
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	avm::BootstrapVocabulary vocabulary{};
+	avm::LinkId pair = avm::invalid_link_id;
+	avm::LinkId expression = avm::invalid_link_id;
+
+	{
+		avm::PersistentLinkStore store(path);
+		avm::BootstrapRuntime runtime(store);
+		vocabulary = runtime.vocabulary();
+		avm::ProgramBuilder builder = runtime.builder();
+
+		const avm::LinkId begin = store.create_point();
+		const avm::LinkId end = store.create_point();
+		expression = builder.pair_intern(builder.literal(begin), builder.literal(end));
+		assert(!store.find(begin, end).has_value());
+
+		const std::size_t before = store.size();
+		pair = runtime.execute(expression);
+		assert(store.size() == before + 1);
+		assert(store.find(begin, end) == pair);
+	}
+
+	{
+		avm::PersistentLinkStore reopened(path);
+		const std::size_t before_restore = reopened.size();
+		avm::BootstrapRuntime runtime(reopened, vocabulary);
+		assert(reopened.size() == before_restore);
+		assert(runtime.execute(expression) == pair);
+		assert(reopened.size() == before_restore);
+	}
+}
+
 void test_legacy_11_vocabulary_upgrades_once()
 {
 	avm::InMemoryLinkStore store;
@@ -155,10 +190,11 @@ void test_legacy_11_vocabulary_upgrades_once()
 	assert(legacy.end_relation == avm::invalid_link_id);
 	assert(legacy.same_relation == avm::invalid_link_id);
 	assert(legacy.link_exists_relation == avm::invalid_link_id);
+	assert(legacy.intern_relation == avm::invalid_link_id);
 
 	const std::size_t before_upgrade = store.size();
 	avm::BootstrapRuntime upgraded(store, legacy);
-	assert(store.size() == before_upgrade + 4);
+	assert(store.size() == before_upgrade + 5);
 
 	const avm::BootstrapVocabulary upgraded_vocabulary = upgraded.vocabulary();
 	assert(upgraded_vocabulary.unit == legacy.unit);
@@ -180,6 +216,52 @@ void test_legacy_11_vocabulary_upgrades_once()
 	assert(store.contains(upgraded_vocabulary.end_relation));
 	assert(store.contains(upgraded_vocabulary.same_relation));
 	assert(store.contains(upgraded_vocabulary.link_exists_relation));
+	assert(store.contains(upgraded_vocabulary.intern_relation));
+
+	const std::size_t after_upgrade = store.size();
+	avm::BootstrapRuntime restored(store, upgraded_vocabulary);
+	static_cast<void>(restored);
+	assert(store.size() == after_upgrade);
+}
+
+void test_read_only_12_vocabulary_upgrades_by_one()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime current(store);
+	const avm::BootstrapVocabulary current_vocabulary = current.vocabulary();
+
+	avm::BootstrapVocabulary read_only_12{
+	    current_vocabulary.unit,
+	    current_vocabulary.nil,
+	    current_vocabulary.true_value,
+	    current_vocabulary.false_value,
+	    current_vocabulary.quote_relation,
+	    current_vocabulary.parameter_relation,
+	    current_vocabulary.sequence_relation,
+	    current_vocabulary.not_relation,
+	    current_vocabulary.and_relation,
+	    current_vocabulary.or_relation,
+	    current_vocabulary.if_relation,
+	    current_vocabulary.function_relation,
+	    current_vocabulary.call_relation,
+	    current_vocabulary.binding_relation,
+	    current_vocabulary.frame_relation,
+	    current_vocabulary.begin_relation,
+	    current_vocabulary.end_relation,
+	    current_vocabulary.same_relation,
+	    current_vocabulary.link_exists_relation,
+	};
+	assert(read_only_12.intern_relation == avm::invalid_link_id);
+
+	const std::size_t before_upgrade = store.size();
+	avm::BootstrapRuntime upgraded(store, read_only_12);
+	assert(store.size() == before_upgrade + 1);
+	const avm::BootstrapVocabulary upgraded_vocabulary = upgraded.vocabulary();
+	assert(upgraded_vocabulary.begin_relation == read_only_12.begin_relation);
+	assert(upgraded_vocabulary.end_relation == read_only_12.end_relation);
+	assert(upgraded_vocabulary.same_relation == read_only_12.same_relation);
+	assert(upgraded_vocabulary.link_exists_relation == read_only_12.link_exists_relation);
+	assert(store.contains(upgraded_vocabulary.intern_relation));
 
 	const std::size_t after_upgrade = store.size();
 	avm::BootstrapRuntime restored(store, upgraded_vocabulary);
@@ -218,7 +300,31 @@ void test_invalid_legacy_vocabulary_rejected_before_upgrade()
 	invalid.end_relation = avm::invalid_link_id;
 	invalid.same_relation = avm::invalid_link_id;
 	invalid.link_exists_relation = avm::invalid_link_id;
+	invalid.intern_relation = avm::invalid_link_id;
 	invalid.frame_relation = invalid.binding_relation;
+
+	const std::size_t before = store.size();
+	bool rejected = false;
+	try
+	{
+		avm::BootstrapRuntime restored(store, invalid);
+		static_cast<void>(restored);
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == before);
+}
+
+void test_invalid_read_only_12_vocabulary_rejected_before_upgrade()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::BootstrapVocabulary invalid = runtime.vocabulary();
+	invalid.intern_relation = avm::invalid_link_id;
+	invalid.same_relation = invalid.end_relation;
 
 	const std::size_t before = store.size();
 	bool rejected = false;
@@ -261,9 +367,12 @@ int main()
 {
 	test_in_memory_vertical_slice();
 	test_persistent_reopen_vertical_slice();
+	test_persistent_pair_intern_effect_reopens_idempotently();
 	test_legacy_11_vocabulary_upgrades_once();
+	test_read_only_12_vocabulary_upgrades_by_one();
 	test_partially_missing_structural_vocabulary_rejected_without_mutation();
 	test_invalid_legacy_vocabulary_rejected_before_upgrade();
+	test_invalid_read_only_12_vocabulary_rejected_before_upgrade();
 	test_invalid_restored_vocabulary_rejected();
 	return 0;
 }


### PR DESCRIPTION
Closes #91. Parent #88. Depends on merged #90.

## Capability
Adds one explicitly mutating link-native structural primitive:

```text
pair_intern(begin_expr, end_expr) -> canonical LinkId(begin,end)
```

`ProgramBuilder::pair_intern` builds an ordinary AVM expression. `BootstrapRuntime` evaluates both arguments through the existing `Executor` and delegates exactly once to canonical `LinkStore::intern(begin,end)`.

No new storage API, persistence format, AST, string opcode table, JSON/Anum path or secondary effect registry is introduced.

## Effect boundary
- `link_exists(a,b)` remains observational and never materializes a missing pair;
- `pair_intern(a,b)` is the explicit mutation boundary;
- missing pair -> exactly one canonical link is created;
- existing pair -> existing LinkId returned with no growth;
- repeated execution is idempotent;
- handler never calls `create_point`;
- `link_begin` / `link_end` can consume the materialized result without further mutation.

## Vocabulary generations
`intern_relation` is appended after the four read-only structural identities. Migration supports exactly three complete generations:

1. legacy 1.1 vocabulary (15 IDs) -> prevalidate old IDs, allocate exactly 5 structural relation identities;
2. read-only AVM 1.2 vocabulary from #90 (19 IDs) -> prevalidate all 19, allocate only `intern_relation` (+1);
3. current 20-ID vocabulary -> restore without mutation.

Any unsupported partial extension is rejected before allocation. Invalid legacy/read-only vocabularies are explicitly tested to leave `store.size()` unchanged.

## Conformance
Core tests cover:
- false `link_exists` before effect and no mutation;
- missing pair materialization -> `size + 1` and exact `find` hit;
- repeated effect -> same ID/no further growth;
- pre-existing pair -> same canonical ID/no growth;
- nested `link_begin/link_end(pair_intern(...))`;
- `(x,x)` for a non-point `x` creates the canonical self-pair distinct from `x`;
- persistent close/reopen retains the same materialized LinkId and repeated execution stays idempotent;
- 15-ID -> 20-ID and 19-ID -> 20-ID vocabulary upgrades;
- invalid migration states rejected before mutation.

The installed package consumer exercises `pair_intern` through `<avm/avm.h>` and verifies both first-write and idempotent/read-only behavior.

## Version
No additional version bump: #90 already established the AVM 1.2.0 development contract; this is the second gate of the same 1.2 standard-library epic.