### PR TITLE
Fix vocabulary lifetime: snapshot helper identities by value

### DIFF
--- a/include/avm/json_compat.h
+++ b/include/avm/json_compat.h
@@ -25,7 +25,7 @@ public:
 	using Json = nlohmann::json;
 
 	JsonProgramImporter(LinkStore &store, const BootstrapVocabulary &vocabulary, LinkId sequence_relation)
-	    : store_(store), vocabulary_(vocabulary), sequence_relation_(sequence_relation), builder_(store, vocabulary)
+	    : store_(store), vocabulary_(vocabulary), sequence_relation_(sequence_relation), builder_(store, vocabulary_)
 	{
 		if (!store_.contains(sequence_relation_))
 			throw std::invalid_argument("JSON compatibility sequence relation is not present in LinkStore");
@@ -275,7 +275,7 @@ private:
 	}
 
 	LinkStore &store_;
-	const BootstrapVocabulary &vocabulary_;
+	BootstrapVocabulary vocabulary_;
 	LinkId sequence_relation_;
 	ProgramBuilder builder_;
 	std::map<std::string, FunctionSymbol> functions_;

--- a/include/avm/program_model.h
+++ b/include/avm/program_model.h
@@ -304,7 +304,7 @@ private:
 	}
 
 	LinkStore &store_;
-	const BootstrapVocabulary &vocabulary_;
+	BootstrapVocabulary vocabulary_;
 };
 
 } // namespace avm

--- a/test/json_session_test.cpp
+++ b/test/json_session_test.cpp
@@ -13,6 +13,21 @@ namespace
 
 using Json = nlohmann::json;
 
+void test_importer_owns_vocabulary_snapshot()
+{
+	avm::InMemoryLinkStore store;
+	const avm::BootstrapVocabulary vocabulary = avm::BootstrapVocabulary::create(store);
+	const avm::LinkId sequence_relation = store.create_point();
+	avm::JsonProgramImporter importer(store, avm::BootstrapVocabulary(vocabulary), sequence_relation);
+
+	const avm::LinkId root = importer.import_program(Json(false));
+	const avm::RelationEntity decoded = avm::decode_relation_entity(store, root);
+	assert(decoded.relation == vocabulary.quote_relation);
+	assert(decoded.subject == vocabulary.unit);
+	assert(decoded.object == vocabulary.false_value);
+	assert(importer.project_value(vocabulary.false_value) == Json(false));
+}
+
 void test_primitives()
 {
 	avm::JsonCompatibilitySession session;
@@ -69,6 +84,7 @@ void test_lazy_if()
 
 int main()
 {
+	test_importer_owns_vocabulary_snapshot();
 	test_primitives();
 	test_persistent_definition_session();
 	test_undefined_function_compatibility();

--- a/test/program_model_test.cpp
+++ b/test/program_model_test.cpp
@@ -9,6 +9,7 @@ int main()
 	avm::InMemoryLinkStore store;
 	const avm::BootstrapVocabulary vocabulary = avm::BootstrapVocabulary::create(store);
 	avm::ProgramBuilder builder(store, vocabulary);
+	avm::ProgramBuilder temporary_vocabulary_builder(store, avm::BootstrapVocabulary(vocabulary));
 
 	const std::vector<avm::LinkId> vocabulary_ids{
 	    vocabulary.unit,
@@ -57,7 +58,12 @@ int main()
 	}
 	assert(cycle_rejected);
 
+	const avm::LinkId temporary_literal = temporary_vocabulary_builder.literal(vocabulary.true_value);
+	assert(avm::decode_relation_entity(store, temporary_literal) ==
+	       (avm::RelationEntity{vocabulary.quote_relation, vocabulary.unit, vocabulary.true_value}));
+
 	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	assert(true_literal == temporary_literal);
 	const std::size_t before_literal_rebuild = store.size();
 	assert(builder.literal(vocabulary.true_value) == true_literal);
 	assert(store.size() == before_literal_rebuild);


### PR DESCRIPTION
Closes #112.

## Bug
`ProgramBuilder` and `JsonProgramImporter` accepted `const BootstrapVocabulary&` and retained that caller-owned reference as a member. Passing a temporary or allowing the caller-local vocabulary object to die left the helper with a dangling reference even though the only data needed is a small set of LinkIds.

## Fix
Keep constructor signatures source-compatible, but store `BootstrapVocabulary` by value:
- `ProgramBuilder::vocabulary_` is now a value snapshot;
- `JsonProgramImporter::vocabulary_` is now a value snapshot;
- the importer constructs its `ProgramBuilder` from its own stored snapshot.

Canonical identities do not change: copying the vocabulary copies only the same LinkIds. `LinkStore` remains caller-owned/non-owning exactly as before.

## Regression tests
Existing registered tests now deliberately create both helpers from temporary vocabulary copies and use them after the temporary full expression has ended:
- `program_model_test` verifies a temporary-vocabulary `ProgramBuilder` produces the exact same canonical literal LinkId;
- `json_session_test` verifies a temporary-vocabulary `JsonProgramImporter` can import/project with the expected canonical identities.

These tests run in the existing strict, JSON and ASan+UBSan lanes; the old reference implementation is the kind of stack-lifetime bug sanitizers are intended to expose.

## Diff veto
Only vocabulary ownership and focused tests change. No Bootstrap vocabulary creation, LinkStore semantics, program encoding, JSON operator semantics, runtime dispatch, persistence or observer behavior changes.

This PR is independent of AVM 1.4 tooling and is tested against the current main merge result.