### PR TITLE
AVM 1.3: prove trace identity across reopen and backend-neutral equivalence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
             test/executor_test.cpp \
             test/execution_observer_test.cpp \
             test/execution_trace_test.cpp \
+            test/execution_trace_persistence_test.cpp \
             test/program_model_test.cpp \
             test/boolean_runtime_test.cpp \
             test/structural_runtime_test.cpp \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,10 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
+    avm_add_core_test(
+        avm_execution_trace_persistence_test
+        test/execution_trace_persistence_test.cpp
+        execution_trace_persistence_tests)
     avm_add_core_test(avm_program_model_test test/program_model_test.cpp program_model_tests)
     avm_add_core_test(avm_boolean_runtime_test test/boolean_runtime_test.cpp boolean_runtime_tests)
     avm_add_core_test(avm_structural_runtime_test test/structural_runtime_test.cpp structural_runtime_tests)
@@ -188,6 +192,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_executor_test
         avm_execution_observer_test
         avm_execution_trace_test
+        avm_execution_trace_persistence_test
         avm_program_model_test
         avm_boolean_runtime_test
         avm_structural_runtime_test

--- a/docs/execution-observability.md
+++ b/docs/execution-observability.md
@@ -128,6 +128,43 @@ BoundedExecutionTrace     = optional host-memory tooling storage
 
 The collector does not own an `Executor`, `LinkStore`, backend, protocol adapter or persistence target. It never writes traces into links or files implicitly.
 
+## Persistent reopen and backend-neutral equivalence
+
+Trace comparison must respect opaque `LinkId` identity. Raw numeric LinkIds are meaningful only inside one logical store; AVM does not define a global LinkId namespace across independent stores.
+
+Two different conformance claims therefore use different comparison rules.
+
+### Same persistent logical store across reopen
+
+`PersistentLinkStore` preserves its LinkIds across close/reopen. After program construction and link-native call-frame/binding state have converged, the same stored program and explicit bootstrap vocabulary must produce the exact same complete `ExecutionEvent` sequence after reopen, including the numeric values of every LinkId field.
+
+The reopen contract covers:
+
+```text
+entity / relation / subject / object
+optional parent / frame
+optional result
+kind / failure_phase
+```
+
+Repeated reopen/execution of the converged program must not grow the store merely because observation is attached.
+
+### Independent stores/backends
+
+An independently constructed `InMemoryLinkStore` and `PersistentLinkStore` may assign different numeric LinkIds to equivalent structure. Comparing raw numbers between them would violate opaque identity semantics.
+
+Backend-neutral conformance therefore compares complete traces modulo a bijective renaming of observed LinkIds. The reference test uses canonical first-occurrence renaming:
+
+1. walk events in execution order;
+2. visit each LinkId-bearing field in fixed order: `entity`, `relation`, `subject`, `object`, `parent`, `frame`, `result`;
+3. assign a local ordinal when an observed LinkId first appears;
+4. reuse that ordinal on every later occurrence of the same LinkId;
+5. preserve `nullopt`, `ExecutionEventKind` and `ExecutionFailurePhase` exactly.
+
+This normalization preserves equality/aliasing relationships while discarding backend-local numeric allocation choices. It is a conformance helper, not a production identity registry or serialization format.
+
+A truncated trace is not eligible for an equivalence claim: it represents only a retained prefix, so normalization/comparison must reject it or otherwise explicitly decline completeness.
+
 ## Diagnostics policy
 
 The deterministic trace contract intentionally stops at AVM-owned failure phase. Human-readable exception text remains runtime diagnostic information, not stable event identity. C++ exception type names, `std::exception_ptr`, stack addresses and backend/protocol errors are not stored in `ExecutionEvent`.
@@ -145,6 +182,8 @@ AVM 1.3 observability does not provide:
 - an unbounded/implicitly complete trace guarantee;
 - profiler timestamps;
 - exception objects or exception strings inside deterministic events;
+- globally comparable numeric LinkIds across independent stores;
+- a production trace-normalization identity registry;
 - JSON/Anum-specific trace events;
 - debugger UI or REPL commands.
 

--- a/plan.md
+++ b/plan.md
@@ -234,13 +234,11 @@ Properties:
 - repeated failure against unchanged state produces identical events;
 - observation does not materialize links.
 
-### Gate 16 — bounded reusable execution trace collector (current)
+### Gate 16 — bounded reusable execution trace collector ✅
 
-Child: #100.
+Implemented through #100/#101.
 
