### PR TITLE
AVM 1.3: add bounded reusable execution trace collector

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,15 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce execution trace tooling isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E 'Executor|LinkStore|BootstrapRuntime|PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num|[Aa]bit|fstream|filesystem' include/avm/execution_trace.h; then
+            echo "ERROR: execution trace collector must remain observer-only tooling state"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |
@@ -177,6 +186,7 @@ jobs:
             test/relations_query_test.cpp \
             test/executor_test.cpp \
             test/execution_observer_test.cpp \
+            test/execution_trace_test.cpp \
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/structural_runtime_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/avm.h
     include/avm/bootstrap_runtime.h
     include/avm/execution_observer.h
+    include/avm/execution_trace.h
     include/avm/executor.h
     include/avm/link_store.h
     include/avm/persistent_link_store.h
@@ -151,6 +152,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_relations_query_test test/relations_query_test.cpp relations_query_tests)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
+    avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
     avm_add_core_test(avm_structural_runtime_test test/structural_runtime_test.cpp structural_runtime_tests)
@@ -185,6 +187,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_relations_query_test
         avm_executor_test
         avm_execution_observer_test
+        avm_execution_trace_test
         avm_program_model_test
         avm_boolean_runtime_test
         avm_structural_runtime_test

--- a/docs/execution-observability.md
+++ b/docs/execution-observability.md
@@ -93,6 +93,41 @@ For the same canonical store/program/vocabulary state, an observer sees the same
 
 Observation itself never materializes links. Attaching or detaching an observer does not change `LinkStore` semantics.
 
+## Bounded tooling collector
+
+`BoundedExecutionTrace` is a reusable host-memory consumer of `ExecutionObserver`. It is a tooling utility, not part of AVM semantic state:
+
+```cpp
+avm::BoundedExecutionTrace trace(128);
+runtime.executor().set_observer(&trace);
+const avm::LinkId result = runtime.execute(root);
+
+for (const avm::ExecutionEvent &event : trace.events())
+{
+    // inspect deterministic AVM events
+}
+
+if (trace.truncated())
+{
+    // configured capacity was insufficient
+}
+```
+
+The event capacity is fixed when the collector is constructed. Its `std::vector` storage is reserved in the constructor, before the collector is normally attached to an executor. Construction/reservation may therefore report normal host allocation failures to the caller before execution starts.
+
+During observation, configured capacity exhaustion does not allocate, throw or fabricate an event. The collector retains the exact event prefix that fits and sets `truncated()==true`. A zero-capacity collector stores no events and becomes truncated as soon as any event arrives.
+
+`reset()` clears retained events and truncation state while preserving the configured `max_events()` and reserved storage policy. Event access is exposed as an immutable `std::span<const ExecutionEvent>`.
+
+This bounded policy distinguishes two concepts that must not be conflated:
+
+```text
+ExecutionEvent semantics  = canonical AVM observation contract
+BoundedExecutionTrace     = optional host-memory tooling storage
+```
+
+The collector does not own an `Executor`, `LinkStore`, backend, protocol adapter or persistence target. It never writes traces into links or files implicitly.
+
 ## Diagnostics policy
 
 The deterministic trace contract intentionally stops at AVM-owned failure phase. Human-readable exception text remains runtime diagnostic information, not stable event identity. C++ exception type names, `std::exception_ptr`, stack addresses and backend/protocol errors are not stored in `ExecutionEvent`.
@@ -106,8 +141,8 @@ AVM 1.3 observability does not provide:
 - breakpoints or step control;
 - handler replacement or result substitution;
 - a global trace singleton;
-- implicit trace persistence in `LinkStore`;
-- a core `std::vector` trace collector;
+- implicit trace persistence in `LinkStore` or files;
+- an unbounded/implicitly complete trace guarantee;
 - profiler timestamps;
 - exception objects or exception strings inside deterministic events;
 - JSON/Anum-specific trace events;

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -2,6 +2,7 @@
 
 #include "avm/bootstrap_runtime.h"
 #include "avm/execution_observer.h"
+#include "avm/execution_trace.h"
 #include "avm/executor.h"
 #include "avm/link_store.h"
 #include "avm/persistent_link_store.h"

