### PR TITLE
AVM 1.4: add typed inspection session over canonical APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
               echo "ERROR: $file has $lines lines (max: $MAX_LINES)"
               FAILED=1
             fi
-          done < <(find src include adapters -type f \( -name '*.cpp' -o -name '*.h' \) -print)
+          done < <(find src include adapters tools -type f \( -name '*.cpp' -o -name '*.h' \) -print)
           if [ "$FAILED" -ne 0 ]; then
             exit 1
           fi
@@ -161,6 +161,19 @@ jobs:
             exit 1
           fi
 
+      - name: Enforce inspection session tooling isolation
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -n -E '(intern|create_point|register_native|register_handler)[[:space:]]*\(|PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num|[Aa]bit' tools/inspection_session.h; then
+            echo "ERROR: inspection session must compose existing neutral APIs without defining storage/protocol semantics"
+            exit 1
+          fi
+          if grep -n -E 'DebugExecutor|ShellExecutor|TraceExecutor' tools/inspection_session.h; then
+            echo "ERROR: inspection tooling must reuse BootstrapRuntime/Executor rather than fork execution"
+            exit 1
+          fi
+
       - name: Verify public version contract
         shell: bash
         run: |
@@ -187,32 +200,10 @@ jobs:
           clang-format --version
           clang-format --dry-run --Werror \
             include/avm/*.h \
-            adapters/anum_denotation_bridge.h \
-            src/cli.cpp \
-            test/assertions_enabled_test.cpp \
-            test/link_store_test.cpp \
-            test/relations_model_test.cpp \
-            test/relations_query_test.cpp \
-            test/executor_test.cpp \
-            test/execution_observer_test.cpp \
-            test/execution_trace_test.cpp \
-            test/execution_trace_persistence_test.cpp \
-            test/program_model_test.cpp \
-            test/boolean_runtime_test.cpp \
-            test/structural_runtime_test.cpp \
-            test/structural_library_test.cpp \
-            test/function_runtime_test.cpp \
-            test/frame_runtime_test.cpp \
-            test/deferred_definition_test.cpp \
-            test/projection_test.cpp \
-            test/raw_carrier_test.cpp \
-            test/protocol_adapter_boundary_test.cpp \
-            test/persistent_link_store_test.cpp \
-            test/vertical_slice_test.cpp \
-            test/json_value_codec_test.cpp \
-            test/json_projection_test.cpp \
-            test/json_session_test.cpp \
-            test/anum_denotation_bridge_test.cpp \
+            adapters/*.h \
+            tools/*.h \
+            src/*.cpp \
+            test/*.cpp \
             test/package_consumer/main.cpp
 
   core:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if(AVM_BUILD_CLI)
             NAME "json_roundtrip_${TEST_FILE}"
             COMMAND ${CMAKE_COMMAND}
                 -DAVM_EXECUTABLE=$<TARGET_FILE:avm>
-                -DTEST_FILE=${TEST_DIR}/${TEST_FILE>
+                -DTEST_FILE=${TEST_DIR}/${TEST_FILE}
                 -DTEST_DIR=${TEST_DIR}
                 -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.cmake")
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ if(AVM_BUILD_CLI)
             NAME "json_roundtrip_${TEST_FILE}"
             COMMAND ${CMAKE_COMMAND}
                 -DAVM_EXECUTABLE=$<TARGET_FILE:avm>
-                -DTEST_FILE=${TEST_DIR}/${TEST_FILE}
+                -DTEST_FILE=${TEST_DIR}/${TEST_FILE>
                 -DTEST_DIR=${TEST_DIR}
                 -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/run_test.cmake")
     endforeach()
@@ -192,6 +192,13 @@ if(AVM_BUILD_CORE_TESTS)
         protocol_adapter_boundary_tests)
     avm_add_core_test(avm_persistent_link_store_test test/persistent_link_store_test.cpp persistent_link_store_tests)
 
+    add_executable(avm_inspection_session_test "${CMAKE_CURRENT_SOURCE_DIR}/test/inspection_session_test.cpp")
+    target_link_libraries(avm_inspection_session_test PRIVATE avm_core)
+    target_include_directories(avm_inspection_session_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+    avm_apply_quality(avm_inspection_session_test)
+    avm_enable_test_assertions(avm_inspection_session_test)
+    add_test(NAME inspection_session_tests COMMAND avm_inspection_session_test)
+
     add_executable(avm_vertical_slice_test "${CMAKE_CURRENT_SOURCE_DIR}/test/vertical_slice_test.cpp")
     avm_add_json_includes(avm_vertical_slice_test)
     avm_apply_quality(avm_vertical_slice_test)
@@ -224,6 +231,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_raw_carrier_test
         avm_protocol_adapter_boundary_test
         avm_persistent_link_store_test
+        avm_inspection_session_test
         avm_vertical_slice_test
         avm_json_value_codec_test)
 endif()

--- a/docs/inspection-session.md
+++ b/docs/inspection-session.md
@@ -1,0 +1,89 @@
+# Typed inspection session contract
+
+AVM 1.4 begins with a host-side inspection session that composes existing AVM 1.x APIs. It is tooling, not a new semantic layer.
+
+## Boundary
+
+The typed session has one path to canonical state and execution:
+
+```text
+InspectionSession
+  -> existing LinkStore read operations
+  -> existing Relations Model query/decode helpers
+  -> existing function/frame structural decoders
+  -> existing BootstrapRuntime::execute
+  -> existing ExecutionObserver / BoundedExecutionTrace
+```
+
+There is no `DebugExecutor`, shell-specific relation registry, copied evaluator or shadow program database.
+
+The implementation lives under `tools/` and is intentionally not added to the installed `avm::core` header set in this gate. The stable public core contracts remain the dependencies that the tool consumes.
+
+## Stable ownership
+
+`InspectionSession` owns its `BootstrapRuntime` and bounded trace collector while the caller owns the `LinkStore`.
+
+This follows the stable-address ownership contract established for `Executor`/`BootstrapRuntime`: native handlers may close over their runtime owner, so the runtime is neither copied nor moved. Consequently the inspection session is also neither copyable nor movable.
+
+The session takes `BootstrapVocabulary` by value when constructed and passes that explicit identity set to the runtime. Constructing a session over a complete current vocabulary must not allocate replacement bootstrap identities or otherwise grow the store.
+
+The session does not attach its collector to an externally owned runtime. `Executor::set_observer` is a non-owning setter without an observer stack/getter; owning the runtime prevents tooling from silently clobbering another caller's observer.
+
+## Read-only inspection
+
+The following operations are observational:
+
+```text
+inspect_link(id)
+find_pair(begin,end)
+outgoing(begin)
+incoming(end)
+query_relations(constraints)
+decode_relation(entity)
+function_definition(handle)
+call_frame(frame)
+```
+
+They delegate to existing `LinkStore`, Relations Model and program-model helpers. They do not call `intern` or `create_point`, invent missing identities, or maintain a second entity index.
+
+A missing exact pair remains absent. A malformed/missing entity may throw the same structural error exposed by the underlying helper, but inspection itself must not materialize repair data.
+
+## Execution and tracing
+
+`execute(root)` delegates directly to the owned `BootstrapRuntime`.
+
+`trace_execute(root)` resets the session-owned `BoundedExecutionTrace`, attaches it to the same runtime executor for one execution, and detaches it on both success and exception paths. The original result or exception remains the runtime result; retained trace events use the AVM 1.3 event/failure contract unchanged.
+
+Trace capacity is fixed when the session is constructed. Capacity exhaustion remains explicit through `trace_truncated()` and never becomes an implicit unbounded collector.
+
+After a failed traced execution, the retained `Fail(phase)` events remain available for inspection. A subsequent ordinary `execute` is not observed because the collector has been detached.
+
+## Effects
+
+The session itself does not reinterpret execution effects. A program executed through the session may perform the same canonical effects it performs through direct `BootstrapRuntime::execute` (for example frame/binding materialization or explicit `pair_intern`).
+
+Therefore the tooling distinction is:
+
+```text
+inspection method   -> observational, no store growth
+execute/trace       -> exactly the existing program/runtime effect contract
+```
+
+## Follow-up layers
+
+A textual/scripted command parser is a separate gate. Command strings will map to these typed operations and remain presentation syntax rather than AVM relation identities.
+
+Persistent-session/reopen behavior is also a separate gate. It must reuse explicit persisted vocabulary/root identities and preserve the existing persistent trace/LinkId contracts.
+
+## Non-goals
+
+This gate does not add:
+
+- breakpoint, step or continue control;
+- handler replacement or result substitution;
+- a symbolic LinkId registry;
+- JSON/Anum parsing inside the session;
+- implicit store enumeration;
+- implicit trace persistence;
+- backend-specific semantic behavior;
+- new `LinkStore` methods or indexes.

--- a/test/inspection_session_test.cpp
+++ b/test/inspection_session_test.cpp
@@ -1,0 +1,182 @@
+#include "inspection_session.h"
+
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+static_assert(!std::is_copy_constructible_v<avm::tooling::InspectionSession>);
+static_assert(!std::is_copy_assignable_v<avm::tooling::InspectionSession>);
+static_assert(!std::is_move_constructible_v<avm::tooling::InspectionSession>);
+static_assert(!std::is_move_assignable_v<avm::tooling::InspectionSession>);
+
+namespace
+{
+
+struct Fixture
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime{store};
+	avm::BootstrapVocabulary vocabulary{runtime.vocabulary()};
+	avm::LinkId point_a{store.create_point()};
+	avm::LinkId point_b{store.create_point()};
+	avm::LinkId point_c{store.create_point()};
+	avm::LinkId unpaired_begin{store.create_point()};
+	avm::LinkId unpaired_end{store.create_point()};
+	avm::LinkId pair{store.intern(point_a, point_b)};
+	avm::LinkId relation{store.create_point()};
+	avm::LinkId relation_entity{avm::encode_relation_entity(store, {relation, point_a, point_c})};
+	avm::LinkId formal{store.create_point()};
+	avm::LinkId function{runtime.builder().create_function_handle()};
+	avm::LinkId body{runtime.builder().parameter(formal)};
+	avm::LinkId definition{runtime.builder().define_function(function, {formal}, body)};
+	avm::LinkId literal_true{runtime.builder().literal(vocabulary.true_value)};
+	avm::LinkId call{runtime.builder().call(function, {literal_true})};
+	avm::LinkId boolean_root{runtime.builder().logical_not(runtime.builder().literal(vocabulary.false_value))};
+};
+
+void verify_session_construction_is_idempotent()
+{
+	Fixture fixture;
+	const std::size_t size_before = fixture.store.size();
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+	assert(fixture.store.size() == size_before);
+	assert(session.vocabulary().true_value == fixture.vocabulary.true_value);
+}
+
+void verify_read_only_inspection_never_materializes()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+	const std::size_t size_before = fixture.store.size();
+
+	const avm::Link expected_point{fixture.point_a, fixture.point_a};
+	const avm::Link expected_pair{fixture.point_a, fixture.point_b};
+	assert(session.inspect_link(fixture.point_a) == expected_point);
+	assert(session.inspect_link(fixture.pair) == expected_pair);
+	assert(session.find_pair(fixture.point_a, fixture.point_b) == fixture.pair);
+	assert(!session.find_pair(fixture.unpaired_begin, fixture.unpaired_end));
+	assert(session.outgoing(fixture.point_a) == fixture.store.outgoing(fixture.point_a));
+	assert(session.incoming(fixture.point_b) == fixture.store.incoming(fixture.point_b));
+
+	const avm::RelationQuery query{
+	    .relation = fixture.relation,
+	    .subject = fixture.point_a,
+	    .object = fixture.point_c,
+	};
+	assert(session.query_relations(query) == avm::query_relation_entities(fixture.store, query));
+	const avm::RelationEntity expected_entity{fixture.relation, fixture.point_a, fixture.point_c};
+	assert(session.decode_relation(fixture.relation_entity) == expected_entity);
+
+	const auto definition = session.function_definition(fixture.function);
+	assert(definition);
+	assert(definition->entity == fixture.definition);
+	assert(definition->handle == fixture.function);
+	assert(definition->parameters == std::vector<avm::LinkId>{fixture.formal});
+	assert(definition->body == fixture.body);
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(session.inspect_link(fixture.store.size() + 1000));
+	}
+	catch (const std::out_of_range &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(fixture.store.size() == size_before);
+}
+
+void verify_execute_reuses_canonical_runtime_semantics()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+
+	const avm::LinkId direct = fixture.runtime.execute(fixture.boolean_root);
+	const std::size_t size_before = fixture.store.size();
+	assert(session.execute(fixture.boolean_root) == direct);
+	assert(fixture.store.size() == size_before);
+}
+
+void verify_trace_and_frame_inspection()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+
+	assert(session.trace_execute(fixture.call) == fixture.vocabulary.true_value);
+	assert(!session.trace_events().empty());
+	assert(!session.trace_truncated());
+
+	std::optional<avm::LinkId> frame;
+	for (const avm::ExecutionEvent &event : session.trace_events())
+	{
+		if (event.context.frame)
+		{
+			frame = event.context.frame;
+			break;
+		}
+	}
+	assert(frame);
+
+	const avm::DecodedCallFrame decoded = session.call_frame(*frame);
+	assert(decoded.entity == *frame);
+	assert(decoded.function == fixture.function);
+	assert(decoded.bindings.size() == 1);
+
+	session.reset_trace();
+	assert(session.trace_events().empty());
+	assert(!session.trace_truncated());
+}
+
+void verify_bounded_trace_and_failure_retention()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession short_session(fixture.store, fixture.vocabulary, 1);
+	assert(short_session.trace_execute(fixture.boolean_root) == fixture.vocabulary.true_value);
+	assert(short_session.trace_events().size() == 1);
+	assert(short_session.trace_truncated());
+
+	const avm::LinkId unknown_relation = fixture.store.create_point();
+	const avm::LinkId failure_subject = fixture.store.create_point();
+	const avm::LinkId failure_object = fixture.store.create_point();
+	const avm::LinkId failure_root =
+	    avm::encode_relation_entity(fixture.store, {unknown_relation, failure_subject, failure_object});
+
+	avm::tooling::InspectionSession failure_session(fixture.store, fixture.vocabulary, 16);
+	const std::size_t size_before = fixture.store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(failure_session.trace_execute(failure_root));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(fixture.store.size() == size_before);
+	assert(failure_session.trace_events().size() == 2);
+	assert(failure_session.trace_events().front().kind == avm::ExecutionEventKind::Enter);
+	assert(failure_session.trace_events().back().kind == avm::ExecutionEventKind::Fail);
+	assert(failure_session.trace_events().back().failure_phase == avm::ExecutionFailurePhase::Dispatch);
+
+	failure_session.reset_trace();
+	assert(failure_session.execute(fixture.boolean_root) == fixture.vocabulary.true_value);
+	assert(failure_session.trace_events().empty());
+}
+
+} // namespace
+
+int main()
+{
+	verify_session_construction_is_idempotent();
+	verify_read_only_inspection_never_materializes();
+	verify_execute_reuses_canonical_runtime_semantics();
+	verify_trace_and_frame_inspection();
+	verify_bounded_trace_and_failure_retention();
+	return 0;
+}

--- a/tools/inspection_session.h
+++ b/tools/inspection_session.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "avm/bootstrap_runtime.h"
+#include "avm/execution_trace.h"
+#include "avm/relations_query.h"
+
+#include <cstddef>
+#include <optional>
+#include <span>
+#include <utility>
+#include <vector>
+
+namespace avm::tooling
+{
+
+class InspectionSession
+{
+public:
+	InspectionSession(LinkStore &store, BootstrapVocabulary vocabulary, std::size_t trace_capacity = 256,
+	                  std::size_t max_call_depth = 1000)
+	    : runtime_(store, std::move(vocabulary), max_call_depth), trace_(trace_capacity)
+	{
+	}
+
+	const BootstrapVocabulary &vocabulary() const noexcept { return runtime_.vocabulary(); }
+
+	Link inspect_link(LinkId id) const { return store().get(id); }
+
+	std::optional<LinkId> find_pair(LinkId begin, LinkId end) const { return store().find(begin, end); }
+
+	std::vector<LinkId> outgoing(LinkId begin) const { return store().outgoing(begin); }
+
+	std::vector<LinkId> incoming(LinkId end) const { return store().incoming(end); }
+
+	std::vector<RelationMatch> query_relations(const RelationQuery &query) const
+	{
+		return query_relation_entities(store(), query);
+	}
+
+	RelationEntity decode_relation(LinkId entity) const { return decode_relation_entity(store(), entity); }
+
+	std::optional<FunctionDefinition> function_definition(LinkId handle) const
+	{
+		return find_function_definition(store(), runtime_.vocabulary(), handle);
+	}
+
+	DecodedCallFrame call_frame(LinkId frame) const { return decode_call_frame(store(), runtime_.vocabulary(), frame); }
+
+	LinkId execute(LinkId root) { return runtime_.execute(root); }
+
+	LinkId trace_execute(LinkId root)
+	{
+		trace_.reset();
+		runtime_.executor().set_observer(&trace_);
+		try
+		{
+			const LinkId result = runtime_.execute(root);
+			runtime_.executor().set_observer(nullptr);
+			return result;
+		}
+		catch (...)
+		{
+			runtime_.executor().set_observer(nullptr);
+			throw;
+		}
+	}
+
+	std::span<const ExecutionEvent> trace_events() const noexcept { return trace_.events(); }
+
+	bool trace_truncated() const noexcept { return trace_.truncated(); }
+
+	std::size_t trace_capacity() const noexcept { return trace_.max_events(); }
+
+	void reset_trace() noexcept { trace_.reset(); }
+
+private:
+	const LinkStore &store() const
+	{
+		const BootstrapRuntime &runtime = runtime_;
+		return runtime.executor().store();
+	}
+
+	BootstrapRuntime runtime_;
+	BoundedExecutionTrace trace_;
+};
+
+} // namespace avm::tooling


### PR DESCRIPTION
Closes #107. Parent #106. Depends on merged ownership fix #109.

## Purpose
Introduce the first AVM 1.4 inspection layer as repository tooling over the already stable AVM 1.x contracts, without adding a parser, debugger executor, semantic registry or new storage API.

## Typed tooling path
`tools/inspection_session.h` owns a normal `BootstrapRuntime` and `BoundedExecutionTrace` while the caller owns the `LinkStore`:

```text
InspectionSession
  -> existing LinkStore reads
  -> existing Relations query/decode helpers
  -> existing function/frame structural decoders
  -> existing BootstrapRuntime::execute
  -> existing BoundedExecutionTrace
```

The header is intentionally not added to the installed `avm::core` public-header set in this gate. It proves that the public core already has enough capability for tooling.

## Read-only operations
Typed operations cover:
- `inspect_link`;
- exact `find_pair`;
- outgoing/incoming adjacency;
- constrained Relations Model query;
- relation decode;
- function-definition lookup;
- call-frame decode.

These delegate to existing observational APIs. No inspection operation calls `intern` or `create_point`, and the conformance test holds store size constant across the whole read-only sequence, including missing-pair and invalid-LinkId cases.

## Execution / trace
`execute(root)` delegates directly to the owned `BootstrapRuntime`.

`trace_execute(root)` resets and attaches the session-owned bounded collector to that same runtime executor for one call, then detaches on both success and exception paths. It preserves the original result/exception and retains the public AVM 1.3 events/failure phase. The test proves truncation, frame inspection, `Fail(Dispatch)` retention, and that a later ordinary execute is no longer observed.

The session owns its runtime instead of temporarily replacing an observer on an externally owned runtime; `Executor` intentionally has a non-owning setter but no observer stack/getter. This also follows the stable-address/non-copyable ownership contract from #109.

## Conformance
A dedicated `inspection_session_test` is part of `avm_core_tests`, so it runs under:
- strict C++20 warnings-as-errors;
- ASan+UBSan;
- portable Linux/Windows/macOS full builds.

It covers construction idempotence, non-copy/non-move ownership, read-only non-mutation, direct-vs-session execution equivalence, frame decoding, bounded trace and failure retention/detachment.

## CI hardening
- source-size gate now includes `tools/`;
- new inspection-session isolation guard rejects storage materialization, backend/protocol coupling and executor forks in the tooling header;
- clang-format coverage is simplified to `include/avm/*.h`, `adapters/*.h`, `tools/*.h`, `src/*.cpp`, `test/*.cpp` plus the package consumer, so future top-level tests/tool headers cannot be silently omitted from formatting gates.

## Documentation
`docs/inspection-session.md` defines ownership, read-only/effect boundaries and the separation from future parser/persistent-session gates.

Follow-ups are already split:
- #110 scripted command parser/presentation;
- #111 persistent reopen session.

## Vetoes
- no changes to production `include/avm` or `src` semantics;
- no new LinkStore API/index;
- no `DebugExecutor`/`ShellExecutor`/copied evaluator;
- no command strings, JSON or Anum in the typed session;
- no hidden symbolic identity registry;
- no implicit trace/session persistence.