### PR TITLE
AVM 1.3: classify deterministic execution failure phases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,10 @@ jobs:
             echo "ERROR: observer events must not expose mutable execution/storage control"
             exit 1
           fi
+          if grep -n -E 'exception_ptr|std::exception|std::string|type_info|typeid[[:space:]]*\(' include/avm/execution_observer.h; then
+            echo "ERROR: deterministic observer events must not embed host exception diagnostics"
+            exit 1
+          fi
 
       - name: Verify public version contract
         shell: bash

--- a/docs/execution-observability.md
+++ b/docs/execution-observability.md
@@ -35,9 +35,18 @@ context = {
   optional frame
 }
 optional result LinkId
+optional failure phase
 ```
 
-`result` is present only for `Return`.
+`result` is present only for `Return`. `failure_phase` is present only for `Fail` and uses the finite AVM-owned taxonomy:
+
+```text
+Dispatch          — no native handler exists for the decoded relation
+Handler           — the selected handler throws
+ResultValidation  — the handler returns a LinkId that is absent from LinkStore
+```
+
+The phase says where canonical execution failed. It does not encode the exception message, C++ type, backend error or protocol-specific diagnostic.
 
 There are deliberately no timestamps, thread IDs, pointers, textual opcode names, JSON values, Anum values or backend-specific data in the event contract.
 
@@ -45,11 +54,11 @@ There are deliberately no timestamps, thread IDs, pointers, textual opcode names
 
 An `ExecutionObserver` receives immutable `ExecutionEvent` values. It is not passed an `Executor`, `LinkStore`, mutable context or mutable result reference.
 
-Observer delivery is isolated inside `Executor`: exceptions thrown by `ExecutionObserver::observe` are suppressed and cannot replace the program result or program exception. This lets an external collector use ordinary C++ facilities while keeping observer failure outside semantic control flow.
+Observer delivery is isolated inside `Executor`: exceptions thrown by `ExecutionObserver::observe` are suppressed and cannot replace the program result or program exception. This applies to successful return and to every failure phase. An external collector may therefore use ordinary C++ facilities without becoming semantic control flow.
 
 The observer object is caller-owned. `Executor` stores only a non-owning pointer set at construction or by `set_observer`; the caller must keep the observer alive while attached.
 
-## Event ordering
+## Event ordering and unwind
 
 Each invocation that reaches a valid context emits:
 
@@ -64,20 +73,35 @@ or:
 ```text
 Enter(context)
   ...nested execute events...