--- a/include/avm/execution_trace.h
+++ b/include/avm/execution_trace.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "avm/execution_observer.h"
+
+#include <cstddef>
+#include <span>
+#include <type_traits>
+#include <vector>
+
+namespace avm
+{
+
+class BoundedExecutionTrace final : public ExecutionObserver
+{
+public:
+	explicit BoundedExecutionTrace(std::size_t max_events) : max_events_(max_events)
+	{
+		static_assert(std::is_nothrow_copy_constructible_v<ExecutionEvent>);
+		events_.reserve(max_events_);
+	}
+
+	void observe(const ExecutionEvent &event) noexcept override
+	{
+		if (events_.size() >= max_events_)
+		{
+			truncated_ = true;
+			return;
+		}
+
+		events_.push_back(event);
+	}
+
+	std::span<const ExecutionEvent> events() const noexcept { return events_; }
+
+	std::size_t size() const noexcept { return events_.size(); }
+
+	std::size_t max_events() const noexcept { return max_events_; }
+
+	bool empty() const noexcept { return events_.empty(); }
+
+	bool truncated() const noexcept { return truncated_; }
+
+	bool complete() const noexcept { return !truncated_; }
+
+	void reset() noexcept
+	{
+		events_.clear();
+		truncated_ = false;
+	}
+
+private:
+	std::size_t max_events_;
+	std::vector<ExecutionEvent> events_;
+	bool truncated_ = false;
+};
+
+} // namespace avm

--- a/plan.md
+++ b/plan.md
@@ -211,11 +211,11 @@ Properties:
 - installed package consumer validates the API on Linux/Windows/macOS;
 - strict warnings, ASan+UBSan and portable matrix are green.
 
-### Gate 15 — deterministic failure phase and unwind observation (current)
+### Gate 15 — deterministic failure phase and unwind observation ✅
 
-Child: #98.
+Implemented through #98/#99.
 
-Extend `Fail` with a finite AVM-owned phase taxonomy:
+`Fail` carries a finite AVM-owned phase taxonomy:
 
 ```text
 Dispatch
@@ -223,7 +223,7 @@ Handler
 ResultValidation
 ```
 
-Requirements:
+Properties:
 
 - phase identifies the canonical execution boundary that failed, not exception text/type;
 - no `std::exception_ptr`, host exception object or backend/protocol diagnostic in `ExecutionEvent`;
@@ -234,13 +234,40 @@ Requirements:
 - repeated failure against unchanged state produces identical events;
 - observation does not materialize links.
 
+### Gate 16 — bounded reusable execution trace collector (current)
+
+Child: #100.
+
+Provide a host-memory tooling collector over the stable observer contract without moving trace storage into semantic state.
+
+Initial contract:
+
+```text
+BoundedExecutionTrace(max_events)
+  -> stores exact ExecutionEvent prefix
+  -> complete when all events fit
+  -> truncated when configured capacity is exceeded
+```
+
+Requirements:
+
+- capacity/storage reservation is established before normal attachment/execution;
+- capacity exhaustion never fabricates events and is reported explicitly by `truncated()`;
+- zero capacity is defined;
+- `reset()` preserves configured capacity while clearing events/truncation;
+- event access is immutable;
+- collector owns no `Executor`, `LinkStore`, backend, parser/protocol or persistence target;
+- collector attachment does not change program results or LinkStore effects;
+- failure phases from Gate 15 pass through unchanged;
+- installed public package can use the collector on Linux/Windows/macOS;
+- strict warnings, ASan+UBSan and portable matrix stay green.
+
 ### Later AVM 1.3 gates
 
-After Gate 15 is stable:
+After Gate 16 is stable:
 
-1. reusable collector/tooling layer outside semantic state;
-2. InMemory/Persistent reopen trace equivalence;
-3. debugger/REPL consumer built on observation rather than a traced executor fork.
+1. InMemory/Persistent reopen trace equivalence;
+2. debugger/REPL consumer built on observation rather than a traced executor fork.
 
 ## Later AVM 1.x directions
 