-Provide a host-memory tooling collector over the stable observer contract without moving trace storage into semantic state.
-
-Initial contract:
+Public tooling contract:
 
 ```text
 BoundedExecutionTrace(max_events)
@@ -249,7 +247,7 @@ BoundedExecutionTrace(max_events)
   -> truncated when configured capacity is exceeded
 ```
 
-Requirements:
+Properties:
 
 - capacity/storage reservation is established before normal attachment/execution;
 - capacity exhaustion never fabricates events and is reported explicitly by `truncated()`;
@@ -259,15 +257,40 @@ Requirements:
 - collector owns no `Executor`, `LinkStore`, backend, parser/protocol or persistence target;
 - collector attachment does not change program results or LinkStore effects;
 - failure phases from Gate 15 pass through unchanged;
-- installed public package can use the collector on Linux/Windows/macOS;
-- strict warnings, ASan+UBSan and portable matrix stay green.
+- installed public package uses the collector on Linux/Windows/macOS;
+- strict warnings, ASan+UBSan and portable matrix are green.
 
-### Later AVM 1.3 gates
+### Gate 17 — persistent reopen and backend-neutral trace equivalence (current)
 
-After Gate 16 is stable:
+Child: #102.
 
-1. InMemory/Persistent reopen trace equivalence;
-2. debugger/REPL consumer built on observation rather than a traced executor fork.
+Two identity claims are intentionally distinct:
+
+```text
+same PersistentLinkStore after reopen
+  -> exact ExecutionEvent equality, including numeric LinkIds
+
+independent InMemory/Persistent stores
+  -> equivalence modulo bijective renaming of opaque LinkIds
+```
+
+Requirements:
+
+- converge link-native function binding/frame state before baseline capture;
+- persistent close/reopen preserves exact success/failure traces and store size;
+- repeated reopen remains exact and idempotent;
+- backend-neutral comparison preserves equality/aliasing relationships across every LinkId-bearing field;
+- normalization uses deterministic first-occurrence ordinals only as test/conformance tooling;
+- raw LinkId numbers are never treated as globally comparable across independent stores;
+- failure phases and event kinds remain exact under normalized comparison;
+- truncated traces are rejected from completeness/equivalence claims;
+- no new LinkStore API/index, persistence format, event field or semantic registry.
+
+### Gate 18 — debugger/REPL consumer
+
+After Gate 17 is stable, build an actual tooling consumer on the public observer/collector boundary without forking `Executor` or introducing a second program representation.
+
+The first consumer should prove that trace inspection, failure presentation and basic execution tooling can be implemented entirely outside semantic state. Breakpoint/control semantics remain a separate design question and are not implied merely by observability.
 
 ## Later AVM 1.x directions
 