-Fail(context)
+Fail(context,phase)
 ```
 
-Nested calls are observed naturally because handlers already recurse through the same canonical `Executor::execute` method.
+Nested calls are observed naturally because handlers already recurse through the same canonical `Executor::execute` method. Failure unwind therefore remains stack-shaped without a second trace stack. If a child handler throws while executing inside a parent handler, the event order is:
+
+```text
+Enter(parent)
+Enter(child)
+Fail(child, Handler)
+Fail(parent, Handler)
+```
+
+The original child exception continues to propagate unchanged.
 
 ## Determinism and execution state
 
-For the same canonical store/program/vocabulary state, an observer sees the same LinkId-based event sequence. Function calls remain link-native: bindings and call frames may be materialized by existing runtime semantics. Once those canonical structures converge, repeated identical calls produce the same event sequence and do not need a separate host-language trace stack.
+For the same canonical store/program/vocabulary state, an observer sees the same LinkId-based event sequence and the same AVM failure phases. Function calls remain link-native: bindings and call frames may be materialized by existing runtime semantics. Once those canonical structures converge, repeated identical calls produce the same event sequence and do not need a separate host-language trace stack.
 
 Observation itself never materializes links. Attaching or detaching an observer does not change `LinkStore` semantics.
 
+## Diagnostics policy
+
+The deterministic trace contract intentionally stops at AVM-owned failure phase. Human-readable exception text remains runtime diagnostic information, not stable event identity. C++ exception type names, `std::exception_ptr`, stack addresses and backend/protocol errors are not stored in `ExecutionEvent`.
+
+A later debugger/REPL layer may display the exception it catches alongside the deterministic trace, but it must not reinterpret that host diagnostic as canonical AVM semantics.
+
 ## Non-goals
 
-AVM 1.3 gate 1 does not provide:
+AVM 1.3 observability does not provide:
 
 - breakpoints or step control;
 - handler replacement or result substitution;
@@ -85,6 +109,7 @@ AVM 1.3 gate 1 does not provide:
 - implicit trace persistence in `LinkStore`;
 - a core `std::vector` trace collector;
 - profiler timestamps;
+- exception objects or exception strings inside deterministic events;
 - JSON/Anum-specific trace events;
 - debugger UI or REPL commands.
 

--- a/include/avm/execution_observer.h
+++ b/include/avm/execution_observer.h
@@ -26,11 +26,19 @@ enum class ExecutionEventKind
 	Fail,
 };
 
+enum class ExecutionFailurePhase
+{
+	Dispatch,
+	Handler,
+	ResultValidation,
+};
+
 struct ExecutionEvent
 {
 	ExecutionEventKind kind;
 	ExecutionContext context;
 	std::optional<LinkId> result;
+	std::optional<ExecutionFailurePhase> failure_phase = std::nullopt;
 
 	bool operator==(const ExecutionEvent &) const = default;
 };

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -73,9 +73,8 @@ public:
 
 		if (!store_.contains(result))
 		{
-			notify(ExecutionEvent{
-			    ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::ResultValidation,
-			});
+			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt,
+			                      ExecutionFailurePhase::ResultValidation});
 			throw std::runtime_error("native relation returned an unknown LinkId");
 		}
 

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -53,24 +53,33 @@ public:
 		};
 		notify(ExecutionEvent{ExecutionEventKind::Enter, context, std::nullopt});
 
+		const auto handler = native_handlers_.find(context.relation);
+		if (handler == native_handlers_.end())
+		{
+			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::Dispatch});
+			throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
+		}
+
+		LinkId result = invalid_link_id;
 		try
 		{
-			const auto handler = native_handlers_.find(context.relation);
-			if (handler == native_handlers_.end())
-				throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
-
-			const LinkId result = handler->second(context, *this);
-			if (!store_.contains(result))
-				throw std::runtime_error("native relation returned an unknown LinkId");
-
-			notify(ExecutionEvent{ExecutionEventKind::Return, context, result});
-			return result;
+			result = handler->second(context, *this);
 		}
 		catch (...)
 		{
-			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt});
+			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::Handler});
 			throw;
 		}
+
+		if (!store_.contains(result))
+		{
+			notify(
+			    ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::ResultValidation});
+			throw std::runtime_error("native relation returned an unknown LinkId");
+		}
+
+		notify(ExecutionEvent{ExecutionEventKind::Return, context, result});
+		return result;
 	}
 
 private:

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -73,8 +73,9 @@ public:
 
 		if (!store_.contains(result))
 		{
-			notify(
-			    ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::ResultValidation});
+			notify(ExecutionEvent{
+			    ExecutionEventKind::Fail, context, std::nullopt, ExecutionFailurePhase::ResultValidation,
+			});
 			throw std::runtime_error("native relation returned an unknown LinkId");
 		}
 

--- a/plan.md
+++ b/plan.md
@@ -187,13 +187,11 @@ Properties:
 
 Epic: #95.
 
-### Gate 14 — deterministic non-controlling execution observer (current)
+### Gate 14 — deterministic non-controlling execution observer ✅
 
-Child: #96.
+Implemented through #96/#97.
 
-Goal: make the canonical `Executor::execute` path observable without turning tracing/debugging into a second execution path or control channel.
-
-Initial event model:
+Public event model:
 
 ```text
 Enter(ExecutionContext)