--- a/test/execution_trace_test.cpp
+++ b/test/execution_trace_test.cpp
@@ -1,0 +1,215 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/execution_trace.h"
+
+#include <cassert>
+#include <stdexcept>
+
+namespace
+{
+
+struct NestedProgram
+{
+	avm::LinkId root;
+	avm::LinkId true_literal;
+	avm::LinkId negated;
+};
+
+NestedProgram build_nested_program(avm::BootstrapRuntime &runtime)
+{
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary &vocabulary = runtime.vocabulary();
+	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
+	const avm::LinkId negated = builder.logical_not(false_literal);
+	return NestedProgram{builder.logical_and(true_literal, negated), true_literal, negated};
+}
+
+void verify_exact_capacity_trace_is_complete()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const NestedProgram program = build_nested_program(runtime);
+	avm::BoundedExecutionTrace trace(8);
+	runtime.executor().set_observer(&trace);
+
+	const std::size_t size_before = store.size();
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(store.size() == size_before);
+	assert(trace.max_events() == 8);
+	assert(trace.size() == 8);
+	assert(!trace.empty());
+	assert(trace.complete());
+	assert(!trace.truncated());
+	assert(trace.events().front().kind == avm::ExecutionEventKind::Enter);
+	assert(trace.events().front().context.entity == program.root);
+	assert(trace.events().back().kind == avm::ExecutionEventKind::Return);
+	assert(trace.events().back().context.entity == program.root);
+	assert(trace.events().back().result == runtime.vocabulary().true_value);
+}
+
+void verify_short_capacity_retains_prefix_and_marks_truncation()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const NestedProgram program = build_nested_program(runtime);
+
+	avm::BoundedExecutionTrace full(8);
+	runtime.executor().set_observer(&full);
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(full.complete());
+
+	avm::BoundedExecutionTrace short_trace(3);
+	runtime.executor().set_observer(&short_trace);
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(short_trace.size() == 3);
+	assert(short_trace.truncated());
+	assert(!short_trace.complete());
+	for (std::size_t i = 0; i < short_trace.size(); ++i)
+		assert(short_trace.events()[i] == full.events()[i]);
+}
+
+void verify_zero_capacity_records_no_events_and_marks_truncation()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const NestedProgram program = build_nested_program(runtime);
+	avm::BoundedExecutionTrace trace(0);
+	runtime.executor().set_observer(&trace);
+
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(trace.max_events() == 0);
+	assert(trace.empty());
+	assert(trace.events().empty());
+	assert(trace.truncated());
+	assert(!trace.complete());
+}
+
+void verify_reset_preserves_capacity_and_reuses_storage_policy()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const NestedProgram program = build_nested_program(runtime);
+	avm::BoundedExecutionTrace trace(4);
+	runtime.executor().set_observer(&trace);
+
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(trace.size() == 4);
+	assert(trace.truncated());
+
+	trace.reset();
+	assert(trace.max_events() == 4);
+	assert(trace.empty());
+	assert(trace.complete());
+	assert(!trace.truncated());
+
+	assert(runtime.execute(program.true_literal) == runtime.vocabulary().true_value);
+	assert(trace.size() == 2);
+	assert(trace.complete());
+	assert(trace.events()[0].context.entity == program.true_literal);
+	assert(trace.events()[1].context.entity == program.true_literal);
+}
+
+void verify_failure_phase_is_retained_unchanged()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, {relation, subject, object});
+	avm::BoundedExecutionTrace trace(2);
+	avm::Executor executor(store, &trace);
+
+	const std::size_t size_before = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	assert(trace.complete());
+	assert(trace.size() == 2);
+	assert(trace.events()[0].kind == avm::ExecutionEventKind::Enter);
+	assert(trace.events()[1].kind == avm::ExecutionEventKind::Fail);
+	assert(trace.events()[1].failure_phase == avm::ExecutionFailurePhase::Dispatch);
+}
+
+struct EffectRun
+{
+	std::size_t growth;
+	bool materialized;
+};
+
+EffectRun run_pair_effect(bool attach_trace)
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId expression = builder.pair_intern(builder.literal(begin), builder.literal(end));
+	avm::BoundedExecutionTrace trace(16);
+	if (attach_trace)
+		runtime.executor().set_observer(&trace);
+
+	const std::size_t size_before = store.size();
+	const avm::LinkId result = runtime.execute(expression);
+	const std::size_t growth = store.size() - size_before;
+	const bool materialized = store.find(begin, end) == result;
+	if (attach_trace)
+	{
+		assert(trace.complete());
+		assert(!trace.empty());
+	}
+	return EffectRun{growth, materialized};
+}
+
+void verify_collector_does_not_change_program_effects()
+{
+	const EffectRun without_trace = run_pair_effect(false);
+	const EffectRun with_trace = run_pair_effect(true);
+	assert(without_trace.growth == 1);
+	assert(with_trace.growth == without_trace.growth);
+	assert(without_trace.materialized);
+	assert(with_trace.materialized);
+}
+
+void verify_repeated_deterministic_execution_reuses_collector()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const NestedProgram program = build_nested_program(runtime);
+	avm::BoundedExecutionTrace trace(8);
+	runtime.executor().set_observer(&trace);
+
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	const std::array<avm::ExecutionEvent, 8> first{
+	    trace.events()[0], trace.events()[1], trace.events()[2], trace.events()[3],
+	    trace.events()[4], trace.events()[5], trace.events()[6], trace.events()[7],
+	};
+
+	trace.reset();
+	assert(runtime.execute(program.root) == runtime.vocabulary().true_value);
+	assert(trace.complete());
+	assert(trace.size() == first.size());
+	for (std::size_t i = 0; i < first.size(); ++i)
+		assert(trace.events()[i] == first[i]);
+}
+
+} // namespace
+
+int main()
+{
+	verify_exact_capacity_trace_is_complete();
+	verify_short_capacity_retains_prefix_and_marks_truncation();
+	verify_zero_capacity_records_no_events_and_marks_truncation();
+	verify_reset_preserves_capacity_and_reuses_storage_policy();
+	verify_failure_phase_is_retained_unchanged();
+	verify_collector_does_not_change_program_effects();
+	verify_repeated_deterministic_execution_reuses_collector();
+	return 0;
+}

