### PR TITLE
AVM 1.2: prove structural library composition without native expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/structural_runtime_test.cpp \
+            test/structural_library_test.cpp \
             test/function_runtime_test.cpp \
             test/frame_runtime_test.cpp \
             test/deferred_definition_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
     avm_add_core_test(avm_structural_runtime_test test/structural_runtime_test.cpp structural_runtime_tests)
+    avm_add_core_test(avm_structural_library_test test/structural_library_test.cpp structural_library_tests)
     avm_add_core_test(avm_function_runtime_test test/function_runtime_test.cpp function_runtime_tests)
     avm_add_core_test(avm_frame_runtime_test test/frame_runtime_test.cpp frame_runtime_tests)
     avm_add_core_test(avm_deferred_definition_test test/deferred_definition_test.cpp deferred_definition_tests)
@@ -184,6 +185,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_program_model_test
         avm_boolean_runtime_test
         avm_structural_runtime_test
+        avm_structural_library_test
         avm_function_runtime_test
         avm_frame_runtime_test
         avm_deferred_definition_test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AVM is an experimental C++20 virtual machine built on the Relations Model and a canonical store of directed links.
 
-**Current public version: 1.1.0.**
+**Current public version: 1.2.0.**
 
 ## Semantic path
 
@@ -48,9 +48,9 @@ AVM 1.0 established and validated:
 
 The former pointer-based `rel_t` universe, JSON semantic interpreter and temporary protocol-value-only Anum bridge have been removed. Git history preserves them; AVM keeps one semantic path.
 
-## AVM 1.1 — read-only associative queries
+## AVM 1.1 — read-only associative queries — complete
 
-AVM 1.1 begins with a dependency-free Relations Model query layer:
+AVM 1.1 added a dependency-free Relations Model query layer:
 
 ```cpp
 avm::RelationQuery query{
@@ -66,7 +66,35 @@ At least one relation/subject/object field must be constrained. Queries use only
 
 Relations Model querying is structural rather than registry-based. AVM does not track a hidden list of links "created as entities"; domain restrictions must themselves be represented through links/relations.
 
+Fan-out benchmarks at 1/8/64/256 demonstrated the expected candidate-expansion cost but did not justify an additional persistent physical index without a concrete workload SLA. Extra indexes remain deferred until measured workloads require them.
+
 See [Relations Model query contract](docs/relations-query.md).
+
+## AVM 1.2 — structural standard library
+
+AVM 1.2 makes canonical dyad structure directly usable by link-native programs.
+
+The minimal native structural kernel is:
+
+```text
+link_begin(expr)       -> begin pole
+link_end(expr)         -> end pole
+identity_equal(a,b)    -> canonical Boolean
+link_exists(a,b)       -> canonical Boolean, observational
+pair_intern(a,b)       -> canonical LinkId(a,b), explicit effect
+```
+
+`link_exists` does not use `nil` as a missing sentinel because `nil` is itself a valid self-link. `pair_intern` is the explicit materialization boundary and is idempotent through `LinkStore::intern`.
+
+Operations reducible to this kernel should be ordinary AVM functions rather than new C++ native handlers. For example:
+
+```text
+is_self_link(x) = identity_equal(link_begin(x), link_end(x))
+```
+
+Function definitions, bindings and call frames remain links. A first function call may therefore materialize canonical execution-state links even when the composed function body contains only observational primitives; this is existing call-frame semantics, not a hidden library effect.
+
+See [Structural standard library](docs/structural-standard-library.md).
 
 ## Supported core library API
 
@@ -110,10 +138,10 @@ cmake -S . -B build-install \
 cmake --install build-install
 ```
 
-A consuming CMake project can require the current AVM 1.1 package:
+A consuming CMake project can require the current AVM 1.2 package:
 
 ```cmake
-find_package(avm 1.1 CONFIG REQUIRED)
+find_package(avm 1.2 CONFIG REQUIRED)
 target_link_libraries(my_program PRIVATE avm::core)
 ```
 
