### PR TITLE
AVM 1.3: add trace-enabled CLI over canonical executor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,15 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce trace CLI remains a consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E 'TraceExecutor|DebugExecutor|register_native[[:space:]]*\(|register_handler[[:space:]]*\(' src/cli.cpp; then
+            echo "ERROR: trace CLI must consume the canonical runtime/observer path, not define execution semantics"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ if(AVM_BUILD_CLI)
     avm_add_trace_cli_test(cli_trace_truncate truncate "${TEST_DIR}/trace_boolean.json")
     avm_add_trace_cli_test(cli_trace_failure failure "${TEST_DIR}/trace_failure.json")
     avm_add_trace_cli_test(cli_trace_nonexpression nonexpression "${TEST_DIR}/true.json")
+    avm_add_trace_cli_test(cli_trace_badlimit badlimit "${TEST_DIR}/trace_boolean.json")
 endif()
 
 if(AVM_BUILD_CORE_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,25 @@ if(AVM_BUILD_CLI)
                 -DTEST_DIR=${TEST_DIR}
                 -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.cmake")
     endforeach()
+
+    function(avm_add_trace_cli_test test_name test_case test_file)
+        add_test(
+            NAME ${test_name}
+            COMMAND ${CMAKE_COMMAND}
+                -DAVM_EXECUTABLE=$<TARGET_FILE:avm>
+                -DTEST_DIR=${TEST_DIR}
+                -DCASE=${test_case}
+                -DTEST_FILE=${test_file}
+                -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_trace_cli_test.cmake")
+    endfunction()
+
+    avm_add_trace_cli_test(cli_usage usage "")
+    avm_add_trace_cli_test(cli_trace_legacy legacy "${TEST_DIR}/trace_boolean.json")
+    avm_add_trace_cli_test(cli_trace_success success "${TEST_DIR}/trace_boolean.json")
+    avm_add_trace_cli_test(cli_trace_function function "${TEST_DIR}/trace_function.json")
+    avm_add_trace_cli_test(cli_trace_truncate truncate "${TEST_DIR}/trace_boolean.json")
+    avm_add_trace_cli_test(cli_trace_failure failure "${TEST_DIR}/trace_failure.json")
+    avm_add_trace_cli_test(cli_trace_nonexpression nonexpression "${TEST_DIR}/true.json")
 endif()
 
 if(AVM_BUILD_CORE_TESTS)

--- a/README.md
+++ b/README.md
@@ -98,11 +98,23 @@ See [Structural standard library](docs/structural-standard-library.md).
 
 ## AVM 1.3 — execution observability
 
-AVM 1.3 begins with an optional deterministic observer attached to the existing `Executor::execute` path. It emits immutable `Enter`, `Return` and `Fail` events containing only canonical `ExecutionContext`/`LinkId` data.
+AVM 1.3 adds deterministic, non-controlling observation to the existing `Executor::execute` path. `ExecutionEvent` uses only canonical AVM data: `Enter`, `Return` and `Fail`, the decoded `ExecutionContext`, optional result `LinkId`, and a finite failure phase (`Dispatch`, `Handler`, `ResultValidation`).
 
-Observers cannot replace handlers, skip execution or substitute results. Observer exceptions are isolated from program control flow, and observation itself does not materialize links. Nested calls are observed through the same executor path, including explicit parent/frame identities.
+Observers cannot replace handlers, skip execution or substitute results. Observer exceptions are isolated from program control flow, and observation itself does not materialize links. Nested calls and failure unwind are observed through the same executor recursion, including explicit parent/frame identities.
 
-This is the boundary for future debugger/REPL tooling; no traced executor, JSON opcode trace or second program representation is introduced.
+`BoundedExecutionTrace` is the reusable public host-memory collector. It reserves a configured event capacity before normal execution, exposes immutable events, reports truncation explicitly, and never becomes `Executor` or `LinkStore` semantic state.
+
+Persistence conformance distinguishes two identity claims: the same `PersistentLinkStore` must produce exactly identical LinkId-based traces after reopen, while independently constructed backends are compared only modulo bijective renaming of opaque LinkIds. AVM never treats raw numeric LinkIds as globally comparable across stores.
+
+The CLI is a real consumer of the same public observation boundary:
+
+```text
+avm program.json
+avm --trace program.json
+avm --trace-limit 64 program.json
+```
+
+Normal mode preserves the compatibility behavior. Trace mode uses the existing `JsonProgramImporter`, the same `BootstrapRuntime::execute(LinkId)` path and existing JSON result projection; it merely attaches `BoundedExecutionTrace` and renders the retained events. Text labels are tooling presentation, not string opcodes or canonical trace identity. Failing executions render retained `Fail(phase)` events before the normal host diagnostic, and trace truncation is never silent.
 
 See [Execution observability contract](docs/execution-observability.md).
 
@@ -179,7 +191,7 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-CI installs the package into a staging prefix and builds an external consumer on Linux, Windows and macOS using only `find_package` and `avm::core`.
+CI installs the package into a staging prefix and builds an external consumer on Linux, Windows and macOS using only `find_package` and `avm::core`. The full portable matrix also runs the trace-enabled CLI conformance cases.
 
 ## Architecture documents
 
@@ -197,7 +209,7 @@ CI installs the package into a staging prefix and builds an external consumer on
 
 ## Project status
 
-AVM 1.0 foundation, AVM 1.1 read-only queries and AVM 1.2 structural standard-library gates are complete. AVM 1.3 is introducing deterministic non-controlling execution observation as the prerequisite for debugger/REPL tooling without creating a second execution path.
+AVM 1.0 foundation, AVM 1.1 read-only queries and AVM 1.2 structural standard-library gates are complete. AVM 1.3 provides deterministic observation, failure-phase classification, bounded trace collection, persistence/backend conformance and trace-enabled CLI tooling while preserving the single `LinkStore -> Relations Model -> Executor` execution path.
 
 ## Dependencies
 

--- a/cmake/run_trace_cli_test.cmake
+++ b/cmake/run_trace_cli_test.cmake
@@ -1,0 +1,124 @@
+# AVM trace CLI conformance harness.
+# Required:
+#   AVM_EXECUTABLE
+#   TEST_DIR
+#   CASE = usage | legacy | success | function | truncate | failure | nonexpression
+# TEST_FILE is required for all cases except usage.
+
+if(NOT DEFINED AVM_EXECUTABLE OR NOT DEFINED TEST_DIR OR NOT DEFINED CASE)
+    message(FATAL_ERROR "AVM_EXECUTABLE, TEST_DIR and CASE are required")
+endif()
+
+set(RES_FILE "${TEST_DIR}/res.json")
+set(DUMP_FILE "${TEST_DIR}/rvm.dump.json")
+file(REMOVE "${RES_FILE}" "${DUMP_FILE}")
+
+if(CASE STREQUAL "usage")
+    execute_process(
+        COMMAND "${AVM_EXECUTABLE}"
+        WORKING_DIRECTORY "${TEST_DIR}"
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE OUTPUT
+        ERROR_VARIABLE ERROR_OUTPUT)
+elseif(CASE STREQUAL "legacy")
+    execute_process(
+        COMMAND "${AVM_EXECUTABLE}" "${TEST_FILE}"
+        WORKING_DIRECTORY "${TEST_DIR}"
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE OUTPUT
+        ERROR_VARIABLE ERROR_OUTPUT)
+elseif(CASE STREQUAL "truncate")
+    execute_process(
+        COMMAND "${AVM_EXECUTABLE}" --trace-limit 1 "${TEST_FILE}"
+        WORKING_DIRECTORY "${TEST_DIR}"
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE OUTPUT
+        ERROR_VARIABLE ERROR_OUTPUT)
+else()
+    execute_process(
+        COMMAND "${AVM_EXECUTABLE}" --trace "${TEST_FILE}"
+        WORKING_DIRECTORY "${TEST_DIR}"
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE OUTPUT
+        ERROR_VARIABLE ERROR_OUTPUT)
+endif()
+
+if(CASE STREQUAL "usage")
+    if(NOT RESULT EQUAL 0)
+        message(FATAL_ERROR "usage command failed: ${RESULT}\n${ERROR_OUTPUT}")
+    endif()
+    string(FIND "${OUTPUT}" "Associative Virtual Machine [Version 1.3.0]" VERSION_POS)
+    if(VERSION_POS EQUAL -1)
+        message(FATAL_ERROR "usage banner does not expose AVM 1.3.0:\n${OUTPUT}")
+    endif()
+    string(FIND "${OUTPUT}" "avm --trace <entry_point>" TRACE_USAGE_POS)
+    if(TRACE_USAGE_POS EQUAL -1)
+        message(FATAL_ERROR "usage banner does not document trace mode:\n${OUTPUT}")
+    endif()
+    return()
+endif()
+
+if(CASE STREQUAL "failure" OR CASE STREQUAL "nonexpression")
+    if(RESULT EQUAL 0)
+        message(FATAL_ERROR "${CASE} unexpectedly succeeded\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
+    endif()
+    if(EXISTS "${RES_FILE}")
+        message(FATAL_ERROR "${CASE} unexpectedly produced res.json")
+    endif()
+else()
+    if(NOT RESULT EQUAL 0)
+        message(FATAL_ERROR "${CASE} failed: ${RESULT}\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
+    endif()
+    if(NOT EXISTS "${RES_FILE}")
+        message(FATAL_ERROR "${CASE} did not produce res.json")
+    endif()
+    file(READ "${RES_FILE}" ACTUAL_RESULT)
+    string(STRIP "${ACTUAL_RESULT}" ACTUAL_RESULT)
+    if(NOT "${ACTUAL_RESULT}" STREQUAL "true")
+        message(FATAL_ERROR "${CASE} expected res.json=true, got: ${ACTUAL_RESULT}")
+    endif()
+endif()
+
+if(CASE STREQUAL "legacy")
+    string(FIND "${OUTPUT}" "trace events=" TRACE_POS)
+    if(NOT TRACE_POS EQUAL -1)
+        message(FATAL_ERROR "legacy mode unexpectedly printed trace output:\n${OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "success")
+    string(FIND "${OUTPUT}" "enter entity=" ENTER_POS)
+    string(FIND "${OUTPUT}" "return entity=" RETURN_POS)
+    string(FIND "${OUTPUT}" "trace events=8 complete=true truncated=false" SUMMARY_POS)
+    if(ENTER_POS EQUAL -1 OR RETURN_POS EQUAL -1 OR SUMMARY_POS EQUAL -1)
+        message(FATAL_ERROR "successful trace output is incomplete:\n${OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "function")
+    string(REGEX MATCH "frame=[0-9]+" FRAME_MATCH "${OUTPUT}")
+    string(FIND "${OUTPUT}" "trace events=" SUMMARY_POS)
+    string(FIND "${OUTPUT}" "complete=true truncated=false" COMPLETE_POS)
+    if("${FRAME_MATCH}" STREQUAL "" OR SUMMARY_POS EQUAL -1 OR COMPLETE_POS EQUAL -1)
+        message(FATAL_ERROR "function trace did not expose a frame-bearing complete trace:\n${OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "truncate")
+    string(FIND "${OUTPUT}" "trace events=1 complete=false truncated=true" SUMMARY_POS)
+    if(SUMMARY_POS EQUAL -1)
+        message(FATAL_ERROR "trace truncation was not reported explicitly:\n${OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "failure")
+    string(FIND "${OUTPUT}" "fail entity=" FAIL_POS)
+    string(FIND "${OUTPUT}" "phase=handler" PHASE_POS)
+    string(FIND "${OUTPUT}" "complete=true truncated=false" COMPLETE_POS)
+    string(FIND "${ERROR_OUTPUT}" "undefined function handle" ERROR_POS)
+    if(FAIL_POS EQUAL -1 OR PHASE_POS EQUAL -1 OR COMPLETE_POS EQUAL -1 OR ERROR_POS EQUAL -1)
+        message(FATAL_ERROR "failure trace/diagnostic mismatch:\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "nonexpression")
+    string(FIND "${OUTPUT}" "trace events=" TRACE_POS)
+    string(FIND "${ERROR_OUTPUT}" "--trace requires an executable JSON compatibility expression" ERROR_POS)
+    if(NOT TRACE_POS EQUAL -1 OR ERROR_POS EQUAL -1)
+        message(FATAL_ERROR "non-expression trace rejection mismatch:\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
+    endif()
+else()
+    message(FATAL_ERROR "unknown trace CLI test CASE: ${CASE}")
+endif()
+
+file(REMOVE "${RES_FILE}" "${DUMP_FILE}")

--- a/cmake/run_trace_cli_test.cmake
+++ b/cmake/run_trace_cli_test.cmake
@@ -2,7 +2,7 @@
 # Required:
 #   AVM_EXECUTABLE
 #   TEST_DIR
-#   CASE = usage | legacy | success | function | truncate | failure | nonexpression
+#   CASE = usage | legacy | success | function | truncate | failure | nonexpression | badlimit
 # TEST_FILE is required for all cases except usage.
 
 if(NOT DEFINED AVM_EXECUTABLE OR NOT DEFINED TEST_DIR OR NOT DEFINED CASE)
@@ -34,6 +34,13 @@ elseif(CASE STREQUAL "truncate")
         RESULT_VARIABLE RESULT
         OUTPUT_VARIABLE OUTPUT
         ERROR_VARIABLE ERROR_OUTPUT)
+elseif(CASE STREQUAL "badlimit")
+    execute_process(
+        COMMAND "${AVM_EXECUTABLE}" --trace-limit nope "${TEST_FILE}"
+        WORKING_DIRECTORY "${TEST_DIR}"
+        RESULT_VARIABLE RESULT
+        OUTPUT_VARIABLE OUTPUT
+        ERROR_VARIABLE ERROR_OUTPUT)
 else()
     execute_process(
         COMMAND "${AVM_EXECUTABLE}" --trace "${TEST_FILE}"
@@ -58,7 +65,7 @@ if(CASE STREQUAL "usage")
     return()
 endif()
 
-if(CASE STREQUAL "failure" OR CASE STREQUAL "nonexpression")
+if(CASE STREQUAL "failure" OR CASE STREQUAL "nonexpression" OR CASE STREQUAL "badlimit")
     if(RESULT EQUAL 0)
         message(FATAL_ERROR "${CASE} unexpectedly succeeded\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
     endif()
@@ -116,6 +123,12 @@ elseif(CASE STREQUAL "nonexpression")
     string(FIND "${ERROR_OUTPUT}" "--trace requires an executable JSON compatibility expression" ERROR_POS)
     if(NOT TRACE_POS EQUAL -1 OR ERROR_POS EQUAL -1)
         message(FATAL_ERROR "non-expression trace rejection mismatch:\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
+    endif()
+elseif(CASE STREQUAL "badlimit")
+    string(FIND "${OUTPUT}" "trace events=" TRACE_POS)
+    string(FIND "${ERROR_OUTPUT}" "trace limit must be a non-negative integer" ERROR_POS)
+    if(NOT TRACE_POS EQUAL -1 OR ERROR_POS EQUAL -1)
+        message(FATAL_ERROR "invalid trace-limit handling mismatch:\nstdout:\n${OUTPUT}\nstderr:\n${ERROR_OUTPUT}")
     endif()
 else()
     message(FATAL_ERROR "unknown trace CLI test CASE: ${CASE}")

--- a/docs/execution-observability.md
+++ b/docs/execution-observability.md
@@ -165,11 +165,48 @@ This normalization preserves equality/aliasing relationships while discarding ba
 
 A truncated trace is not eligible for an equivalence claim: it represents only a retained prefix, so normalization/comparison must reject it or otherwise explicitly decline completeness.
 
+## Trace-enabled CLI consumer
+
+The repository CLI is the first user-facing consumer of the AVM 1.3 observability boundary. Its normal compatibility mode remains unchanged:
+
+```text
+avm program.json
+```
+
+Trace mode is explicit:
+
+```text
+avm --trace program.json
+avm --trace-limit 64 program.json
+```
+
+The execution path is still the existing JSON compatibility projection and canonical runtime:
+
+```text
+JSON input
+  -> JsonProgramImporter
+  -> LinkId program
+  -> attach BoundedExecutionTrace to JsonCompatibilitySession::runtime().executor()
+  -> BootstrapRuntime::execute(LinkId)
+  -> result LinkId
+  -> existing JSON result projection
+```
+
+There is no `TraceExecutor`, copied evaluator or trace-specific opcode dispatch. JSON is a frontend format only; the trace collector sees the same `ExecutionEvent` values that any core observer sees.
+
+CLI trace rendering is presentation, not semantic identity. Each line displays the event kind and numeric LinkId fields (`entity`, `relation`, `subject`, `object`, optional `parent`, `frame`, `result`) plus the AVM failure phase. Human labels such as `enter`, `return`, `handler` or `dispatch` are textual renderings of the enums, not execution opcodes.
+
+The final summary reports retained event count and `complete`/`truncated` status. `--trace-limit` exists so resource bounds are explicit rather than silently dropping events.
+
+Trace mode intentionally uses `import_program` + `execute` + `project_result` instead of the convenience `interpret()` wrapper. This allows a failing execution to render its retained `Fail(phase)` events and still propagate the original failure to the CLI top-level diagnostic/exit-status policy. Normal compatibility mode continues to use `interpret()` and therefore keeps its historical behavior.
+
+A non-expression JSON value is valid in normal roundtrip mode but rejected explicitly in trace mode because there is no execution context to observe. AVM does not fabricate execution events for value serialization.
+
 ## Diagnostics policy
 
 The deterministic trace contract intentionally stops at AVM-owned failure phase. Human-readable exception text remains runtime diagnostic information, not stable event identity. C++ exception type names, `std::exception_ptr`, stack addresses and backend/protocol errors are not stored in `ExecutionEvent`.
 
-A later debugger/REPL layer may display the exception it catches alongside the deterministic trace, but it must not reinterpret that host diagnostic as canonical AVM semantics.
+The CLI may display the host exception it catches alongside the deterministic trace, but it does not reinterpret that host diagnostic as canonical AVM semantics.
 
 ## Non-goals
 
@@ -184,7 +221,7 @@ AVM 1.3 observability does not provide:
 - exception objects or exception strings inside deterministic events;
 - globally comparable numeric LinkIds across independent stores;
 - a production trace-normalization identity registry;
-- JSON/Anum-specific trace events;
-- debugger UI or REPL commands.
+- JSON/Anum-specific canonical trace events;
+- an interactive debugger UI or REPL command language.
 
 Those facilities may consume the observer boundary later, but they must not become a second execution path.

--- a/plan.md
+++ b/plan.md
@@ -260,9 +260,9 @@ Properties:
 - installed public package uses the collector on Linux/Windows/macOS;
 - strict warnings, ASan+UBSan and portable matrix are green.
 
-### Gate 17 — persistent reopen and backend-neutral trace equivalence (current)
+### Gate 17 — persistent reopen and backend-neutral trace equivalence ✅
 
-Child: #102.
+Implemented through #102/#103.
 
 Two identity claims are intentionally distinct:
 
@@ -274,33 +274,60 @@ independent InMemory/Persistent stores
   -> equivalence modulo bijective renaming of opaque LinkIds
 ```
 
-Requirements:
+Properties:
 
-- converge link-native function binding/frame state before baseline capture;
+- link-native function binding/frame state is converged before baseline capture;
 - persistent close/reopen preserves exact success/failure traces and store size;
 - repeated reopen remains exact and idempotent;
 - backend-neutral comparison preserves equality/aliasing relationships across every LinkId-bearing field;
-- normalization uses deterministic first-occurrence ordinals only as test/conformance tooling;
+- deterministic first-occurrence normalization exists only as test/conformance tooling;
 - raw LinkId numbers are never treated as globally comparable across independent stores;
 - failure phases and event kinds remain exact under normalized comparison;
 - truncated traces are rejected from completeness/equivalence claims;
 - no new LinkStore API/index, persistence format, event field or semantic registry.
 
-### Gate 18 — debugger/REPL consumer
+### Gate 18 — trace-enabled CLI consumer (current)
 
-After Gate 17 is stable, build an actual tooling consumer on the public observer/collector boundary without forking `Executor` or introducing a second program representation.
+Child: #104.
 
-The first consumer should prove that trace inspection, failure presentation and basic execution tooling can be implemented entirely outside semantic state. Breakpoint/control semantics remain a separate design question and are not implied merely by observability.
+Use the already existing JSON compatibility frontend and public AVM 1.3 observation API to provide a real tooling consumer without forking execution:
+
+```text
+JSON input
+  -> existing JsonProgramImporter
+  -> LinkId root
+  -> attach BoundedExecutionTrace to the existing BootstrapRuntime/Executor
+  -> execute(root)
+  -> result LinkId
+  -> existing JSON result projection
+  -> tooling-only trace presentation
+```
+
+Requirements:
+
+- legacy `avm program.json` behavior remains unchanged;
+- explicit `--trace` mode prints ordered LinkId-based events;
+- explicit bounded trace limit reports truncation rather than silently dropping events;
+- function execution exposes frame-bearing events;
+- failures render retained `Fail(phase)` events and preserve failure exit status/host diagnostics;
+- non-expression JSON remains valid in normal value-roundtrip mode but is rejected in trace mode rather than receiving fabricated execution events;
+- textual event/phase labels are presentation only, not opcodes or canonical trace identity;
+- CLI uses the existing `JsonProgramImporter`, `BootstrapRuntime::execute` and JSON result projection rather than copied evaluator logic;
+- stale hard-coded CLI version banner is replaced by the AVM 1.3 public version contract;
+- CTest validates trace CLI behavior in the strict CLI lane and portable Linux/Windows/macOS builds.
+
+Completion of this gate closes AVM 1.3 observability: observer, failure taxonomy, bounded collector, persistence/backend conformance and an actual tooling consumer all share the single canonical execution path.
 
 ## Later AVM 1.x directions
 
 After the observability boundary:
 
-1. additional thin protocol/front-end adapters;
-2. packaging/integration tooling;
-3. visualization/GUI;
-4. production physical backends and persistence experiments;
-5. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
+1. interactive debugger/REPL control semantics, if needed, as a separate design problem;
+2. additional thin protocol/front-end adapters;
+3. packaging/integration tooling;
+4. visualization/GUI;
+5. production physical backends and persistence experiments;
+6. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
 
 Every extension must reuse the existing `LinkStore -> Relations Model -> Executor` architecture.
 

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -10,6 +10,7 @@
 #include <stdexcept>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 namespace
 {
@@ -186,16 +187,16 @@ void print_usage()
 
 int main(int argc, char *argv[])
 {
-	const std::optional<CliOptions> options = parse_options(argc, argv);
-	if (!options)
-	{
-		print_usage();
-		return 0;
-	}
-
 	Json root;
 	try
 	{
+		const std::optional<CliOptions> options = parse_options(argc, argv);
+		if (!options)
+		{
+			print_usage();
+			return 0;
+		}
+
 		get_json(root, options->path);
 
 		Json result;

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -1,8 +1,12 @@
+#include "avm/execution_trace.h"
 #include "avm/json_compat.h"
 #include "avm/json_value_codec.h"
+#include "avm/version.h"
 
+#include <charconv>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -11,6 +15,15 @@ namespace
 {
 
 using Json = nlohmann::json;
+
+constexpr std::size_t default_trace_limit = 256;
+
+struct CliOptions
+{
+	std::string path;
+	bool trace = false;
+	std::size_t trace_limit = default_trace_limit;
+};
 
 void get_json(Json &value, const std::string &path)
 {
@@ -51,21 +64,130 @@ Json roundtrip_value(const Json &root)
 	return codec.decode(codec.encode(root));
 }
 
+std::size_t parse_trace_limit(std::string_view text)
+{
+	std::size_t value = 0;
+	const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+	if (error != std::errc{} || end != text.data() + text.size())
+		throw std::invalid_argument("trace limit must be a non-negative integer");
+	return value;
+}
+
+std::optional<CliOptions> parse_options(int argc, char *argv[])
+{
+	if (argc == 2)
+		return CliOptions{argv[1], false, default_trace_limit};
+
+	if (argc == 3 && std::string_view(argv[1]) == "--trace")
+		return CliOptions{argv[2], true, default_trace_limit};
+
+	if (argc == 4 && std::string_view(argv[1]) == "--trace-limit")
+		return CliOptions{argv[3], true, parse_trace_limit(argv[2])};
+
+	return std::nullopt;
+}
+
+const char *event_kind_name(avm::ExecutionEventKind kind)
+{
+	switch (kind)
+	{
+	case avm::ExecutionEventKind::Enter:
+		return "enter";
+	case avm::ExecutionEventKind::Return:
+		return "return";
+	case avm::ExecutionEventKind::Fail:
+		return "fail";
+	}
+	return "unknown";
+}
+
+const char *failure_phase_name(std::optional<avm::ExecutionFailurePhase> phase)
+{
+	if (!phase)
+		return "-";
+
+	switch (*phase)
+	{
+	case avm::ExecutionFailurePhase::Dispatch:
+		return "dispatch";
+	case avm::ExecutionFailurePhase::Handler:
+		return "handler";
+	case avm::ExecutionFailurePhase::ResultValidation:
+		return "result-validation";
+	}
+	return "unknown";
+}
+
+void print_optional_link(std::optional<avm::LinkId> id)
+{
+	if (id)
+		std::cout << *id;
+	else
+		std::cout << '-';
+}
+
+void print_trace(const avm::BoundedExecutionTrace &trace)
+{
+	for (const avm::ExecutionEvent &event : trace.events())
+	{
+		std::cout << event_kind_name(event.kind) << " entity=" << event.context.entity
+		          << " relation=" << event.context.relation << " subject=" << event.context.subject
+		          << " object=" << event.context.object << " parent=";
+		print_optional_link(event.context.parent);
+		std::cout << " frame=";
+		print_optional_link(event.context.frame);
+		std::cout << " result=";
+		print_optional_link(event.result);
+		std::cout << " phase=" << failure_phase_name(event.failure_phase) << '\n';
+	}
+
+	std::cout << "trace events=" << trace.size() << " complete=" << (trace.complete() ? "true" : "false")
+	          << " truncated=" << (trace.truncated() ? "true" : "false") << '\n';
+}
+
+Json execute_traced(const Json &root, std::size_t trace_limit)
+{
+	if (!is_expression_candidate(root))
+		throw std::invalid_argument("--trace requires an executable JSON compatibility expression");
+
+	avm::JsonCompatibilitySession session;
+	const avm::LinkId program = session.import_program(root);
+	avm::BoundedExecutionTrace trace(trace_limit);
+	session.runtime().executor().set_observer(&trace);
+
+	avm::LinkId result = avm::invalid_link_id;
+	try
+	{
+		result = session.execute(program);
+	}
+	catch (...)
+	{
+		session.runtime().executor().set_observer(nullptr);
+		print_trace(trace);
+		throw;
+	}
+
+	session.runtime().executor().set_observer(nullptr);
+	print_trace(trace);
+	return session.project_result(result);
+}
+
 void print_usage()
 {
-	std::cout << R"(https://github.com/netkeep80/avm
-     Associative Virtual Machine [Version 0.0.5]
-
-Usage:
-       avm [entry_point]
-)";
+	std::cout << "https://github.com/netkeep80/avm\n"
+	          << "     Associative Virtual Machine [Version " << avm::version_string << "]\n\n"
+	          << "Usage:\n"
+	          << "       avm <entry_point>\n"
+	          << "       avm --trace <entry_point>\n"
+	          << "       avm --trace-limit <events> <entry_point>\n";
 }
 
 } // namespace
 
 int main(int argc, char *argv[])
 {
-	if (argc != 2)
+	const std::optional<CliOptions> options = parse_options(argc, argv);
+	if (!options)
 	{
 		print_usage();
 		return 0;
@@ -74,10 +196,14 @@ int main(int argc, char *argv[])
 	Json root;
 	try
 	{
-		get_json(root, argv[1]);
+		get_json(root, options->path);
 
 		Json result;
-		if (is_expression_candidate(root))
+		if (options->trace)
+		{
+			result = execute_traced(root, options->trace_limit);
+		}
+		else if (is_expression_candidate(root))
 		{
 			avm::JsonCompatibilitySession session;
 			result = session.interpret(root);

--- a/test/trace_boolean.json
+++ b/test/trace_boolean.json
@@ -1,0 +1,1 @@
+{"And":[true,{"Not":[false]}]}

--- a/test/trace_failure.json
+++ b/test/trace_failure.json
@@ -1,0 +1,1 @@
+{"Call":["missing",true]}

--- a/test/trace_function.json
+++ b/test/trace_function.json
@@ -1,0 +1,1 @@
+[{"Def":["identity",["x"],"x"]},{"Call":["identity",true]}]


### PR DESCRIPTION
Closes #104. Parent #95. Depends on merged #103.

## User-facing tooling
Adds explicit trace modes to the existing AVM CLI while preserving normal compatibility behavior:

```text
avm program.json
avm --trace program.json
avm --trace-limit N program.json
```

The stale hard-coded CLI version banner is replaced by the public `avm::version_string` contract (1.3.0).

## No execution fork
Normal mode remains unchanged: executable JSON still uses `JsonCompatibilitySession::interpret`, while non-expression JSON uses the existing value roundtrip codec.

Trace mode intentionally uses the lower-level pieces of the same compatibility/runtime path:

```text
JSON
-> JsonProgramImporter / JsonCompatibilitySession::import_program
-> LinkId root
-> attach BoundedExecutionTrace to session.runtime().executor()
-> BootstrapRuntime::execute(root)
-> result LinkId
-> existing project_result
```

There is no `TraceExecutor`, `DebugExecutor`, copied evaluator, string-opcode dispatch table or second program representation.

## Trace presentation
Each retained event is rendered in execution order with:
- event kind;
- numeric `entity/relation/subject/object` LinkIds;
- optional parent/frame/result LinkIds;
- deterministic AVM failure phase.

The textual labels (`enter`, `return`, `fail`, `handler`, etc.) are presentation only; canonical trace identity remains the public enums/LinkIds.

A final summary reports `events`, `complete` and `truncated`. The default bound is 256 events and `--trace-limit N` exposes the resource bound explicitly.

## Failure behavior
Trace mode bypasses only the convenience `interpret()` error-to-null wrapper, not the semantic runtime. This lets a real execution failure render retained `Fail(phase)` events and then propagate the original error to the existing CLI top-level diagnostic/exit-status policy.

A non-expression JSON value remains valid in normal roundtrip mode but is rejected in trace mode because there is no execution context to observe; no fake events are synthesized.

Malformed `--trace-limit` is routed through the same CLI error policy and returns a normal non-zero diagnostic instead of escaping as an uncaught exception.

## CTest conformance
New portable CLI cases cover:
- usage banner and AVM 1.3 version;
- legacy mode unchanged/no trace output;
- successful nested Boolean trace and unchanged `res.json`;
- function call with frame-bearing events;
- explicit trace truncation;
- failing undefined function call with `Fail(Handler)` plus non-zero exit/host diagnostic;
- non-expression trace rejection;
- invalid trace-limit handling.

These cases are registered under `AVM_BUILD_CLI`, so the strict CLI job and full Linux/Windows/macOS portable matrix execute them.

## Vetoes
- no changes to `include/avm`, Executor, LinkStore, observer or persistence contracts;
- no trace persistence into links/files;
- no breakpoint/step/result-substitution semantics;
- no canonical string opcode/name trace data;
- no silent truncation.

Merging this fully green gate completes epic #95 / AVM 1.3 observability.