### PR TITLE
AVM 1.3: add deterministic non-controlling execution observer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,19 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce execution observer isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E 'PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num|[Aa]bit' include/avm/execution_observer.h; then
+            echo "ERROR: execution observer contract must remain backend/protocol neutral"
+            exit 1
+          fi
+          if grep -n -E 'Executor|LinkStore[[:space:]]*[&*]' include/avm/execution_observer.h; then
+            echo "ERROR: observer events must not expose mutable execution/storage control"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |
@@ -159,6 +172,7 @@ jobs:
             test/relations_model_test.cpp \
             test/relations_query_test.cpp \
             test/executor_test.cpp \
+            test/execution_observer_test.cpp \
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/structural_runtime_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 message("Configuring: ${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_PROJECT_VERSION 1.2.0)
+set(CMAKE_PROJECT_VERSION 1.3.0)
 
 project(avm
     VERSION ${CMAKE_PROJECT_VERSION}
@@ -28,6 +28,7 @@ target_include_directories(avm_core INTERFACE
 set(AVM_CORE_PUBLIC_HEADERS
     include/avm/avm.h
     include/avm/bootstrap_runtime.h
+    include/avm/execution_observer.h
     include/avm/executor.h
     include/avm/link_store.h
     include/avm/persistent_link_store.h
@@ -149,6 +150,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_relations_model_test test/relations_model_test.cpp relations_model_tests)
     avm_add_core_test(avm_relations_query_test test/relations_query_test.cpp relations_query_tests)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
+    avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
     avm_add_core_test(avm_structural_runtime_test test/structural_runtime_test.cpp structural_runtime_tests)
@@ -182,6 +184,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_relations_model_test
         avm_relations_query_test
         avm_executor_test
+        avm_execution_observer_test
         avm_program_model_test
         avm_boolean_runtime_test
         avm_structural_runtime_test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 AVM is an experimental C++20 virtual machine built on the Relations Model and a canonical store of directed links.
 
-**Current public version: 1.2.0.**
+**Current public version: 1.3.0.**
 
 ## Semantic path
 
@@ -70,7 +70,7 @@ Fan-out benchmarks at 1/8/64/256 demonstrated the expected candidate-expansion c
 
 See [Relations Model query contract](docs/relations-query.md).
 
-## AVM 1.2 — structural standard library
+## AVM 1.2 — structural standard library — complete
 
 AVM 1.2 makes canonical dyad structure directly usable by link-native programs.
 
@@ -86,7 +86,7 @@ pair_intern(a,b)       -> canonical LinkId(a,b), explicit effect
 
 `link_exists` does not use `nil` as a missing sentinel because `nil` is itself a valid self-link. `pair_intern` is the explicit materialization boundary and is idempotent through `LinkStore::intern`.
 
-Operations reducible to this kernel should be ordinary AVM functions rather than new C++ native handlers. For example:
+Operations reducible to this kernel are ordinary AVM functions rather than new C++ native handlers. For example:
 
 ```text
 is_self_link(x) = identity_equal(link_begin(x), link_end(x))
@@ -95,6 +95,16 @@ is_self_link(x) = identity_equal(link_begin(x), link_end(x))
 Function definitions, bindings and call frames remain links. A first function call may therefore materialize canonical execution-state links even when the composed function body contains only observational primitives; this is existing call-frame semantics, not a hidden library effect.
 
 See [Structural standard library](docs/structural-standard-library.md).
+
+## AVM 1.3 — execution observability
+
+AVM 1.3 begins with an optional deterministic observer attached to the existing `Executor::execute` path. It emits immutable `Enter`, `Return` and `Fail` events containing only canonical `ExecutionContext`/`LinkId` data.
+
+Observers cannot replace handlers, skip execution or substitute results. Observer exceptions are isolated from program control flow, and observation itself does not materialize links. Nested calls are observed through the same executor path, including explicit parent/frame identities.
+
+This is the boundary for future debugger/REPL tooling; no traced executor, JSON opcode trace or second program representation is introduced.
+
+See [Execution observability contract](docs/execution-observability.md).
 
 ## Supported core library API
 
@@ -138,10 +148,10 @@ cmake -S . -B build-install \
 cmake --install build-install
 ```
 
-A consuming CMake project can require the current AVM 1.2 package:
+A consuming CMake project can require the current AVM 1.3 package:
 
 ```cmake
-find_package(avm 1.2 CONFIG REQUIRED)
+find_package(avm 1.3 CONFIG REQUIRED)
 target_link_libraries(my_program PRIVATE avm::core)
 ```
 
@@ -175,6 +185,7 @@ CI installs the package into a staging prefix and builds an external consumer on
 
 - [AVM architecture contract](docs/architecture.md)
 - [Execution kernel](docs/execution-kernel.md)
+- [Execution observability contract](docs/execution-observability.md)
 - [External protocol adapter contract](docs/protocol-adapter-contract.md)
 - [Anum L3→L4 bridge](docs/anum-l3-l4-bridge.md)
 - [Relations Model query contract](docs/relations-query.md)
@@ -186,7 +197,7 @@ CI installs the package into a staging prefix and builds an external consumer on
 
 ## Project status
 
-AVM 1.0 foundation and AVM 1.1 read-only query gates are complete. AVM 1.2 provides link-native structural observation plus explicit canonical pair materialization, and is closing with proof that higher-level structural operations compose as ordinary AVM functions instead of expanding the native registry.
+AVM 1.0 foundation, AVM 1.1 read-only queries and AVM 1.2 structural standard-library gates are complete. AVM 1.3 is introducing deterministic non-controlling execution observation as the prerequisite for debugger/REPL tooling without creating a second execution path.
 
 ## Dependencies
 

--- a/docs/execution-observability.md
+++ b/docs/execution-observability.md
@@ -1,0 +1,91 @@
+# Execution observability contract
+
+AVM 1.3 adds observation to the existing execution path without adding a traced executor, debugger-specific runtime or second semantic representation.
+
+## Boundary
+
+There is still one execution path:
+
+```text
+entity LinkId
+  -> decode Relations Model entity
+  -> ExecutionContext
+  -> optional Enter observation
+  -> relation-LinkId dispatch
+  -> handler / nested Executor::execute calls
+  -> result validation
+  -> optional Return observation
+  -> result LinkId
+```
+
+If execution fails after a valid `ExecutionContext` exists, the invocation emits `Fail` and rethrows the original exception. Failures before a context can be decoded do not emit an event.
+
+## Public event model
+
+`ExecutionEvent` contains only deterministic AVM data:
+
+```text
+kind = Enter | Return | Fail
+context = {
+  entity,
+  relation,
+  subject,
+  object,
+  optional parent,
+  optional frame
+}
+optional result LinkId
+```
+
+`result` is present only for `Return`.
+
+There are deliberately no timestamps, thread IDs, pointers, textual opcode names, JSON values, Anum values or backend-specific data in the event contract.
+
+## Non-controlling observer
+
+An `ExecutionObserver` receives immutable `ExecutionEvent` values. It is not passed an `Executor`, `LinkStore`, mutable context or mutable result reference.
+
+Observer delivery is isolated inside `Executor`: exceptions thrown by `ExecutionObserver::observe` are suppressed and cannot replace the program result or program exception. This lets an external collector use ordinary C++ facilities while keeping observer failure outside semantic control flow.
+
+The observer object is caller-owned. `Executor` stores only a non-owning pointer set at construction or by `set_observer`; the caller must keep the observer alive while attached.
+
+## Event ordering
+
+Each invocation that reaches a valid context emits:
+
+```text
+Enter(context)
+  ...nested execute events...
+Return(context,result)
+```
+
+or:
+
+```text
+Enter(context)
+  ...nested execute events...
+Fail(context)
+```
+
+Nested calls are observed naturally because handlers already recurse through the same canonical `Executor::execute` method.
+
+## Determinism and execution state
+
+For the same canonical store/program/vocabulary state, an observer sees the same LinkId-based event sequence. Function calls remain link-native: bindings and call frames may be materialized by existing runtime semantics. Once those canonical structures converge, repeated identical calls produce the same event sequence and do not need a separate host-language trace stack.
+
+Observation itself never materializes links. Attaching or detaching an observer does not change `LinkStore` semantics.
+
+## Non-goals
+
+AVM 1.3 gate 1 does not provide:
+
+- breakpoints or step control;
+- handler replacement or result substitution;
+- a global trace singleton;
+- implicit trace persistence in `LinkStore`;
+- a core `std::vector` trace collector;
+- profiler timestamps;
+- JSON/Anum-specific trace events;
+- debugger UI or REPL commands.
+
+Those facilities may consume the observer boundary later, but they must not become a second execution path.

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "avm/bootstrap_runtime.h"
+#include "avm/execution_observer.h"
 #include "avm/executor.h"
 #include "avm/link_store.h"
 #include "avm/persistent_link_store.h"

--- a/include/avm/execution_observer.h
+++ b/include/avm/execution_observer.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "avm/link_store.h"
+
+#include <optional>
+
+namespace avm
+{
+
+struct ExecutionContext
+{
+	LinkId entity;
+	LinkId relation;
+	LinkId subject;
+	LinkId object;
+	std::optional<LinkId> parent;
+	std::optional<LinkId> frame;
+
+	bool operator==(const ExecutionContext &) const = default;
+};
+
+enum class ExecutionEventKind
+{
+	Enter,
+	Return,
+	Fail,
+};
+
+struct ExecutionEvent
+{
+	ExecutionEventKind kind;
+	ExecutionContext context;
+	std::optional<LinkId> result;
+
+	bool operator==(const ExecutionEvent &) const = default;
+};
+
+class ExecutionObserver
+{
+public:
+	virtual ~ExecutionObserver() = default;
+	virtual void observe(const ExecutionEvent &event) = 0;
+};
+
+} // namespace avm

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -27,8 +27,6 @@ public:
 
 	void set_observer(ExecutionObserver *observer) noexcept { observer_ = observer; }
 
-	ExecutionObserver *observer() const noexcept { return observer_; }
-
 	void register_native(LinkId relation, NativeRelationHandler handler)
 	{
 		if (!store_.contains(relation))

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "avm/execution_observer.h"
 #include "avm/relations_model.h"
 
 #include <functional>
@@ -12,27 +13,21 @@
 namespace avm
 {
 
-struct ExecutionContext
-{
-	LinkId entity;
-	LinkId relation;
-	LinkId subject;
-	LinkId object;
-	std::optional<LinkId> parent;
-	std::optional<LinkId> frame;
-};
-
 class Executor;
 using NativeRelationHandler = std::function<LinkId(const ExecutionContext &, Executor &)>;
 
 class Executor
 {
 public:
-	explicit Executor(LinkStore &store) : store_(store) {}
+	explicit Executor(LinkStore &store, ExecutionObserver *observer = nullptr) : store_(store), observer_(observer) {}
 
 	LinkStore &store() { return store_; }
 
 	const LinkStore &store() const { return store_; }
+
+	void set_observer(ExecutionObserver *observer) noexcept { observer_ = observer; }
+
+	ExecutionObserver *observer() const noexcept { return observer_; }
 
 	void register_native(LinkId relation, NativeRelationHandler handler)
 	{
@@ -58,20 +53,45 @@ public:
 		const ExecutionContext context{
 		    entity, decoded.relation, decoded.subject, decoded.object, parent, frame,
 		};
+		notify(ExecutionEvent{ExecutionEventKind::Enter, context, std::nullopt});
 
-		const auto handler = native_handlers_.find(context.relation);
-		if (handler == native_handlers_.end())
-			throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
+		try
+		{
+			const auto handler = native_handlers_.find(context.relation);
+			if (handler == native_handlers_.end())
+				throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
 
-		const LinkId result = handler->second(context, *this);
-		if (!store_.contains(result))
-			throw std::runtime_error("native relation returned an unknown LinkId");
+			const LinkId result = handler->second(context, *this);
+			if (!store_.contains(result))
+				throw std::runtime_error("native relation returned an unknown LinkId");
 
-		return result;
+			notify(ExecutionEvent{ExecutionEventKind::Return, context, result});
+			return result;
+		}
+		catch (...)
+		{
+			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt});
+			throw;
+		}
 	}
 
 private:
+	void notify(const ExecutionEvent &event) noexcept
+	{
+		if (observer_ == nullptr)
+			return;
+
+		try
+		{
+			observer_->observe(event);
+		}
+		catch (...)
+		{
+		}
+	}
+
 	LinkStore &store_;
+	ExecutionObserver *observer_ = nullptr;
 	std::map<LinkId, NativeRelationHandler> native_handlers_;
 };
 

--- a/include/avm/version.h
+++ b/include/avm/version.h
@@ -6,8 +6,8 @@ namespace avm
 {
 
 inline constexpr int version_major = 1;
-inline constexpr int version_minor = 2;
+inline constexpr int version_minor = 3;
 inline constexpr int version_patch = 0;
-inline constexpr std::string_view version_string = "1.2.0";
+inline constexpr std::string_view version_string = "1.3.0";
 
 } // namespace avm

--- a/plan.md
+++ b/plan.md
@@ -118,7 +118,7 @@ Decision:
 
 No backend-specific map is promoted into semantic code merely for convenience.
 
-## AVM 1.2 — link-native structural standard library
+## AVM 1.2 — link-native structural standard library — complete ✅
 
 Epic: #88.
 
@@ -161,13 +161,11 @@ Properties:
 - vocabulary migration supports complete 15-ID, 19-ID and current 20-ID generations with prevalidation before writes;
 - persistent reopen preserves the materialized LinkId.
 
-### Gate 13 — standard-library composition (current)
+### Gate 13 — standard-library composition ✅
 
-Child: #93.
+Implemented through #93/#94.
 
-Goal: prove that higher-level structural operations are ordinary AVM functions instead of new native handlers.
-
-Initial compositions:
+Higher-level structural operations are ordinary AVM functions instead of new native handlers:
 
 ```text
 is_self_link(x) = identity_equal(link_begin(x), link_end(x))
@@ -176,7 +174,7 @@ pair_matches(x,b,e) = AND(identity_equal(link_begin(x), b),
                           identity_equal(link_end(x), e))
 ```
 
-Requirements:
+Properties:
 
 - function bodies are ordinary link-native expressions;
 - function handles have no native handlers;
@@ -185,18 +183,54 @@ Requirements:
 - effect accounting keeps existing link-native binding/call-frame materialization visible instead of hiding it in an ephemeral host-language stack;
 - no new production relation identity or storage API merely for a reducible library operation.
 
-Completion of this gate closes AVM 1.2.
+## AVM 1.3 — execution observability and debugger boundary
+
+Epic: #95.
+
+### Gate 14 — deterministic non-controlling execution observer (current)
+
+Child: #96.
+
+Goal: make the canonical `Executor::execute` path observable without turning tracing/debugging into a second execution path or control channel.
+
+Initial event model:
+
+```text
+Enter(ExecutionContext)
+Return(ExecutionContext, result LinkId)
+Fail(ExecutionContext)
+```
+
+Requirements:
+
+- events contain canonical LinkId/context data only;
+- no timestamps, host pointers, textual opcode names, JSON/Anum or backend data in the semantic event contract;
+- observer receives no mutable `Executor`, `LinkStore`, context or result reference;
+- observer exceptions cannot replace program success/failure;
+- nested calls are observed through the same `Executor::execute` recursion;
+- observer presence/absence does not change program result or store effects;
+- pre-context failures emit no context event;
+- installed package consumer validates the observer API on Linux/Windows/macOS;
+- strict warnings, ASan+UBSan and portable matrix remain green.
+
+### Later AVM 1.3 gates
+
+After Gate 14 is stable:
+
+1. failure/unwind trace hardening and explicit diagnostics policy;
+2. reusable collector/tooling layer outside semantic state;
+3. InMemory/Persistent reopen trace equivalence;
+4. debugger/REPL consumer built on observation rather than a traced executor fork.
 
 ## Later AVM 1.x directions
 
-After the structural standard-library foundation:
+After the observability boundary:
 
 1. additional thin protocol/front-end adapters;
-2. debugger/REPL and execution observability;
-3. packaging/integration tooling;
-4. visualization/GUI;
-5. production physical backends and persistence experiments;
-6. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
+2. packaging/integration tooling;
+3. visualization/GUI;
+4. production physical backends and persistence experiments;
+5. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
 
 Every extension must reuse the existing `LinkStore -> Relations Model -> Executor` architecture.
 

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -49,15 +49,14 @@ void verify_success_events_and_detach()
 	assert(store.size() == size_before);
 	assert(observer.events.size() == 2);
 	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
-	assert(observer.events[0].context == avm::ExecutionContext{entity, relation, subject, object, std::nullopt,
-	                                                           std::nullopt});
+	const avm::ExecutionContext expected_context{entity, relation, subject, object, std::nullopt, std::nullopt};
+	assert(observer.events[0].context == expected_context);
 	assert(!observer.events[0].result.has_value());
 	assert(observer.events[1].kind == avm::ExecutionEventKind::Return);
 	assert(observer.events[1].context == observer.events[0].context);
 	assert(observer.events[1].result == object);
 
 	executor.set_observer(nullptr);
-	assert(executor.observer() == nullptr);
 	assert(executor.execute(entity) == object);
 	assert(store.size() == size_before);
 	assert(observer.events.size() == 2);
@@ -161,6 +160,7 @@ void verify_failure_event_preserves_original_exception()
 	assert(observer.events.size() == 2);
 	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
 	assert(observer.events[1].kind == avm::ExecutionEventKind::Fail);
+	assert(observer.events[1].context == observer.events[0].context);
 	assert(!observer.events[1].result.has_value());
 }
 

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -181,6 +181,33 @@ void verify_observer_failure_cannot_control_execution()
 	assert(observer.calls == 2);
 }
 
+void verify_observer_failure_cannot_replace_program_failure()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	ThrowingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation, [](const avm::ExecutionContext &, avm::Executor &) -> avm::LinkId
+	                         { throw std::logic_error("program failure"); });
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::logic_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()) == "program failure");
+	}
+	assert(rejected);
+	assert(observer.calls == 2);
+}
+
 void verify_pre_context_failure_emits_no_event()
 {
 	avm::InMemoryLinkStore store;
@@ -209,6 +236,7 @@ int main()
 	verify_function_call_trace_converges_with_link_native_frame();
 	verify_failure_event_preserves_original_exception();
 	verify_observer_failure_cannot_control_execution();
+	verify_observer_failure_cannot_replace_program_failure();
 	verify_pre_context_failure_emits_no_event();
 	return 0;
 }

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -1,0 +1,214 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/executor.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+class RecordingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override { events.push_back(event); }
+
+	void clear() { events.clear(); }
+
+	std::vector<avm::ExecutionEvent> events;
+};
+
+class ThrowingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &) override
+	{
+		++calls;
+		throw std::runtime_error("observer failure");
+	}
+
+	std::size_t calls = 0;
+};
+
+void verify_success_events_and_detach()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &) { return context.object; });
+
+	const std::size_t size_before = store.size();
+	assert(executor.execute(entity) == object);
+	assert(store.size() == size_before);
+	assert(observer.events.size() == 2);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert(observer.events[0].context == avm::ExecutionContext{entity, relation, subject, object, std::nullopt,
+	                                                           std::nullopt});
+	assert(!observer.events[0].result.has_value());
+	assert(observer.events[1].kind == avm::ExecutionEventKind::Return);
+	assert(observer.events[1].context == observer.events[0].context);
+	assert(observer.events[1].result == object);
+
+	executor.set_observer(nullptr);
+	assert(executor.observer() == nullptr);
+	assert(executor.execute(entity) == object);
+	assert(store.size() == size_before);
+	assert(observer.events.size() == 2);
+}
+
+void verify_nested_event_order_is_deterministic()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+
+	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
+	const avm::LinkId negated = builder.logical_not(false_literal);
+	const avm::LinkId root = builder.logical_and(true_literal, negated);
+
+	RecordingObserver observer;
+	runtime.executor().set_observer(&observer);
+	const std::size_t size_before = store.size();
+	assert(runtime.execute(root) == vocabulary.true_value);
+	assert(store.size() == size_before);
+
+	const std::vector<avm::ExecutionEvent> first = observer.events;
+	assert(first.size() == 8);
+	assert(first[0].kind == avm::ExecutionEventKind::Enter && first[0].context.entity == root);
+	assert(first[1].kind == avm::ExecutionEventKind::Enter && first[1].context.entity == true_literal);
+	assert(first[2].kind == avm::ExecutionEventKind::Return && first[2].context.entity == true_literal);
+	assert(first[3].kind == avm::ExecutionEventKind::Enter && first[3].context.entity == negated);
+	assert(first[4].kind == avm::ExecutionEventKind::Enter && first[4].context.entity == false_literal);
+	assert(first[5].kind == avm::ExecutionEventKind::Return && first[5].context.entity == false_literal);
+	assert(first[6].kind == avm::ExecutionEventKind::Return && first[6].context.entity == negated);
+	assert(first[7].kind == avm::ExecutionEventKind::Return && first[7].context.entity == root);
+	assert(first[1].context.parent == root);
+	assert(first[3].context.parent == root);
+	assert(first[4].context.parent == negated);
+
+	observer.clear();
+	assert(runtime.execute(root) == vocabulary.true_value);
+	assert(store.size() == size_before);
+	assert(observer.events == first);
+}
+
+void verify_function_call_trace_converges_with_link_native_frame()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId handle = builder.create_function_handle();
+	builder.define_function(handle, {formal}, builder.parameter(formal));
+	const avm::LinkId call = builder.call(handle, {builder.literal(vocabulary.true_value)});
+
+	RecordingObserver observer;
+	runtime.executor().set_observer(&observer);
+	assert(runtime.execute(call) == vocabulary.true_value);
+	const std::size_t after_first = store.size();
+	const std::vector<avm::ExecutionEvent> first = observer.events;
+	assert(!first.empty());
+
+	bool saw_frame = false;
+	for (const avm::ExecutionEvent &event : first)
+	{
+		if (event.context.frame.has_value())
+			saw_frame = true;
+	}
+	assert(saw_frame);
+
+	observer.clear();
+	assert(runtime.execute(call) == vocabulary.true_value);
+	assert(store.size() == after_first);
+	assert(observer.events == first);
+}
+
+void verify_failure_event_preserves_original_exception()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation, [](const avm::ExecutionContext &, avm::Executor &) -> avm::LinkId
+	                         { throw std::logic_error("program failure"); });
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::logic_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()) == "program failure");
+	}
+	assert(rejected);
+	assert(observer.events.size() == 2);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert(observer.events[1].kind == avm::ExecutionEventKind::Fail);
+	assert(!observer.events[1].result.has_value());
+}
+
+void verify_observer_failure_cannot_control_execution()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	ThrowingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &) { return context.object; });
+
+	assert(executor.execute(entity) == object);
+	assert(observer.calls == 2);
+}
+
+void verify_pre_context_failure_emits_no_event()
+{
+	avm::InMemoryLinkStore store;
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(999999));
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(observer.events.empty());
+}
+
+} // namespace
+
+int main()
+{
+	verify_success_events_and_detach();
+	verify_nested_event_order_is_deterministic();
+	verify_function_call_trace_converges_with_link_native_frame();
+	verify_failure_event_preserves_original_exception();
+	verify_observer_failure_cannot_control_execution();
+	verify_pre_context_failure_emits_no_event();
+	return 0;
+}