@@ -150,6 +178,7 @@ CI installs the package into a staging prefix and builds an external consumer on
 - [External protocol adapter contract](docs/protocol-adapter-contract.md)
 - [Anum L3→L4 bridge](docs/anum-l3-l4-bridge.md)
 - [Relations Model query contract](docs/relations-query.md)
+- [Structural standard library](docs/structural-standard-library.md)
 - [Persistent LinkStore contract](docs/persistent-link-store.md)
 - [AVM 1.x release policy](docs/release-policy.md)
 - [Project analysis](analysis.md)
@@ -157,7 +186,7 @@ CI installs the package into a staging prefix and builds an external consumer on
 
 ## Project status
 
-Architecture Foundation / AVM 1.0 gates are complete. AVM 1.1 now develops read-only associative query facilities while preserving the same canonical `LinkStore -> Relations Model -> Executor` foundation. New physical indexes are considered only after the existing-index query baselines demonstrate a measured need.
+AVM 1.0 foundation and AVM 1.1 read-only query gates are complete. AVM 1.2 provides link-native structural observation plus explicit canonical pair materialization, and is closing with proof that higher-level structural operations compose as ordinary AVM functions instead of expanding the native registry.
 
 ## Dependencies
 

--- a/docs/structural-standard-library.md
+++ b/docs/structural-standard-library.md
@@ -1,0 +1,76 @@
+# AVM 1.2 structural standard library
+
+AVM 1.2 separates the structural surface into a small native kernel and an open-ended link-native library.
+
+## Native structural kernel
+
+The bootstrap runtime owns only the primitive relations that cannot be reduced further without already having structural observation/effect semantics:
+
+```text
+link_begin(expr)       -> begin pole of evaluated LinkId
+link_end(expr)         -> end pole of evaluated LinkId
+identity_equal(a,b)    -> canonical Boolean
+link_exists(a,b)       -> canonical Boolean, observational
+pair_intern(a,b)       -> canonical LinkId(a,b), explicit effect
+```
+
+`link_begin`, `link_end`, `identity_equal` and `link_exists` do not materialize the queried structure. `pair_intern` is the explicit canonical structural mutation boundary and delegates to `LinkStore::intern`.
+
+## Derived operations are programs, not opcodes
+
+A standard-library operation that can be expressed with the existing kernel must be represented as an ordinary AVM function definition rather than as another native handler.
+
+For example:
+
+```text
+is_self_link(x) = identity_equal(link_begin(x), link_end(x))
+```
+
+and:
+
+```text
+pair_matches(x,b,e) = AND(identity_equal(link_begin(x), b),
+                          identity_equal(link_end(x), e))
+```
+
+Both bodies are ordinary Relations Model expression entities created by `ProgramBuilder`. Their function handles are normal `LinkId` values and `Executor::has_native(handle)` is false.
+
+This keeps the semantic direction:
+
+```text
+small native kernel
+    -> link-native function definitions
+    -> further functions may call those functions
+```
+
+rather than:
+
+```text
+ever-growing C++ opcode/native-handler registry
+```
+
+## Function calls and effect accounting
+
+A composed function whose body contains only observational primitives is not necessarily a zero-write operation at the physical `LinkStore` level.
+
+AVM intentionally represents function execution state as links. The existing call runtime materializes canonical binding and call-frame structures. Therefore the first execution of a particular structural call may increase the store even though the function body itself contains no structural mutation primitive.
+
+The correct distinction is:
+
+- **library semantics:** `is_self_link` and `pair_matches` contain no `pair_intern` and introduce no native handler;
+- **execution-state semantics:** the existing function machinery may intern bindings, binding lists, frame payloads and frame entities;
+- **canonical convergence:** repeating the same structurally identical call reuses those structures where their identities are the same.
+
+Replacing link-native call frames with an ephemeral C++ stack merely to label composed functions “pure” would create a second execution-state model and is intentionally rejected.
+
+## Persistence
+
+Function definitions are already link-native and therefore persist with the store. To use a composed library after reopen, a caller retains the explicit function handles together with the bootstrap vocabulary it already needs to restore the runtime.
+
+There is no hidden standard-library registry and no string-name lookup table. A handle is the identity of the function.
+
+## Extension rule
+
+Before adding any future native relation, ask whether its behavior can be expressed as a function over existing primitives.
+
+If yes, implement it as links. A new native relation is justified only when it introduces a genuinely irreducible observation/effect boundary or when measured requirements demonstrate that the composition cannot satisfy the contract without violating AVM invariants.