--- a/test/execution_trace_persistence_test.cpp
+++ b/test/execution_trace_persistence_test.cpp
@@ -126,7 +126,7 @@ ScenarioProgram build_scenario(avm::LinkStore &store, avm::BootstrapRuntime &run
 }
 
 std::vector<avm::ExecutionEvent> capture_success(avm::BootstrapRuntime &runtime, avm::LinkStore &store,
-                                                avm::LinkId root, avm::LinkId expected)
+                                                 avm::LinkId root, avm::LinkId expected)
 {
 	avm::BoundedExecutionTrace trace(128);
 	runtime.executor().set_observer(&trace);
@@ -138,7 +138,7 @@ std::vector<avm::ExecutionEvent> capture_success(avm::BootstrapRuntime &runtime,
 }
 
 std::vector<avm::ExecutionEvent> capture_failure(avm::BootstrapRuntime &runtime, avm::LinkStore &store,
-                                                avm::LinkId root)
+                                                 avm::LinkId root)
 {
 	avm::BoundedExecutionTrace trace(128);
 	runtime.executor().set_observer(&trace);

--- a/test/execution_trace_persistence_test.cpp
+++ b/test/execution_trace_persistence_test.cpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <optional>
 #include <stdexcept>
+#include <string>
 #include <vector>
 
 namespace
@@ -58,14 +59,14 @@ std::vector<NormalizedExecutionEvent> normalize_trace(const avm::BoundedExecutio
 
 	std::map<avm::LinkId, std::size_t> ordinals;
 	std::size_t next_ordinal = 0;
-	const auto ordinal = [&ordinals, &next_ordinal](avm::LinkId id) mutable
+	auto ordinal = [&ordinals, &next_ordinal](avm::LinkId id)
 	{
 		const auto [it, inserted] = ordinals.emplace(id, next_ordinal);
 		if (inserted)
 			++next_ordinal;
 		return it->second;
 	};
-	const auto optional_ordinal = [&ordinal](std::optional<avm::LinkId> id) mutable -> std::optional<std::size_t>
+	auto optional_ordinal = [&ordinal](std::optional<avm::LinkId> id) -> std::optional<std::size_t>
 	{
 		if (!id)
 			return std::nullopt;

--- a/test/execution_trace_persistence_test.cpp
+++ b/test/execution_trace_persistence_test.cpp
@@ -1,0 +1,309 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/execution_trace.h"
+#include "avm/persistent_link_store.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+std::filesystem::path temporary_path()
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() / ("avm-trace-reopen-" + std::to_string(nonce) + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+std::vector<avm::ExecutionEvent> copy_complete_trace(const avm::BoundedExecutionTrace &trace)
+{
+	if (trace.truncated())
+		throw std::invalid_argument("cannot compare a truncated execution trace");
+	return std::vector<avm::ExecutionEvent>(trace.events().begin(), trace.events().end());
+}
+
+struct NormalizedExecutionEvent
+{
+	avm::ExecutionEventKind kind;
+	std::size_t entity;
+	std::size_t relation;
+	std::size_t subject;
+	std::size_t object;
+	std::optional<std::size_t> parent;
+	std::optional<std::size_t> frame;
+	std::optional<std::size_t> result;
+	std::optional<avm::ExecutionFailurePhase> failure_phase;
+
+	bool operator==(const NormalizedExecutionEvent &) const = default;
+};
+
+std::vector<NormalizedExecutionEvent> normalize_trace(const avm::BoundedExecutionTrace &trace)
+{
+	if (trace.truncated())
+		throw std::invalid_argument("cannot normalize a truncated execution trace");
+
+	std::map<avm::LinkId, std::size_t> ordinals;
+	std::size_t next_ordinal = 0;
+	const auto ordinal = [&ordinals, &next_ordinal](avm::LinkId id) mutable
+	{
+		const auto [it, inserted] = ordinals.emplace(id, next_ordinal);
+		if (inserted)
+			++next_ordinal;
+		return it->second;
+	};
+	const auto optional_ordinal = [&ordinal](std::optional<avm::LinkId> id) mutable -> std::optional<std::size_t>
+	{
+		if (!id)
+			return std::nullopt;
+		return ordinal(*id);
+	};
+
+	std::vector<NormalizedExecutionEvent> normalized;
+	normalized.reserve(trace.size());
+	for (const avm::ExecutionEvent &event : trace.events())
+	{
+		normalized.push_back(NormalizedExecutionEvent{
+		    event.kind,
+		    ordinal(event.context.entity),
+		    ordinal(event.context.relation),
+		    ordinal(event.context.subject),
+		    ordinal(event.context.object),
+		    optional_ordinal(event.context.parent),
+		    optional_ordinal(event.context.frame),
+		    optional_ordinal(event.result),
+		    event.failure_phase,
+		});
+	}
+	return normalized;
+}
+
+struct ScenarioProgram
+{
+	avm::BootstrapVocabulary vocabulary;
+	avm::LinkId boolean_root;
+	avm::LinkId call_root;
+	avm::LinkId failure_root;
+	avm::LinkId expected_result;
+};
+
+ScenarioProgram build_scenario(avm::LinkStore &store, avm::BootstrapRuntime &runtime)
+{
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::BootstrapVocabulary vocabulary = runtime.vocabulary();
+
+	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	const avm::LinkId false_literal = builder.literal(vocabulary.false_value);
+	const avm::LinkId negated = builder.logical_not(false_literal);
+	const avm::LinkId boolean_root = builder.logical_and(true_literal, negated);
+
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId function = builder.create_function_handle();
+	builder.define_function(function, {formal}, builder.parameter(formal));
+	const avm::LinkId call_root = builder.call(function, {true_literal});
+
+	const avm::LinkId unknown_relation = store.create_point();
+	const avm::LinkId failure_subject = store.create_point();
+	const avm::LinkId failure_object = store.create_point();
+	const avm::LinkId failure_root =
+	    avm::encode_relation_entity(store, {unknown_relation, failure_subject, failure_object});
+
+	return ScenarioProgram{vocabulary, boolean_root, call_root, failure_root, vocabulary.true_value};
+}
+
+std::vector<avm::ExecutionEvent> capture_success(avm::BootstrapRuntime &runtime, avm::LinkStore &store,
+                                                avm::LinkId root, avm::LinkId expected)
+{
+	avm::BoundedExecutionTrace trace(128);
+	runtime.executor().set_observer(&trace);
+	const std::size_t size_before = store.size();
+	assert(runtime.execute(root) == expected);
+	assert(store.size() == size_before);
+	runtime.executor().set_observer(nullptr);
+	return copy_complete_trace(trace);
+}
+
+std::vector<avm::ExecutionEvent> capture_failure(avm::BootstrapRuntime &runtime, avm::LinkStore &store,
+                                                avm::LinkId root)
+{
+	avm::BoundedExecutionTrace trace(128);
+	runtime.executor().set_observer(&trace);
+	const std::size_t size_before = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(root));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == size_before);
+	runtime.executor().set_observer(nullptr);
+	const std::vector<avm::ExecutionEvent> events = copy_complete_trace(trace);
+	assert(!events.empty());
+	assert(events.back().kind == avm::ExecutionEventKind::Fail);
+	assert(events.back().failure_phase == avm::ExecutionFailurePhase::Dispatch);
+	return events;
+}
+
+struct PersistentBaseline
+{
+	ScenarioProgram program;
+	std::vector<avm::ExecutionEvent> boolean_trace;
+	std::vector<avm::ExecutionEvent> call_trace;
+	std::vector<avm::ExecutionEvent> failure_trace;
+	std::size_t store_size;
+};
+
+PersistentBaseline create_persistent_baseline(const std::filesystem::path &path)
+{
+	avm::PersistentLinkStore store(path);
+	avm::BootstrapRuntime runtime(store);
+	const ScenarioProgram program = build_scenario(store, runtime);
+
+	static_cast<void>(runtime.execute(program.call_root));
+	const std::size_t converged_size = store.size();
+	assert(runtime.execute(program.call_root) == program.expected_result);
+	assert(store.size() == converged_size);
+
+	const std::vector<avm::ExecutionEvent> boolean_trace =
+	    capture_success(runtime, store, program.boolean_root, program.expected_result);
+	const std::vector<avm::ExecutionEvent> call_trace =
+	    capture_success(runtime, store, program.call_root, program.expected_result);
+	const std::vector<avm::ExecutionEvent> failure_trace = capture_failure(runtime, store, program.failure_root);
+
+	return PersistentBaseline{program, boolean_trace, call_trace, failure_trace, store.size()};
+}
+
+void assert_persistent_reopen_matches(const std::filesystem::path &path, const PersistentBaseline &baseline)
+{
+	avm::PersistentLinkStore store(path);
+	assert(store.size() == baseline.store_size);
+	avm::BootstrapRuntime runtime(store, baseline.program.vocabulary);
+	assert(store.size() == baseline.store_size);
+
+	assert(capture_success(runtime, store, baseline.program.boolean_root, baseline.program.expected_result) ==
+	       baseline.boolean_trace);
+	assert(capture_success(runtime, store, baseline.program.call_root, baseline.program.expected_result) ==
+	       baseline.call_trace);
+	assert(capture_failure(runtime, store, baseline.program.failure_root) == baseline.failure_trace);
+	assert(store.size() == baseline.store_size);
+}
+
+void verify_persistent_trace_identity_survives_multiple_reopens()
+{
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	const PersistentBaseline baseline = create_persistent_baseline(path);
+	assert_persistent_reopen_matches(path, baseline);
+	assert_persistent_reopen_matches(path, baseline);
+}
+
+struct NormalizedScenario
+{
+	std::vector<NormalizedExecutionEvent> boolean_trace;
+	std::vector<NormalizedExecutionEvent> call_trace;
+	std::vector<NormalizedExecutionEvent> failure_trace;
+
+	bool operator==(const NormalizedScenario &) const = default;
+};
+
+NormalizedScenario capture_normalized_scenario(avm::LinkStore &store)
+{
+	avm::BootstrapRuntime runtime(store);
+	const ScenarioProgram program = build_scenario(store, runtime);
+
+	static_cast<void>(runtime.execute(program.call_root));
+	const std::size_t converged_size = store.size();
+
+	avm::BoundedExecutionTrace boolean_trace(128);
+	runtime.executor().set_observer(&boolean_trace);
+	assert(runtime.execute(program.boolean_root) == program.expected_result);
+	assert(store.size() == converged_size);
+
+	avm::BoundedExecutionTrace call_trace(128);
+	runtime.executor().set_observer(&call_trace);
+	assert(runtime.execute(program.call_root) == program.expected_result);
+	assert(store.size() == converged_size);
+
+	avm::BoundedExecutionTrace failure_trace(128);
+	runtime.executor().set_observer(&failure_trace);
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(program.failure_root));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == converged_size);
+	runtime.executor().set_observer(nullptr);
+
+	return NormalizedScenario{
+	    normalize_trace(boolean_trace),
+	    normalize_trace(call_trace),
+	    normalize_trace(failure_trace),
+	};
+}
+
+void verify_independent_backends_match_modulo_opaque_link_id_renaming()
+{
+	avm::InMemoryLinkStore memory_store;
+	const NormalizedScenario memory = capture_normalized_scenario(memory_store);
+
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	avm::PersistentLinkStore persistent_store(path);
+	const NormalizedScenario persistent = capture_normalized_scenario(persistent_store);
+
+	assert(memory == persistent);
+}
+
+void verify_normalization_rejects_truncated_trace()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const ScenarioProgram program = build_scenario(store, runtime);
+	avm::BoundedExecutionTrace trace(1);
+	runtime.executor().set_observer(&trace);
+	static_cast<void>(runtime.execute(program.boolean_root));
+	assert(trace.truncated());
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(normalize_trace(trace));
+	}
+	catch (const std::invalid_argument &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+}
+
+} // namespace
+
+int main()
+{
+	verify_persistent_trace_identity_survives_multiple_reopens();
+	verify_independent_backends_match_modulo_opaque_link_id_renaming();
+	verify_normalization_rejects_truncated_trace();
+	return 0;
+}