--- a/test/package_consumer/CMakeLists.txt
+++ b/test/package_consumer/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_package(avm 1.2 CONFIG REQUIRED)
+find_package(avm 1.3 CONFIG REQUIRED)
 
 add_executable(avm_package_consumer main.cpp)
 target_link_libraries(avm_package_consumer PRIVATE avm::core)

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -1,20 +1,48 @@
 #include <avm/avm.h>
 
+#include <array>
+#include <cstddef>
+
+namespace
+{
+
+class FixedObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override
+	{
+		if (count < events.size())
+			events[count++] = event;
+	}
+
+	std::array<avm::ExecutionEvent, 4> events{};
+	std::size_t count = 0;
+};
+
+} // namespace
+
 int main()
 {
 	static_assert(avm::version_major == 1);
-	static_assert(avm::version_minor == 2);
+	static_assert(avm::version_minor == 3);
 	static_assert(avm::version_patch == 0);
-	static_assert(avm::version_string == "1.2.0");
+	static_assert(avm::version_string == "1.3.0");
 
 	avm::InMemoryLinkStore store;
 	avm::BootstrapRuntime runtime(store);
 	avm::ProgramBuilder builder = runtime.builder();
 
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
+	FixedObserver observer;
+	runtime.executor().set_observer(&observer);
 	const avm::LinkId result = runtime.execute(expression);
 	if (result != runtime.vocabulary().true_value)
 		return 1;
+	if (observer.count != 4 || observer.events[0].kind != avm::ExecutionEventKind::Enter ||
+	    observer.events[0].context.entity != expression || observer.events[3].kind != avm::ExecutionEventKind::Return ||
+	    observer.events[3].context.entity != expression || observer.events[3].result != result)
+		return 2;
+	runtime.executor().set_observer(nullptr);
 
 	const avm::LinkId relation = store.create_point();
 	const avm::LinkId subject = store.create_point();
@@ -25,12 +53,12 @@ int main()
 	    avm::query_relation_entities(store, {.relation = relation, .subject = subject, .object = object});
 	if (matches.size() != 1 || matches.front().entity_id != entity ||
 	    matches.front().entity != avm::RelationEntity{relation, subject, object})
-		return 2;
+		return 3;
 
 	const avm::LinkId begin = store.create_point();
 	const avm::LinkId end = store.create_point();
 	if (store.find(begin, end).has_value())
-		return 3;
+		return 4;
 
 	const avm::LinkId begin_literal = builder.literal(begin);
 	const avm::LinkId end_literal = builder.literal(end);
@@ -40,12 +68,12 @@ int main()
 
 	const avm::LinkId pair = runtime.execute(materialize);
 	if (store.size() != size_before + 1 || store.find(begin, end) != pair)
-		return 4;
+		return 5;
 
 	const std::size_t size_after = store.size();
 	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin ||
 	    store.size() != size_after)