--- a/plan.md
+++ b/plan.md
@@ -80,15 +80,13 @@ Validated on the same public package/core contracts:
 - one documented execution path;
 - no legacy semantic path.
 
-## AVM 1.1 — associative query facilities
+## AVM 1.1 — associative query facilities — complete ✅
 
-Current epic: #83.
+Epic: #83.
 
-### Gate 9 — constrained Relations Model queries (current)
+### Gate 9 — constrained Relations Model queries ✅
 
-Child: #84.
-
-Goal: read-only query facilities over the existing Relations Model and `LinkStore` indexes, without a second storage/index universe.
+Implemented through #84/#85.
 
 Public query shape:
 
@@ -99,37 +97,106 @@ relation? / subject? / object?
 -> deterministic RelationMatch list
 ```
 
-Requirements:
+Properties:
 
 - at least one constraint;
 - no `intern` / `create_point` in queries;
 - no guessed full-store enumeration;
 - deterministic ordering/deduplication;
 - InMemory/Persistent/reopen equivalence;
-- benchmark baselines for each lookup strategy;
 - installed public package consumption.
 
-### Gate 10 — measured query/index evolution
+### Gate 10 — measured query/index evolution ✅ decision
 
-Only after Gate 9 benchmarks and real workloads show a need:
+Fan-out scaling was measured at 1/8/64/256 in #86/#87. Existing-index query cost grows with candidate expansion, but no concrete AVM workload/SLA currently justifies another physical/persistent index.
 
-- evaluate explicit LinkStore enumeration contract;
-- evaluate additional secondary/index operations;
-- preserve backend replaceability and read-only semantics;
-- require conformance across in-memory/persistent backends.
+Decision:
+
+- keep canonical `find/outgoing/incoming` as the only primitive lookup/index contract;
+- defer extra indexes until real workload evidence demonstrates a need;
+- any future extension must compare against the recorded scaling baseline and prove InMemory/Persistent conformance.
 
 No backend-specific map is promoted into semantic code merely for convenience.
 
+## AVM 1.2 — link-native structural standard library
+
+Epic: #88.
+
+### Gate 11 — read-only structural primitives ✅
+
+Implemented through #89/#90.
+
+Native observational kernel:
+
+```text
+link_begin(expr)
+link_end(expr)
+identity_equal(a,b)
+link_exists(a,b)
+```
+
+Properties:
+
+- arguments are evaluated ordinary AVM expressions;
+- handlers observe `LinkStore::get/find` only;
+- no missing-link materialization;
+- canonical Boolean results for predicates;
+- `link_exists` does not overload `nil` as a missing sentinel;
+- persisted 1.1 vocabulary can upgrade without changing older LinkIds.
+
+### Gate 12 — explicit canonical pair effect ✅
+
+Implemented through #91/#92.
+
+```text
+pair_intern(a,b) -> canonical LinkId(a,b)
+```
+
+Properties:
+
+- the handler delegates to canonical `LinkStore::intern`;
+- missing pair creates exactly one link;
+- existing/repeated materialization is idempotent;
+- no point synthesis in the effect handler;
+- vocabulary migration supports complete 15-ID, 19-ID and current 20-ID generations with prevalidation before writes;
+- persistent reopen preserves the materialized LinkId.
+
+### Gate 13 — standard-library composition (current)
+
+Child: #93.
+
+Goal: prove that higher-level structural operations are ordinary AVM functions instead of new native handlers.
+
+Initial compositions:
+
+```text
+is_self_link(x) = identity_equal(link_begin(x), link_end(x))
+
+pair_matches(x,b,e) = AND(identity_equal(link_begin(x), b),
+                          identity_equal(link_end(x), e))
+```
+
+Requirements:
+
+- function bodies are ordinary link-native expressions;
+- function handles have no native handlers;
+- composed functions may call other composed functions;
+- definitions survive persistent reopen through explicit handles;
+- effect accounting keeps existing link-native binding/call-frame materialization visible instead of hiding it in an ephemeral host-language stack;
+- no new production relation identity or storage API merely for a reducible library operation.
+
+Completion of this gate closes AVM 1.2.
+
 ## Later AVM 1.x directions
 
-After the query foundation:
+After the structural standard-library foundation:
 
-1. link-native standard library expansion;
-2. additional thin protocol/front-end adapters;
-3. debugger/REPL and observability;
-4. packaging/integration tooling;
-5. visualization/GUI;
-6. production physical backends and persistence experiments.
+1. additional thin protocol/front-end adapters;
+2. debugger/REPL and execution observability;
+3. packaging/integration tooling;
+4. visualization/GUI;
+5. production physical backends and persistence experiments;
+6. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
 
 Every extension must reuse the existing `LinkStore -> Relations Model -> Executor` architecture.
 

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -47,5 +47,19 @@ int main()
 	    store.size() != size_after)
 		return 5;
 
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId is_self_link = builder.create_function_handle();
+	const avm::LinkId parameter = builder.parameter(formal);
+	builder.define_function(is_self_link, {formal},
+	                        builder.identity_equal(builder.link_begin(parameter), builder.link_end(parameter)));
+	if (runtime.executor().has_native(is_self_link))
+		return 6;
+
+	const avm::LinkId point = store.create_point();
+	if (runtime.execute(builder.call(is_self_link, {builder.literal(point)})) != runtime.vocabulary().true_value)
+		return 7;
+	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
+		return 8;
+
 	return 0;
 }

--- a/test/structural_library_test.cpp
+++ b/test/structural_library_test.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <chrono>
 #include <filesystem>
+#include <string>
 
 namespace
 {

--- a/test/structural_library_test.cpp
+++ b/test/structural_library_test.cpp
@@ -1,0 +1,206 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/persistent_link_store.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+
+namespace
+{
+
+struct StructuralLibrary
+{
+	avm::LinkId is_self_link;
+	avm::LinkId pair_matches;
+	avm::LinkId is_self_via_pair_matches;
+};
+
+StructuralLibrary define_structural_library(avm::LinkStore &store, avm::BootstrapRuntime &runtime)
+{
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId self_x = store.create_point();
+	const avm::LinkId is_self_link = builder.create_function_handle();
+	const avm::LinkId self_parameter = builder.parameter(self_x);
+	const avm::LinkId self_body =
+	    builder.identity_equal(builder.link_begin(self_parameter), builder.link_end(self_parameter));
+	builder.define_function(is_self_link, {self_x}, self_body);
+
+	const avm::LinkId match_x = store.create_point();
+	const avm::LinkId match_begin = store.create_point();
+	const avm::LinkId match_end = store.create_point();
+	const avm::LinkId pair_matches = builder.create_function_handle();
+	const avm::LinkId begin_matches =
+	    builder.identity_equal(builder.link_begin(builder.parameter(match_x)), builder.parameter(match_begin));
+	const avm::LinkId end_matches =
+	    builder.identity_equal(builder.link_end(builder.parameter(match_x)), builder.parameter(match_end));
+	builder.define_function(pair_matches, {match_x, match_begin, match_end},
+	                        builder.logical_and(begin_matches, end_matches));
+
+	const avm::LinkId nested_x = store.create_point();
+	const avm::LinkId is_self_via_pair_matches = builder.create_function_handle();
+	const avm::LinkId nested_parameter = builder.parameter(nested_x);
+	const avm::LinkId nested_begin = builder.link_begin(nested_parameter);
+	const avm::LinkId nested_body = builder.call(pair_matches, {nested_parameter, nested_begin, nested_begin});
+	builder.define_function(is_self_via_pair_matches, {nested_x}, nested_body);
+
+	return StructuralLibrary{is_self_link, pair_matches, is_self_via_pair_matches};
+}
+
+void assert_composed_definitions_are_not_native(avm::BootstrapRuntime &runtime, const StructuralLibrary &library)
+{
+	assert(!runtime.executor().has_native(library.is_self_link));
+	assert(!runtime.executor().has_native(library.pair_matches));
+	assert(!runtime.executor().has_native(library.is_self_via_pair_matches));
+}
+
+void assert_definition_roots_use_existing_relations(const avm::LinkStore &store,
+                                                    const avm::BootstrapVocabulary &vocabulary,
+                                                    const StructuralLibrary &library)
+{
+	const auto self_definition = avm::find_function_definition(store, vocabulary, library.is_self_link);
+	const auto match_definition = avm::find_function_definition(store, vocabulary, library.pair_matches);
+	const auto nested_definition =
+	    avm::find_function_definition(store, vocabulary, library.is_self_via_pair_matches);
+	assert(self_definition.has_value());
+	assert(match_definition.has_value());
+	assert(nested_definition.has_value());
+
+	assert(avm::decode_relation_entity(store, self_definition->body).relation == vocabulary.same_relation);
+	assert(avm::decode_relation_entity(store, match_definition->body).relation == vocabulary.and_relation);
+	assert(avm::decode_relation_entity(store, nested_definition->body).relation == vocabulary.call_relation);
+}
+
+void verify_composed_structural_library_behavior()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+	const StructuralLibrary library = define_structural_library(store, runtime);
+
+	assert_composed_definitions_are_not_native(runtime, library);
+	assert_definition_roots_use_existing_relations(store, vocabulary, library);
+
+	const avm::LinkId point = store.create_point();
+	const avm::LinkId left = store.create_point();
+	const avm::LinkId right = store.create_point();
+	const avm::LinkId nonpoint = store.intern(left, right);
+	const avm::LinkId self_pair = store.intern(nonpoint, nonpoint);
+
+	const avm::LinkId point_call = builder.call(library.is_self_link, {builder.literal(point)});
+	const avm::LinkId nonpoint_call = builder.call(library.is_self_link, {builder.literal(nonpoint)});
+	const avm::LinkId self_pair_call = builder.call(library.is_self_link, {builder.literal(self_pair)});
+	assert(runtime.execute(point_call) == vocabulary.true_value);
+	assert(runtime.execute(nonpoint_call) == vocabulary.false_value);
+	assert(runtime.execute(self_pair_call) == vocabulary.true_value);
+
+	const avm::LinkId match_call = builder.call(
+	    library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(right)});
+	const avm::LinkId wrong_end_call = builder.call(
+	    library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(point)});
+	assert(runtime.execute(match_call) == vocabulary.true_value);
+	assert(runtime.execute(wrong_end_call) == vocabulary.false_value);
+
+	const avm::LinkId nested_point =
+	    builder.call(library.is_self_via_pair_matches, {builder.literal(point)});
+	const avm::LinkId nested_nonpoint =
+	    builder.call(library.is_self_via_pair_matches, {builder.literal(nonpoint)});
+	assert(runtime.execute(nested_point) == vocabulary.true_value);
+	assert(runtime.execute(nested_nonpoint) == vocabulary.false_value);
+}
+
+void verify_call_frame_effect_accounting_converges()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+	const StructuralLibrary library = define_structural_library(store, runtime);
+
+	const avm::LinkId left = store.create_point();
+	const avm::LinkId right = store.create_point();
+	const avm::LinkId fresh = store.intern(left, right);
+	const avm::LinkId call = builder.call(library.is_self_link, {builder.literal(fresh)});
+
+	const std::size_t before_size = store.size();
+	const std::size_t before_bindings = store.outgoing(vocabulary.binding_relation).size();
+	const std::size_t before_frames = store.outgoing(vocabulary.frame_relation).size();
+	assert(runtime.execute(call) == vocabulary.false_value);
+	const std::size_t after_first_size = store.size();
+	const std::size_t after_first_bindings = store.outgoing(vocabulary.binding_relation).size();
+	const std::size_t after_first_frames = store.outgoing(vocabulary.frame_relation).size();
+
+	assert(after_first_size > before_size);
+	assert(after_first_bindings > before_bindings);
+	assert(after_first_frames > before_frames);
+
+	assert(runtime.execute(call) == vocabulary.false_value);
+	assert(store.size() == after_first_size);
+	assert(store.outgoing(vocabulary.binding_relation).size() == after_first_bindings);
+	assert(store.outgoing(vocabulary.frame_relation).size() == after_first_frames);
+}
+
+std::filesystem::path temporary_path()
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() / ("avm-structural-library-" + std::to_string(nonce) + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+void verify_composed_definitions_survive_reopen()
+{
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	avm::BootstrapVocabulary vocabulary{};
+	StructuralLibrary library{};
+	avm::LinkId call = avm::invalid_link_id;
+
+	{
+		avm::PersistentLinkStore store(path);
+		avm::BootstrapRuntime runtime(store);
+		vocabulary = runtime.vocabulary();
+		library = define_structural_library(store, runtime);
+		avm::ProgramBuilder builder = runtime.builder();
+
+		const avm::LinkId left = store.create_point();
+		const avm::LinkId right = store.create_point();
+		const avm::LinkId nonpoint = store.intern(left, right);
+		call = builder.call(library.is_self_link, {builder.literal(nonpoint)});
+		assert_composed_definitions_are_not_native(runtime, library);
+		assert_definition_roots_use_existing_relations(store, vocabulary, library);
+	}
+
+	{
+		avm::PersistentLinkStore reopened(path);
+		const std::size_t before_runtime = reopened.size();
+		avm::BootstrapRuntime runtime(reopened, vocabulary);
+		assert(reopened.size() == before_runtime);
+		assert_composed_definitions_are_not_native(runtime, library);
+		assert_definition_roots_use_existing_relations(reopened, vocabulary, library);
+
+		assert(runtime.execute(call) == vocabulary.false_value);
+		const std::size_t after_first_call = reopened.size();
+		assert(runtime.execute(call) == vocabulary.false_value);
+		assert(reopened.size() == after_first_call);
+	}
+}
+
+} // namespace
+
+int main()
+{
+	verify_composed_structural_library_behavior();
+	verify_call_frame_effect_accounting_converges();
+	verify_composed_definitions_survive_reopen();
+	return 0;
+}

--- a/test/structural_library_test.cpp
+++ b/test/structural_library_test.cpp
@@ -61,8 +61,7 @@ void assert_definition_roots_use_existing_relations(const avm::LinkStore &store,
 {
 	const auto self_definition = avm::find_function_definition(store, vocabulary, library.is_self_link);
 	const auto match_definition = avm::find_function_definition(store, vocabulary, library.pair_matches);
-	const auto nested_definition =
-	    avm::find_function_definition(store, vocabulary, library.is_self_via_pair_matches);
+	const auto nested_definition = avm::find_function_definition(store, vocabulary, library.is_self_via_pair_matches);
 	assert(self_definition.has_value());
 	assert(match_definition.has_value());
 	assert(nested_definition.has_value());
@@ -96,17 +95,15 @@ void verify_composed_structural_library_behavior()
 	assert(runtime.execute(nonpoint_call) == vocabulary.false_value);
 	assert(runtime.execute(self_pair_call) == vocabulary.true_value);
 
-	const avm::LinkId match_call = builder.call(
-	    library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(right)});
-	const avm::LinkId wrong_end_call = builder.call(
-	    library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(point)});
+	const avm::LinkId match_call =
+	    builder.call(library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(right)});
+	const avm::LinkId wrong_end_call =
+	    builder.call(library.pair_matches, {builder.literal(nonpoint), builder.literal(left), builder.literal(point)});
 	assert(runtime.execute(match_call) == vocabulary.true_value);
 	assert(runtime.execute(wrong_end_call) == vocabulary.false_value);
 
-	const avm::LinkId nested_point =
-	    builder.call(library.is_self_via_pair_matches, {builder.literal(point)});
-	const avm::LinkId nested_nonpoint =
-	    builder.call(library.is_self_via_pair_matches, {builder.literal(nonpoint)});
+	const avm::LinkId nested_point = builder.call(library.is_self_via_pair_matches, {builder.literal(point)});
+	const avm::LinkId nested_nonpoint = builder.call(library.is_self_via_pair_matches, {builder.literal(nonpoint)});
 	assert(runtime.execute(nested_point) == vocabulary.true_value);
 	assert(runtime.execute(nested_nonpoint) == vocabulary.false_value);
 }


### PR DESCRIPTION
Closes #93. Parent #88. Depends on merged #92.

## Purpose
Close AVM 1.2 by proving that the structural standard library grows as ordinary link-native programs instead of adding another native relation for every derived operation.

This PR intentionally changes **no production header/source semantics**. The only code-path changes are tests/build wiring and the installed public-package consumer.

## Link-native compositions
The conformance test defines through ordinary `ProgramBuilder` APIs:

```text
is_self_link(x) = identity_equal(link_begin(x), link_end(x))