--- a/test/execution_trace_test.cpp
+++ b/test/execution_trace_test.cpp
@@ -1,6 +1,7 @@
 #include "avm/bootstrap_runtime.h"
 #include "avm/execution_trace.h"
 
+#include <array>
 #include <cassert>
 #include <stdexcept>
 

--- a/test/package_consumer/main.cpp
+++ b/test/package_consumer/main.cpp
@@ -1,28 +1,7 @@
 #include <avm/avm.h>
 
-#include <array>
 #include <cstddef>
 #include <stdexcept>
-
-namespace
-{
-
-class FixedObserver final : public avm::ExecutionObserver
-{
-public:
-	void observe(const avm::ExecutionEvent &event) override
-	{
-		if (count < events.size())
-			events[count++] = event;
-	}
-
-	void clear() { count = 0; }
-
-	std::array<avm::ExecutionEvent, 4> events{};
-	std::size_t count = 0;
-};
-
-} // namespace
 
 int main()
 {
@@ -36,15 +15,15 @@ int main()
 	avm::ProgramBuilder builder = runtime.builder();
 
 	const avm::LinkId expression = builder.logical_not(builder.literal(runtime.vocabulary().false_value));
-	FixedObserver observer;
-	runtime.executor().set_observer(&observer);
+	avm::BoundedExecutionTrace trace(4);
+	runtime.executor().set_observer(&trace);
 	const avm::LinkId result = runtime.execute(expression);
 	if (result != runtime.vocabulary().true_value)
 		return 1;
-	if (observer.count != 4 || observer.events[0].kind != avm::ExecutionEventKind::Enter ||
-	    observer.events[0].context.entity != expression || observer.events[3].kind != avm::ExecutionEventKind::Return ||
-	    observer.events[3].context.entity != expression || observer.events[3].result != result ||
-	    observer.events[3].failure_phase.has_value())
+	if (trace.max_events() != 4 || trace.size() != 4 || !trace.complete() || trace.truncated() ||
+	    trace.events()[0].kind != avm::ExecutionEventKind::Enter || trace.events()[0].context.entity != expression ||
+	    trace.events()[3].kind != avm::ExecutionEventKind::Return || trace.events()[3].context.entity != expression ||
+	    trace.events()[3].result != result || trace.events()[3].failure_phase.has_value())
 		return 2;
 	runtime.executor().set_observer(nullptr);
 
@@ -59,8 +38,8 @@ int main()
 	    matches.front().entity != avm::RelationEntity{relation, subject, object})
 		return 3;
 