-		return 5;
+		return 6;
 
 	const avm::LinkId formal = store.create_point();
 	const avm::LinkId is_self_link = builder.create_function_handle();
@@ -53,13 +81,13 @@ int main()
 	builder.define_function(is_self_link, {formal},
 	                        builder.identity_equal(builder.link_begin(parameter), builder.link_end(parameter)));
 	if (runtime.executor().has_native(is_self_link))
-		return 6;
+		return 7;
 
 	const avm::LinkId point = store.create_point();
 	if (runtime.execute(builder.call(is_self_link, {builder.literal(point)})) != runtime.vocabulary().true_value)
-		return 7;
-	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
 		return 8;
+	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
+		return 9;
 
 	return 0;
 }


### PR DESCRIPTION
Closes #96. Parent #95.

## Public AVM 1.3 capability
Adds an optional deterministic observer to the existing canonical `Executor::execute` path. There is no traced executor fork, debugger runtime or second semantic representation.

Public core types:

```text
ExecutionEventKind = Enter | Return | Fail
ExecutionEvent = { kind, ExecutionContext, optional result LinkId }
ExecutionObserver::observe(const ExecutionEvent&)
Executor::set_observer(ExecutionObserver*)
```

The package version is advanced consistently to AVM 1.3.0 and `execution_observer.h` is part of the installed dependency-free core surface.