pair_matches(x,b,e) = AND(identity_equal(link_begin(x), b),
                          identity_equal(link_end(x), e))
```

and a nested composition:

```text
is_self_via_pair_matches(x)
  = pair_matches(x, link_begin(x), link_begin(x))
```

The nested form is equivalent to the self-link predicate because its second endpoint comparison succeeds iff `begin(x) == end(x)`.

## Native-registry veto
Each composed function has an ordinary function handle and definition encoded as links. Tests assert:

```cpp
runtime.executor().has_native(function_handle) == false
```

and inspect the stored definition roots:
- `is_self_link` body root uses existing `same_relation`;
- `pair_matches` body root uses existing `and_relation`;
- nested composition body root uses existing `call_relation`.

No new vocabulary identity, native handler, LinkStore method, parser path or hidden library registry is added.

## Effect accounting
This PR explicitly does **not** pretend ordinary function calls are physically read-only. Existing AVM semantics materialize bindings/call frames as links.

Tests record binding/frame candidates before a fresh composed call, prove first execution may grow those existing execution-state structures, then prove the identical repeated call converges with no further growth.

That preserves the established link-native execution-state model instead of introducing an ephemeral C++ stack merely to make derived functions appear pure.

## Persistence
Composed definitions and call expressions are persisted in `PersistentLinkStore`. After reopen using the explicit bootstrap vocabulary and function handles:
- definitions remain discoverable;
- function handles remain non-native;
- the persisted call executes correctly;
- repeating the identical call after its first reopened execution does not grow the store further.

## Installed package
The external `find_package(avm 1.2)` consumer now creates `is_self_link` using only `<avm/avm.h>` / public `ProgramBuilder`, proves its handle is not native, and executes it for a point and a non-point link.

## Documentation alignment
- README is corrected from stale 1.1.0 text to current 1.2.0 and documents AVM 1.1 completion + AVM 1.2 structural kernel;
- `docs/structural-standard-library.md` records primitive/effect/composition rules and honest call-frame effect accounting;
- roadmap marks AVM 1.1 complete and Gate 13 as the current/final AVM 1.2 gate.

If all strict/sanitizer/package/portable gates are green, merging this PR completes epic #88.