@@ -201,26 +199,48 @@ Return(ExecutionContext, result LinkId)
 Fail(ExecutionContext)
 ```
 
-Requirements:
+Properties:
 
-- events contain canonical LinkId/context data only;
-- no timestamps, host pointers, textual opcode names, JSON/Anum or backend data in the semantic event contract;
+- canonical LinkId/context data only;
+- no timestamps, host pointers, textual opcode names, JSON/Anum or backend data;
 - observer receives no mutable `Executor`, `LinkStore`, context or result reference;
 - observer exceptions cannot replace program success/failure;
 - nested calls are observed through the same `Executor::execute` recursion;
 - observer presence/absence does not change program result or store effects;
 - pre-context failures emit no context event;
-- installed package consumer validates the observer API on Linux/Windows/macOS;
-- strict warnings, ASan+UBSan and portable matrix remain green.
+- installed package consumer validates the API on Linux/Windows/macOS;
+- strict warnings, ASan+UBSan and portable matrix are green.
+
+### Gate 15 — deterministic failure phase and unwind observation (current)
+
+Child: #98.
+
+Extend `Fail` with a finite AVM-owned phase taxonomy:
+
+```text
+Dispatch
+Handler
+ResultValidation
+```
+
+Requirements:
+
+- phase identifies the canonical execution boundary that failed, not exception text/type;
+- no `std::exception_ptr`, host exception object or backend/protocol diagnostic in `ExecutionEvent`;
+- unknown relation, throwing handler and invalid returned LinkId are distinguishable;
+- nested failure is observed through ordinary stack-shaped `Executor::execute` events;
+- original exception type/message behavior remains unchanged;
+- observer exceptions remain suppressed for every failure phase;
+- repeated failure against unchanged state produces identical events;
+- observation does not materialize links.
 
 ### Later AVM 1.3 gates
 
-After Gate 14 is stable:
+After Gate 15 is stable:
 
-1. failure/unwind trace hardening and explicit diagnostics policy;
-2. reusable collector/tooling layer outside semantic state;
-3. InMemory/Persistent reopen trace equivalence;
-4. debugger/REPL consumer built on observation rather than a traced executor fork.
+1. reusable collector/tooling layer outside semantic state;
+2. InMemory/Persistent reopen trace equivalence;
+3. debugger/REPL consumer built on observation rather than a traced executor fork.
 
 ## Later AVM 1.x directions
 

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -264,9 +264,9 @@ void verify_nested_unwind_is_stack_shaped()
 	avm::Executor executor(store, &observer);
 	executor.register_native(child_relation, [](const avm::ExecutionContext &, avm::Executor &) -> avm::LinkId
 	                         { throw std::logic_error("child failure"); });
-	executor.register_native(parent_relation,
-	                         [](const avm::ExecutionContext &context, avm::Executor &nested)
-	                         { return nested.execute(context.object, context.entity, context.frame); });
+	executor.register_native(
+	    parent_relation, [](const avm::ExecutionContext &context, avm::Executor &nested)
+	    { return nested.execute(context.object, context.entity, context.frame); });
 
 	const std::size_t size_before = store.size();
 	bool rejected = false;

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -31,6 +31,14 @@ public:
 	std::size_t calls = 0;
 };
 
+void assert_failure_event(const avm::ExecutionEvent &event, avm::LinkId entity, avm::ExecutionFailurePhase phase)
+{
+	assert(event.kind == avm::ExecutionEventKind::Fail);
+	assert(event.context.entity == entity);
+	assert(!event.result.has_value());
+	assert(event.failure_phase == phase);
+}
+
 void verify_success_events_and_detach()
 {
 	avm::InMemoryLinkStore store;
@@ -52,9 +60,11 @@ void verify_success_events_and_detach()
 	const avm::ExecutionContext expected_context{entity, relation, subject, object, std::nullopt, std::nullopt};
 	assert(observer.events[0].context == expected_context);
 	assert(!observer.events[0].result.has_value());
+	assert(!observer.events[0].failure_phase.has_value());
 	assert(observer.events[1].kind == avm::ExecutionEventKind::Return);
 	assert(observer.events[1].context == observer.events[0].context);
 	assert(observer.events[1].result == object);
+	assert(!observer.events[1].failure_phase.has_value());
 
 	executor.set_observer(nullptr);
 	assert(executor.execute(entity) == object);
@@ -93,6 +103,9 @@ void verify_nested_event_order_is_deterministic()
 	assert(first[1].context.parent == root);
 	assert(first[3].context.parent == root);
 	assert(first[4].context.parent == negated);
+
+	for (const avm::ExecutionEvent &event : first)
+		assert(!event.failure_phase.has_value());
 
 	observer.clear();
 	assert(runtime.execute(root) == vocabulary.true_value);
@@ -133,7 +146,50 @@ void verify_function_call_trace_converges_with_link_native_frame()
 	assert(observer.events == first);
 }
 
-void verify_failure_event_preserves_original_exception()
+void verify_dispatch_failure_phase()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	const std::size_t size_before = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()).find("unknown relation") != std::string::npos);
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(observer.events.size() == 2);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert_failure_event(observer.events[1], entity, avm::ExecutionFailurePhase::Dispatch);
+
+	const std::vector<avm::ExecutionEvent> first = observer.events;
+	observer.clear();
+	rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(observer.events == first);
+}
+
+void verify_handler_failure_phase_preserves_original_exception()
 {
 	avm::InMemoryLinkStore store;
 	const avm::LinkId relation = store.create_point();
@@ -159,12 +215,96 @@ void verify_failure_event_preserves_original_exception()
 	assert(rejected);
 	assert(observer.events.size() == 2);
 	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
-	assert(observer.events[1].kind == avm::ExecutionEventKind::Fail);
+	assert_failure_event(observer.events[1], entity, avm::ExecutionFailurePhase::Handler);
 	assert(observer.events[1].context == observer.events[0].context);
-	assert(!observer.events[1].result.has_value());
 }
 
-void verify_observer_failure_cannot_control_execution()
+void verify_result_validation_failure_phase()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation,
+	                         [](const avm::ExecutionContext &, avm::Executor &) { return avm::LinkId{999999}; });
+
+	const std::size_t size_before = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()).find("unknown LinkId") != std::string::npos);
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(observer.events.size() == 2);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert_failure_event(observer.events[1], entity, avm::ExecutionFailurePhase::ResultValidation);
+}
+
+void verify_nested_unwind_is_stack_shaped()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId parent_relation = store.create_point();
+	const avm::LinkId child_relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId child = avm::encode_relation_entity(store, {child_relation, subject, object});
+	const avm::LinkId parent = avm::encode_relation_entity(store, {parent_relation, subject, child});
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(child_relation, [](const avm::ExecutionContext &, avm::Executor &) -> avm::LinkId
+	                         { throw std::logic_error("child failure"); });
+	executor.register_native(parent_relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &nested)
+	                         { return nested.execute(context.object, context.entity, context.frame); });
+
+	const std::size_t size_before = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(parent));
+	}
+	catch (const std::logic_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()) == "child failure");
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(observer.events.size() == 4);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter && observer.events[0].context.entity == parent);
+	assert(observer.events[1].kind == avm::ExecutionEventKind::Enter && observer.events[1].context.entity == child);
+	assert(observer.events[1].context.parent == parent);
+	assert_failure_event(observer.events[2], child, avm::ExecutionFailurePhase::Handler);
+	assert_failure_event(observer.events[3], parent, avm::ExecutionFailurePhase::Handler);
+
+	const std::vector<avm::ExecutionEvent> first = observer.events;
+	observer.clear();
+	rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(parent));
+	}
+	catch (const std::logic_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(observer.events == first);
+}
+
+void verify_observer_failure_cannot_control_success()
 {
 	avm::InMemoryLinkStore store;
 	const avm::LinkId relation = store.create_point();
@@ -181,7 +321,7 @@ void verify_observer_failure_cannot_control_execution()
 	assert(observer.calls == 2);
 }
 
-void verify_observer_failure_cannot_replace_program_failure()
+void verify_observer_failure_cannot_replace_handler_failure()
 {
 	avm::InMemoryLinkStore store;
 	const avm::LinkId relation = store.create_point();
@@ -203,6 +343,57 @@ void verify_observer_failure_cannot_replace_program_failure()
 	{
 		rejected = true;
 		assert(std::string(error.what()) == "program failure");
+	}
+	assert(rejected);
+	assert(observer.calls == 2);
+}
+
+void verify_observer_failure_cannot_replace_dispatch_failure()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	ThrowingObserver observer;
+	avm::Executor executor(store, &observer);
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()).find("unknown relation") != std::string::npos);
+	}
+	assert(rejected);
+	assert(observer.calls == 2);
+}
+
+void verify_observer_failure_cannot_replace_result_validation_failure()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+
+	ThrowingObserver observer;
+	avm::Executor executor(store, &observer);
+	executor.register_native(relation,
+	                         [](const avm::ExecutionContext &, avm::Executor &) { return avm::LinkId{999999}; });
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &error)
+	{
+		rejected = true;
+		assert(std::string(error.what()).find("unknown LinkId") != std::string::npos);
 	}
 	assert(rejected);
 	assert(observer.calls == 2);
@@ -234,9 +425,14 @@ int main()
 	verify_success_events_and_detach();
 	verify_nested_event_order_is_deterministic();
 	verify_function_call_trace_converges_with_link_native_frame();
-	verify_failure_event_preserves_original_exception();
-	verify_observer_failure_cannot_control_execution();
-	verify_observer_failure_cannot_replace_program_failure();
+	verify_dispatch_failure_phase();
+	verify_handler_failure_phase_preserves_original_exception();
+	verify_result_validation_failure_phase();
+	verify_nested_unwind_is_stack_shaped();
+	verify_observer_failure_cannot_control_success();
+	verify_observer_failure_cannot_replace_handler_failure();
+	verify_observer_failure_cannot_replace_dispatch_failure();
+	verify_observer_failure_cannot_replace_result_validation_failure();
 	verify_pre_context_failure_emits_no_event();
 	return 0;
 }

--- a/test/execution_observer_test.cpp
+++ b/test/execution_observer_test.cpp
@@ -264,9 +264,8 @@ void verify_nested_unwind_is_stack_shaped()
 	avm::Executor executor(store, &observer);
 	executor.register_native(child_relation, [](const avm::ExecutionContext &, avm::Executor &) -> avm::LinkId
 	                         { throw std::logic_error("child failure"); });
-	executor.register_native(
-	    parent_relation, [](const avm::ExecutionContext &context, avm::Executor &nested)
-	    { return nested.execute(context.object, context.entity, context.frame); });
+	executor.register_native(parent_relation, [](const avm::ExecutionContext &context, avm::Executor &nested)
+	                         { return nested.execute(context.object, context.entity, context.frame); });
 
 	const std::size_t size_before = store.size();
 	bool rejected = false;

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstddef>
+#include <stdexcept>
 
 namespace
 {
@@ -14,6 +15,8 @@ public:
 		if (count < events.size())
 			events[count++] = event;
 	}
+
+	void clear() { count = 0; }
 
 	std::array<avm::ExecutionEvent, 4> events{};
 	std::size_t count = 0;
@@ -40,7 +43,8 @@ int main()
 		return 1;
 	if (observer.count != 4 || observer.events[0].kind != avm::ExecutionEventKind::Enter ||
 	    observer.events[0].context.entity != expression || observer.events[3].kind != avm::ExecutionEventKind::Return ||
-	    observer.events[3].context.entity != expression || observer.events[3].result != result)
+	    observer.events[3].context.entity != expression || observer.events[3].result != result ||
+	    observer.events[3].failure_phase.has_value())
 		return 2;
 	runtime.executor().set_observer(nullptr);
 
@@ -55,10 +59,26 @@ int main()
 	    matches.front().entity != avm::RelationEntity{relation, subject, object})
 		return 3;
 
+	observer.clear();
+	runtime.executor().set_observer(&observer);
+	bool dispatch_failed = false;
+	try
+	{
+		static_cast<void>(runtime.execute(entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		dispatch_failed = true;
+	}
+	if (!dispatch_failed || observer.count != 2 || observer.events[1].kind != avm::ExecutionEventKind::Fail ||
+	    observer.events[1].failure_phase != avm::ExecutionFailurePhase::Dispatch)
+		return 4;
+	runtime.executor().set_observer(nullptr);
+
 	const avm::LinkId begin = store.create_point();
 	const avm::LinkId end = store.create_point();
 	if (store.find(begin, end).has_value())
-		return 4;
+		return 5;
 
 	const avm::LinkId begin_literal = builder.literal(begin);
 	const avm::LinkId end_literal = builder.literal(end);
@@ -68,12 +88,12 @@ int main()
 
 	const avm::LinkId pair = runtime.execute(materialize);
 	if (store.size() != size_before + 1 || store.find(begin, end) != pair)
-		return 5;
+		return 6;
 
 	const std::size_t size_after = store.size();
 	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin ||
 	    store.size() != size_after)
-		return 6;
+		return 7;
 
 	const avm::LinkId formal = store.create_point();
 	const avm::LinkId is_self_link = builder.create_function_handle();
@@ -81,13 +101,13 @@ int main()
 	builder.define_function(is_self_link, {formal},
 	                        builder.identity_equal(builder.link_begin(parameter), builder.link_end(parameter)));
 	if (runtime.executor().has_native(is_self_link))
-		return 7;
+		return 8;
 
 	const avm::LinkId point = store.create_point();
 	if (runtime.execute(builder.call(is_self_link, {builder.literal(point)})) != runtime.vocabulary().true_value)
-		return 8;
-	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
 		return 9;
+	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
+		return 10;
 
 	return 0;
 }


### PR DESCRIPTION
Closes #98. Parent #95. Depends on merged #97.

## Capability
Extends the existing AVM 1.3 `Fail` observation with a finite deterministic `ExecutionFailurePhase`:

```text
Dispatch
Handler
ResultValidation
```

`ExecutionEvent::failure_phase` is present only for `Fail`; `Enter` and `Return` keep it empty. The AVM package remains 1.3.0 because this is the second gate of the same observability minor line.

## Canonical boundaries
`Executor::execute` now classifies failure at three explicit points without changing the underlying exception behavior:
- missing native handler -> `Fail(Dispatch)` then the existing unknown-relation `runtime_error`;
- selected handler throws -> `Fail(Handler)` then rethrow the original exception unchanged;
- handler returns an absent LinkId -> `Fail(ResultValidation)` then the existing invalid-result `runtime_error`.

There is deliberately no broad catch that collapses these boundaries.

## Unwind semantics
Nested failures remain ordinary recursion through the one canonical `Executor::execute` path. A child handler failure observed inside a parent handler yields stack-shaped order:

```text
Enter(parent)
Enter(child)
Fail(child, Handler)
Fail(parent, Handler)
```

No synthetic trace stack or debugger-specific execution path is introduced.

## Diagnostics policy
Failure phase is canonical AVM data; host diagnostics are not. `ExecutionEvent` still contains no exception message, C++ RTTI/type name, `std::exception_ptr`, backend error or protocol-specific diagnostic.

CI extends the observer-isolation gate to reject host exception objects/strings/type-info from the public observer contract.

## Conformance
Tests cover:
- deterministic Dispatch/Handler/ResultValidation classification;
- original exception type/message behavior preservation;
- nested child-to-parent unwind order;
- repeated identical failure produces exactly the same event sequence and no store growth;
- throwing observer cannot replace successful execution or any of the three failure branches;
- success events have no failure phase;
- pre-context missing LinkId still emits no event.

## Installed package
The external AVM 1.3 consumer observes an unknown relation through `<avm/avm.h>` and verifies `Fail(Dispatch)` while retaining all prior 1.1/1.2/1.3 package checks.

## Vetoes
- no exception strings/types in deterministic event identity;
- no observer control over rethrow/unwind;
- no LinkStore materialization for diagnostics;
- no backend/protocol failure phase;
- no second traced executor.