### PR DESCRIPTION
Closes #102. Parent #95. Depends on merged #101.

## Purpose
Prove the AVM 1.3 observation contract across persistence/reopen and replaceable LinkStore backends without weakening opaque `LinkId` semantics.

This PR intentionally changes no `include/avm` or `src` production semantics. It adds conformance, build/CI wiring and documentation only.

## Two distinct identity claims
Raw numeric LinkIds are not a global cross-store namespace. Therefore conformance uses two intentionally different comparison rules.

### Same persistent logical store after reopen
`PersistentLinkStore` preserves its LinkIds. After link-native function binding/frame state is converged, the same stored program and explicit `BootstrapVocabulary` must produce exactly the same complete `ExecutionEvent` sequence after close/reopen, including every numeric LinkId field.

The test captures baseline traces for:
- nested read-only Boolean execution;
- a converged link-native function call;
- deterministic `Fail(Dispatch)` execution.

It then reopens the same store twice and requires exact event equality, exact result identity and no store growth.

### Independent InMemory vs Persistent stores
Equivalent independently constructed stores may choose different numeric LinkIds. Their traces are compared modulo canonical first-occurrence renaming instead of raw numeric equality.

The test-only normalizer visits every event in order and every LinkId-bearing field in fixed order:

```text
entity, relation, subject, object, parent, frame, result
```