-	observer.clear();
-	runtime.executor().set_observer(&observer);
+	trace.reset();
+	runtime.executor().set_observer(&trace);
 	bool dispatch_failed = false;
 	try
 	{
@@ -70,15 +49,23 @@ int main()
 	{
 		dispatch_failed = true;
 	}
-	if (!dispatch_failed || observer.count != 2 || observer.events[1].kind != avm::ExecutionEventKind::Fail ||
-	    observer.events[1].failure_phase != avm::ExecutionFailurePhase::Dispatch)
+	if (!dispatch_failed || trace.size() != 2 || !trace.complete() ||
+	    trace.events()[1].kind != avm::ExecutionEventKind::Fail ||
+	    trace.events()[1].failure_phase != avm::ExecutionFailurePhase::Dispatch)
 		return 4;
+	runtime.executor().set_observer(nullptr);
+
+	avm::BoundedExecutionTrace zero_trace(0);
+	runtime.executor().set_observer(&zero_trace);
+	static_cast<void>(runtime.execute(expression));
+	if (!zero_trace.empty() || !zero_trace.truncated() || zero_trace.complete())
+		return 5;
 	runtime.executor().set_observer(nullptr);
 
 	const avm::LinkId begin = store.create_point();
 	const avm::LinkId end = store.create_point();
 	if (store.find(begin, end).has_value())
-		return 5;
+		return 6;
 
 	const avm::LinkId begin_literal = builder.literal(begin);
 	const avm::LinkId end_literal = builder.literal(end);
@@ -88,12 +75,12 @@ int main()
 
 	const avm::LinkId pair = runtime.execute(materialize);
 	if (store.size() != size_before + 1 || store.find(begin, end) != pair)
-		return 6;
+		return 7;
 
 	const std::size_t size_after = store.size();
 	if (runtime.execute(materialize) != pair || runtime.execute(begin_expression) != begin ||
 	    store.size() != size_after)
-		return 7;
+		return 8;
 
 	const avm::LinkId formal = store.create_point();
 	const avm::LinkId is_self_link = builder.create_function_handle();
@@ -101,13 +88,13 @@ int main()
 	builder.define_function(is_self_link, {formal},
 	                        builder.identity_equal(builder.link_begin(parameter), builder.link_end(parameter)));
 	if (runtime.executor().has_native(is_self_link))
-		return 8;
+		return 9;
 
 	const avm::LinkId point = store.create_point();
 	if (runtime.execute(builder.call(is_self_link, {builder.literal(point)})) != runtime.vocabulary().true_value)
-		return 9;
-	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
 		return 10;
+	if (runtime.execute(builder.call(is_self_link, {builder.literal(pair)})) != runtime.vocabulary().false_value)
+		return 11;
 
 	return 0;
 }


### PR DESCRIPTION
Closes #100. Parent #95. Depends on merged #99.

## Capability
Adds `BoundedExecutionTrace`, a reusable public tooling observer that stores a bounded prefix of the existing deterministic `ExecutionEvent` stream.

```cpp
avm::BoundedExecutionTrace trace(128);
runtime.executor().set_observer(&trace);
const avm::LinkId result = runtime.execute(root);

for (const avm::ExecutionEvent &event : trace.events())
{
    // inspect canonical AVM observation data
}

if (trace.truncated())
{
    // configured event capacity was insufficient
}
```

This PR intentionally changes no `Executor`, `ExecutionEvent`, LinkStore, persistence or protocol semantics.

## Resource policy
The collector makes trace completeness explicit instead of pretending an unbounded host-memory observer is infallible:
- `max_events` is configured at construction;
- backing `std::vector` storage is reserved in the constructor, before normal attachment/execution;
- construction/reservation may report ordinary host allocation errors to the caller before execution;
- once configured capacity is exhausted, `observe` stores no more events and sets `truncated=true`;
- capacity exhaustion itself does not allocate, throw or fabricate events;
- zero capacity is defined: no events retained, first observed event marks truncation;
- `reset()` clears retained events/truncation while preserving configured capacity/storage policy;
- events are exposed as immutable `std::span<const ExecutionEvent>`.

`ExecutionEvent` is statically required to remain nothrow-copy-constructible for this pre-reserved observation path.

## Architecture
`BoundedExecutionTrace` is host-memory tooling state only:
- implements `ExecutionObserver`;
- owns no `Executor`, `LinkStore`, `BootstrapRuntime`, backend or protocol object;
- persists nothing implicitly to links/files;
- adds no timestamps, opcode names, exception text or new event semantics;
- does not become a field of `Executor` or semantic state.

CI adds a dedicated isolation guard rejecting execution/storage ownership, backend/protocol coupling and file persistence from `execution_trace.h`.

## Conformance
New core tests cover:
- exact-capacity nested trace -> complete/not truncated;
- short capacity -> exact retained prefix + explicit truncation;
- zero capacity behavior;
- reset/reuse with configured capacity preserved;
- Gate 15 failure phase retained unchanged;
- collector vs no observer preserves explicit `pair_intern` effect semantics;
- repeated deterministic execution after reset yields identical events.

## Installed package
The external AVM 1.3 consumer now uses `BoundedExecutionTrace` through `<avm/avm.h>` instead of a test-local observer. It verifies successful trace collection, reset/failure-phase collection and zero-capacity truncation on the installed package.

## Package / CI
- `execution_trace.h` is installed as part of dependency-free `avm::core` and exposed by `<avm/avm.h>`;
- trace conformance joins core strict, ASan+UBSan and portable Linux/Windows/macOS aggregates;
- package remains AVM 1.3.0; no additional minor/patch bump for this gate.

## Vetoes
- no trace storage inside `Executor`;
- no implicit persistence;
- no hidden/unreported configured-capacity truncation;
- no execution control/breakpoints/result substitution;
- no protocol/backend dependency;
- no second traced executor.