## Event semantics
For every invocation that reaches a valid decoded `ExecutionContext`:
- `Enter` is emitted before relation dispatch/handler execution;
- `Return` is emitted only after the returned LinkId is validated;
- `Fail` is emitted on any post-context execution/result-validation failure and the original exception is rethrown unchanged;
- failures before a valid context exists emit no context event;
- nested calls are observed naturally because they recurse through the same `Executor::execute` method.

Events contain canonical LinkIds/context only. No timestamps, host pointers, thread IDs, textual opcodes, JSON, Anum or backend-specific data are semantic trace fields.

## Non-controlling isolation
Observers receive immutable event data only: no mutable `Executor`, `LinkStore`, context or result reference.

Observer delivery is wrapped in an internal `noexcept` barrier. Exceptions thrown by an observer are suppressed and cannot replace either a successful program result or the original program failure. Tests explicitly cover both cases.

The observer is caller-owned and attached through a non-owning pointer; no global trace singleton or hidden semantic state is introduced.

## Determinism / link-native execution state
Conformance covers a nested `AND(true, NOT(false))` trace and exact repeated event equality. Function-call tracing observes the existing link-native frame identity; after canonical binding/frame convergence, an identical call produces the same event sequence without further store growth.

Observation itself does not materialize links and attach/detach does not change execution results or store state.

## Conformance
New core tests cover:
- successful Enter/Return context/result data;
- observer detach;
- deterministic nested event ordering and parent identities;
- link-native function frame observation and repeated-call convergence;
- Fail event with original exception type/message preserved;
- throwing observer cannot control successful execution;
- throwing observer cannot replace program failure;
- pre-context invalid LinkId emits no event.

## Package / CI
- public installed package consumer requires AVM 1.3 and records `NOT(false)` events using only `<avm/avm.h>`;
- quality gate rejects backend/protocol coupling and mutable execution/storage references in the observer contract;
- observer test is part of core strict, ASan+UBSan and portable Linux/Windows/macOS test aggregates;
- README, roadmap and `docs/execution-observability.md` document the boundary.

## Vetoes
- no breakpoint/skip/replace-result API;
- no string opcode trace semantics;
- no implicit LinkStore trace persistence;
- no core collector/global singleton;
- no JSON/Anum/backend dependency;
- no separate traced executor path.