Each observed LinkId receives a local ordinal at first occurrence and reuses that ordinal thereafter. `nullopt`, event kind and failure phase remain exact. This preserves equality/aliasing topology while discarding backend-local numeric allocation choices.

The normalizer is conformance tooling only: it is not a production identity registry, serialization format or public semantic layer.

## Completeness rule
Only complete `BoundedExecutionTrace` instances are eligible for equivalence claims. The normalizer explicitly rejects a truncated trace.

## Scenarios and effect accounting
Before baseline capture, the function call executes once so canonical binding/call-frame links converge. Captured runs must then be observational with respect to store size.

The conformance checks:
- exact persistent baseline == first reopen == second reopen;
- runtime construction from the persisted vocabulary does not grow the store;
- converged function trace remains exact across reopen;
- failure phase remains exact across reopen;
- InMemory/Persistent normalized Boolean/call/failure traces match;
- truncated trace normalization is rejected.

## Architecture vetoes
- no new LinkStore method/index;
- no persistence-format change;
- no global LinkId namespace claim;
- no new ExecutionEvent field or native relation;
- no production normalization registry;
- no trace persistence side-channel.

## CI
`execution_trace_persistence_test` joins the core aggregate, so it runs under strict warnings-as-errors, ASan+UBSan and portable Linux/Windows/macOS. Existing installed-package validation remains unchanged and must stay green.

Docs now explicitly state the exact-vs-renamed equivalence rule and the roadmap advances Gate 17 to this PR.