### PR TITLE
AVM 1.4: add scripted inspection commands over typed session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,15 +161,15 @@ jobs:
             exit 1
           fi
 
-      - name: Enforce inspection session tooling isolation
+      - name: Enforce inspection tooling isolation
         shell: bash
         run: |
           set -euo pipefail
-          if grep -n -E '(intern|create_point|register_native|register_handler)[[:space:]]*\(|PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num|[Aa]bit' tools/inspection_session.h; then
-            echo "ERROR: inspection session must compose existing neutral APIs without defining storage/protocol semantics"
+          if grep -n -E '(intern|create_point|register_native|register_handler)[[:space:]]*\(|PersistentLinkStore|InMemoryLinkStore|nlohmann|json\.hpp|[Aa]num|[Aa]bit' tools/*.h; then
+            echo "ERROR: inspection tooling must compose existing neutral APIs without defining storage/protocol semantics"
             exit 1
           fi
-          if grep -n -E 'DebugExecutor|ShellExecutor|TraceExecutor' tools/inspection_session.h; then
+          if grep -n -E 'DebugExecutor|ShellExecutor|TraceExecutor' tools/*.h; then
             echo "ERROR: inspection tooling must reuse BootstrapRuntime/Executor rather than fork execution"
             exit 1
           fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,15 @@ if(AVM_BUILD_CORE_TESTS)
         add_test(NAME ${test_name} COMMAND ${target})
     endfunction()
 
+    function(avm_add_tool_test target source test_name)
+        add_executable(${target} "${CMAKE_CURRENT_SOURCE_DIR}/${source}")
+        target_link_libraries(${target} PRIVATE avm_core)
+        target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+        avm_apply_quality(${target})
+        avm_enable_test_assertions(${target})
+        add_test(NAME ${test_name} COMMAND ${target})
+    endfunction()
+
     avm_add_core_test(avm_assertions_enabled_test test/assertions_enabled_test.cpp assertions_enabled_tests)
     avm_add_core_test(avm_link_store_test test/link_store_test.cpp link_store_tests)
     avm_add_core_test(avm_relations_model_test test/relations_model_test.cpp relations_model_tests)
@@ -191,13 +200,14 @@ if(AVM_BUILD_CORE_TESTS)
         test/protocol_adapter_boundary_test.cpp
         protocol_adapter_boundary_tests)
     avm_add_core_test(avm_persistent_link_store_test test/persistent_link_store_test.cpp persistent_link_store_tests)
-
-    add_executable(avm_inspection_session_test "${CMAKE_CURRENT_SOURCE_DIR}/test/inspection_session_test.cpp")
-    target_link_libraries(avm_inspection_session_test PRIVATE avm_core)
-    target_include_directories(avm_inspection_session_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
-    avm_apply_quality(avm_inspection_session_test)
-    avm_enable_test_assertions(avm_inspection_session_test)
-    add_test(NAME inspection_session_tests COMMAND avm_inspection_session_test)
+    avm_add_tool_test(
+        avm_inspection_session_test
+        test/inspection_session_test.cpp
+        inspection_session_tests)
+    avm_add_tool_test(
+        avm_inspection_commands_test
+        test/inspection_commands_test.cpp
+        inspection_commands_tests)
 
     add_executable(avm_vertical_slice_test "${CMAKE_CURRENT_SOURCE_DIR}/test/vertical_slice_test.cpp")
     avm_add_json_includes(avm_vertical_slice_test)
@@ -232,6 +242,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_protocol_adapter_boundary_test
         avm_persistent_link_store_test
         avm_inspection_session_test
+        avm_inspection_commands_test
         avm_vertical_slice_test
         avm_json_value_codec_test)
 endif()

--- a/docs/inspection-commands.md
+++ b/docs/inspection-commands.md
@@ -1,0 +1,95 @@
+# Scripted inspection command contract
+
+The AVM 1.4 command layer is a parser and renderer around the typed `InspectionSession`. It is not an execution language and does not introduce string-named AVM opcodes.
+
+## Layering
+
+```text
+text line
+  -> parse_inspection_command
+  -> typed InspectionCommand variant
+  -> execute_inspection_command
+  -> typed InspectionSession operation
+  -> existing LinkStore / Relations / BootstrapRuntime / trace contracts
+  -> typed InspectionResult variant
+  -> render_inspection_result
+  -> presentation text
+```
+
+The only string dispatch occurs in the parser. Once parsing succeeds, execution dispatch is by C++ command type. Runtime relation dispatch remains the existing LinkId-based `Executor` path. Command/result visitors are intentionally compile-time exhaustive: adding a new variant alternative without handling it is a build error rather than a fallback action.
+
+## Grammar
+
+The initial scripted grammar is deliberately small and decimal-LinkId oriented:
+
+```text
+link <id>
+find <begin> <end>
+outgoing <begin>
+incoming <end>
+relation <entity>
+query <relation|-> <subject|-> <object|->
+function <handle>
+frame <frame-id>
+execute <root>
+trace <root>
+trace-reset
+```
+
+Tokens are separated by ASCII whitespace. LinkIds use unsigned decimal syntax. `-` is reserved only for an absent Relations query constraint.
+
+`query - - -` is rejected before session execution because the underlying Relations query contract requires at least one constraint and AVM intentionally exposes no guessed full-store enumeration.
+
+## Error boundary
+
+Parser errors are tooling errors (`InspectionCommandError`). Examples include:
+
+- empty command;
+- unknown command;
+- wrong argument count;
+- malformed/negative/overflowing LinkId;
+- unconstrained query.
+
+They occur before an `InspectionSession` operation is invoked and therefore cannot mutate the store or trace state.
+
+After a command is parsed, errors from the typed operation retain their existing meaning. For example, `trace <root>` may propagate an AVM runtime exception. The session keeps the bounded trace that was observed before failure, so tooling can render `render_current_trace(session)` separately from the host exception diagnostic.
+
+No exception string or C++ exception type is inserted into canonical `ExecutionEvent` data.
+
+## Typed results
+
+Command execution returns typed result variants for link inspection, pair lookup, adjacency, relation query/decode, function/frame inspection, execute and trace operations. Adjacency direction is represented by an enum; string labels appear only in the renderer.
+
+Presentation strings such as `link`, `outgoing`, `enter`, `fail` and `dispatch` are renderer labels only. They are not persisted, interned, registered as relations or used by `Executor` to choose semantics.
+
+## Read-only and effect boundaries
+
+The commands
+
+```text
+link / find / outgoing / incoming / relation / query / function / frame
+```
+
+map to read-only session operations. Parsing and rendering are host-only work and must not alter `LinkStore`.
+
+`execute` and `trace` deliberately invoke the existing runtime and therefore have exactly the same effect contract as direct `BootstrapRuntime::execute`. `trace-reset` changes only bounded host tooling state.
+
+## Deterministic rendering
+
+Rendering uses numeric LinkIds and deterministic ordering inherited from the underlying APIs. Trace rendering presents retained events in event order and always prints explicit completeness/truncation state.
+
+Raw numeric LinkIds remain scoped to one logical store. Rendered numbers are not a cross-store identity protocol.
+
+## Non-goals
+
+This command layer does not provide:
+
+- quoted/string data arguments or a general expression grammar;
+- JSON or Anum parsing;
+- symbolic LinkId names;
+- breakpoint/step/continue;
+- handler registration/replacement;
+- implicit `intern`/`create_point` commands;
+- global store enumeration;
+- trace persistence;
+- a second executor or evaluator.

--- a/test/inspection_commands_test.cpp
+++ b/test/inspection_commands_test.cpp
@@ -1,0 +1,238 @@
+#include "inspection_commands.h"
+
+#include <cassert>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <variant>
+
+namespace
+{
+
+struct Fixture
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime{store};
+	avm::BootstrapVocabulary vocabulary{runtime.vocabulary()};
+	avm::LinkId point_a{store.create_point()};
+	avm::LinkId point_b{store.create_point()};
+	avm::LinkId point_c{store.create_point()};
+	avm::LinkId missing_begin{store.create_point()};
+	avm::LinkId missing_end{store.create_point()};
+	avm::LinkId pair{store.intern(point_a, point_b)};
+	avm::LinkId relation{store.create_point()};
+	avm::LinkId relation_entity{avm::encode_relation_entity(store, {relation, point_a, point_c})};
+	avm::LinkId formal{store.create_point()};
+	avm::LinkId function{runtime.builder().create_function_handle()};
+	avm::LinkId parameter{runtime.builder().parameter(formal)};
+	avm::LinkId definition{runtime.builder().define_function(function, {formal}, parameter)};
+	avm::LinkId true_literal{runtime.builder().literal(vocabulary.true_value)};
+	avm::LinkId call{runtime.builder().call(function, {true_literal})};
+	avm::LinkId boolean_root{runtime.builder().logical_not(runtime.builder().literal(vocabulary.false_value))};
+};
+
+std::string command(std::string name, avm::LinkId id)
+{
+	return std::move(name) + " " + std::to_string(id);
+}
+
+std::string command(std::string name, avm::LinkId first, avm::LinkId second)
+{
+	return std::move(name) + " " + std::to_string(first) + " " + std::to_string(second);
+}
+
+void expect_parse_error(std::string_view line)
+{
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(avm::tooling::parse_inspection_command(line));
+	}
+	catch (const avm::tooling::InspectionCommandError &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+}
+
+void verify_parser_produces_typed_commands()
+{
+	const auto link = avm::tooling::parse_inspection_command("  link\t42  ");
+	assert(std::holds_alternative<avm::tooling::InspectLinkCommand>(link));
+	assert(std::get<avm::tooling::InspectLinkCommand>(link).id == 42);
+
+	const auto find = avm::tooling::parse_inspection_command("find 7 9");
+	assert(std::holds_alternative<avm::tooling::FindPairCommand>(find));
+	assert(std::get<avm::tooling::FindPairCommand>(find).begin == 7);
+	assert(std::get<avm::tooling::FindPairCommand>(find).end == 9);
+
+	const auto query = avm::tooling::parse_inspection_command("query 10 - 12");
+	assert(std::holds_alternative<avm::tooling::QueryRelationsCommand>(query));
+	const avm::RelationQuery parsed = std::get<avm::tooling::QueryRelationsCommand>(query).query;
+	assert(parsed.relation == 10);
+	assert(!parsed.subject);
+	assert(parsed.object == 12);
+
+	assert(std::holds_alternative<avm::tooling::TraceResetCommand>(
+	    avm::tooling::parse_inspection_command("trace-reset")));
+}
+
+void verify_parse_errors_are_pre_execution_and_non_mutating()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary);
+	const std::size_t size_before = fixture.store.size();
+
+	expect_parse_error("");
+	expect_parse_error("unknown 1");
+	expect_parse_error("link");
+	expect_parse_error("link 1 2");
+	expect_parse_error("link -1");
+	expect_parse_error("link 18446744073709551616");
+	expect_parse_error("query - - -");
+	expect_parse_error("query 1 2");
+
+	assert(fixture.store.size() == size_before);
+	assert(session.trace_events().empty());
+}
+
+void verify_read_only_commands_match_canonical_apis()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary);
+	const std::size_t size_before = fixture.store.size();
+
+	const std::string link_text = avm::tooling::run_inspection_command(session, command("link", fixture.point_a));
+	assert(link_text == "link id=" + std::to_string(fixture.point_a) + " begin=" + std::to_string(fixture.point_a) +
+	                        " end=" + std::to_string(fixture.point_a));
+
+	const std::string find_text =
+	    avm::tooling::run_inspection_command(session, command("find", fixture.point_a, fixture.point_b));
+	assert(find_text.find("id=" + std::to_string(fixture.pair)) != std::string::npos);
+
+	const std::string missing_text =
+	    avm::tooling::run_inspection_command(session, command("find", fixture.missing_begin, fixture.missing_end));
+	assert(missing_text.ends_with("id=-"));
+
+	const auto outgoing_command = avm::tooling::parse_inspection_command(command("outgoing", fixture.point_a));
+	const auto outgoing_result = avm::tooling::execute_inspection_command(session, outgoing_command);
+	const auto &outgoing = std::get<avm::tooling::AdjacencyResult>(outgoing_result);
+	assert(outgoing.direction == avm::tooling::AdjacencyDirection::Outgoing);
+	assert(outgoing.ids == fixture.store.outgoing(fixture.point_a));
+
+	const auto incoming_command = avm::tooling::parse_inspection_command(command("incoming", fixture.point_b));
+	const auto incoming_result = avm::tooling::execute_inspection_command(session, incoming_command);
+	const auto &incoming = std::get<avm::tooling::AdjacencyResult>(incoming_result);
+	assert(incoming.direction == avm::tooling::AdjacencyDirection::Incoming);
+	assert(incoming.ids == fixture.store.incoming(fixture.point_b));
+
+	const auto relation_command = avm::tooling::parse_inspection_command(command("relation", fixture.relation_entity));
+	const auto relation_result = avm::tooling::execute_inspection_command(session, relation_command);
+	const avm::tooling::DecodeRelationResult decoded = std::get<avm::tooling::DecodeRelationResult>(relation_result);
+	assert(decoded.entity.relation == fixture.relation);
+	assert(decoded.entity.subject == fixture.point_a);
+	assert(decoded.entity.object == fixture.point_c);
+
+	const std::string query_line = "query " + std::to_string(fixture.relation) + " " +
+	                               std::to_string(fixture.point_a) + " " + std::to_string(fixture.point_c);
+	const auto query_result = avm::tooling::execute_inspection_command(
+	    session, avm::tooling::parse_inspection_command(query_line));
+	const auto &matches = std::get<avm::tooling::QueryRelationsResult>(query_result).matches;
+	assert(matches.size() == 1);
+	assert(matches.front().entity_id == fixture.relation_entity);
+
+	const std::string function_text =
+	    avm::tooling::run_inspection_command(session, command("function", fixture.function));
+	assert(function_text.find("entity=" + std::to_string(fixture.definition)) != std::string::npos);
+
+	assert(fixture.store.size() == size_before);
+}
+
+void verify_execute_and_trace_reuse_session_runtime()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+
+	const std::string execute_text =
+	    avm::tooling::run_inspection_command(session, command("execute", fixture.boolean_root));
+	assert(execute_text == "execute result=" + std::to_string(fixture.vocabulary.true_value));
+
+	const std::string trace_text = avm::tooling::run_inspection_command(session, command("trace", fixture.boolean_root));
+	assert(trace_text.find("trace result=" + std::to_string(fixture.vocabulary.true_value)) == 0);
+	assert(trace_text.find("enter entity=") != std::string::npos);
+	assert(trace_text.find("return entity=") != std::string::npos);
+	assert(trace_text.find("complete=true truncated=false") != std::string::npos);
+
+	const std::string reset_text = avm::tooling::run_inspection_command(session, "trace-reset");
+	assert(reset_text == "trace reset");
+	assert(session.trace_events().empty());
+}
+
+void verify_frame_command_uses_structural_decoder()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession session(fixture.store, fixture.vocabulary, 128);
+	assert(session.trace_execute(fixture.call) == fixture.vocabulary.true_value);
+
+	std::optional<avm::LinkId> frame;
+	for (const avm::ExecutionEvent &event : session.trace_events())
+	{
+		if (event.context.frame)
+		{
+			frame = event.context.frame;
+			break;
+		}
+	}
+	assert(frame);
+
+	const std::string frame_text = avm::tooling::run_inspection_command(session, command("frame", *frame));
+	assert(frame_text.find("frame entity=" + std::to_string(*frame)) == 0);
+	assert(frame_text.find("function=" + std::to_string(fixture.function)) != std::string::npos);
+}
+
+void verify_trace_truncation_and_failure_state()
+{
+	Fixture fixture;
+	avm::tooling::InspectionSession short_session(fixture.store, fixture.vocabulary, 1);
+	const std::string short_trace =
+	    avm::tooling::run_inspection_command(short_session, command("trace", fixture.boolean_root));
+	assert(short_trace.find("trace events=1 complete=false truncated=true") != std::string::npos);
+
+	const avm::LinkId unknown_relation = fixture.store.create_point();
+	const avm::LinkId failure_subject = fixture.store.create_point();
+	const avm::LinkId failure_object = fixture.store.create_point();
+	const avm::LinkId failure_root =
+	    avm::encode_relation_entity(fixture.store, {unknown_relation, failure_subject, failure_object});
+	avm::tooling::InspectionSession failure_session(fixture.store, fixture.vocabulary, 16);
+
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(
+		    avm::tooling::run_inspection_command(failure_session, command("trace", failure_root)));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+
+	const std::string retained = avm::tooling::render_current_trace(failure_session);
+	assert(retained.find("fail entity=") != std::string::npos);
+	assert(retained.find("phase=dispatch") != std::string::npos);
+	assert(retained.find("complete=true truncated=false") != std::string::npos);
+}
+
+} // namespace
+
+int main()
+{
+	verify_parser_produces_typed_commands();
+	verify_parse_errors_are_pre_execution_and_non_mutating();
+	verify_read_only_commands_match_canonical_apis();
+	verify_execute_and_trace_reuse_session_runtime();
+	verify_frame_command_uses_structural_decoder();
+	verify_trace_truncation_and_failure_state();
+	return 0;
+}

--- a/test/inspection_commands_test.cpp
+++ b/test/inspection_commands_test.cpp
@@ -74,8 +74,8 @@ void verify_parser_produces_typed_commands()
 	assert(!parsed.subject);
 	assert(parsed.object == 12);
 
-	assert(std::holds_alternative<avm::tooling::TraceResetCommand>(
-	    avm::tooling::parse_inspection_command("trace-reset")));
+	const auto reset = avm::tooling::parse_inspection_command("trace-reset");
+	assert(std::holds_alternative<avm::tooling::TraceResetCommand>(reset));
 }
 
 void verify_parse_errors_are_pre_execution_and_non_mutating()
@@ -104,8 +104,10 @@ void verify_read_only_commands_match_canonical_apis()
 	const std::size_t size_before = fixture.store.size();
 
 	const std::string link_text = avm::tooling::run_inspection_command(session, command("link", fixture.point_a));
-	assert(link_text == "link id=" + std::to_string(fixture.point_a) + " begin=" + std::to_string(fixture.point_a) +
-	                        " end=" + std::to_string(fixture.point_a));
+	const std::string expected_link = "link id=" + std::to_string(fixture.point_a) +
+	                                  " begin=" + std::to_string(fixture.point_a) +
+	                                  " end=" + std::to_string(fixture.point_a);
+	assert(link_text == expected_link);
 
 	const std::string find_text =
 	    avm::tooling::run_inspection_command(session, command("find", fixture.point_a, fixture.point_b));
@@ -136,8 +138,8 @@ void verify_read_only_commands_match_canonical_apis()
 
 	const std::string query_line = "query " + std::to_string(fixture.relation) + " " +
 	                               std::to_string(fixture.point_a) + " " + std::to_string(fixture.point_c);
-	const auto query_result = avm::tooling::execute_inspection_command(
-	    session, avm::tooling::parse_inspection_command(query_line));
+	const auto query_command = avm::tooling::parse_inspection_command(query_line);
+	const auto query_result = avm::tooling::execute_inspection_command(session, query_command);
 	const auto &matches = std::get<avm::tooling::QueryRelationsResult>(query_result).matches;
 	assert(matches.size() == 1);
 	assert(matches.front().entity_id == fixture.relation_entity);
@@ -205,12 +207,12 @@ void verify_trace_truncation_and_failure_state()
 	const avm::LinkId failure_root =
 	    avm::encode_relation_entity(fixture.store, {unknown_relation, failure_subject, failure_object});
 	avm::tooling::InspectionSession failure_session(fixture.store, fixture.vocabulary, 16);
+	const auto failure_command = avm::tooling::parse_inspection_command(command("trace", failure_root));
 
 	bool rejected = false;
 	try
 	{
-		static_cast<void>(
-		    avm::tooling::run_inspection_command(failure_session, command("trace", failure_root)));
+		static_cast<void>(avm::tooling::execute_inspection_command(failure_session, failure_command));
 	}
 	catch (const std::runtime_error &)
 	{

--- a/tools/inspection_commands.h
+++ b/tools/inspection_commands.h
@@ -1,0 +1,490 @@
+#pragma once
+
+#include "inspection_session.h"
+
+#include <charconv>
+#include <cstddef>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace avm::tooling
+{
+
+class InspectionCommandError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+struct InspectLinkCommand
+{
+	LinkId id;
+};
+
+struct FindPairCommand
+{
+	LinkId begin;
+	LinkId end;
+};
+
+struct OutgoingCommand
+{
+	LinkId begin;
+};
+
+struct IncomingCommand
+{
+	LinkId end;
+};
+
+struct DecodeRelationCommand
+{
+	LinkId entity;
+};
+
+struct QueryRelationsCommand
+{
+	RelationQuery query;
+};
+
+struct FunctionDefinitionCommand
+{
+	LinkId handle;
+};
+
+struct CallFrameCommand
+{
+	LinkId frame;
+};
+
+struct ExecuteCommand
+{
+	LinkId root;
+};
+
+struct TraceExecuteCommand
+{
+	LinkId root;
+};
+
+struct TraceResetCommand
+{
+};
+
+using InspectionCommand =
+    std::variant<InspectLinkCommand, FindPairCommand, OutgoingCommand, IncomingCommand, DecodeRelationCommand,
+                 QueryRelationsCommand, FunctionDefinitionCommand, CallFrameCommand, ExecuteCommand, TraceExecuteCommand,
+                 TraceResetCommand>;
+
+struct InspectLinkResult
+{
+	LinkId id;
+	Link link;
+};
+
+struct FindPairResult
+{
+	LinkId begin;
+	LinkId end;
+	std::optional<LinkId> id;
+};
+
+enum class AdjacencyDirection
+{
+	Outgoing,
+	Incoming,
+};
+
+struct AdjacencyResult
+{
+	AdjacencyDirection direction;
+	LinkId endpoint;
+	std::vector<LinkId> ids;
+};
+
+struct DecodeRelationResult
+{
+	LinkId entity_id;
+	RelationEntity entity;
+};
+
+struct QueryRelationsResult
+{
+	std::vector<RelationMatch> matches;
+};
+
+struct FunctionDefinitionResult
+{
+	LinkId handle;
+	std::optional<FunctionDefinition> definition;
+};
+
+struct CallFrameResult
+{
+	DecodedCallFrame frame;
+};
+
+struct ExecuteResult
+{
+	LinkId result;
+};
+
+struct TraceExecuteResult
+{
+	LinkId result;
+	std::vector<ExecutionEvent> events;
+	bool truncated;
+};
+
+struct TraceResetResult
+{
+};
+
+using InspectionResult =
+    std::variant<InspectLinkResult, FindPairResult, AdjacencyResult, DecodeRelationResult, QueryRelationsResult,
+                 FunctionDefinitionResult, CallFrameResult, ExecuteResult, TraceExecuteResult, TraceResetResult>;
+
+namespace detail
+{
+
+template <typename>
+inline constexpr bool always_false = false;
+
+inline bool is_space(char value) noexcept
+{
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n';
+}
+
+inline std::vector<std::string_view> tokenize(std::string_view line)
+{
+	std::vector<std::string_view> tokens;
+	std::size_t cursor = 0;
+	while (cursor < line.size())
+	{
+		while (cursor < line.size() && is_space(line[cursor]))
+			++cursor;
+		if (cursor == line.size())
+			break;
+
+		const std::size_t begin = cursor;
+		while (cursor < line.size() && !is_space(line[cursor]))
+			++cursor;
+		tokens.push_back(line.substr(begin, cursor - begin));
+	}
+	return tokens;
+}
+
+inline LinkId parse_link_id(std::string_view token)
+{
+	LinkId value = invalid_link_id;
+	const auto [end, error] = std::from_chars(token.data(), token.data() + token.size(), value);
+	if (token.empty() || error != std::errc{} || end != token.data() + token.size())
+		throw InspectionCommandError("LinkId must be an unsigned decimal integer");
+	return value;
+}
+
+inline std::optional<LinkId> parse_constraint(std::string_view token)
+{
+	if (token == "-")
+		return std::nullopt;
+	return parse_link_id(token);
+}
+
+inline void require_arity(const std::vector<std::string_view> &tokens, std::size_t expected,
+                          std::string_view command)
+{
+	if (tokens.size() != expected)
+		throw InspectionCommandError(std::string(command) + " has invalid argument count");
+}
+
+inline const char *adjacency_direction_name(AdjacencyDirection direction) noexcept
+{
+	switch (direction)
+	{
+	case AdjacencyDirection::Outgoing:
+		return "outgoing";
+	case AdjacencyDirection::Incoming:
+		return "incoming";
+	}
+	return "unknown";
+}
+
+inline const char *event_kind_name(ExecutionEventKind kind) noexcept
+{
+	switch (kind)
+	{
+	case ExecutionEventKind::Enter:
+		return "enter";
+	case ExecutionEventKind::Return:
+		return "return";
+	case ExecutionEventKind::Fail:
+		return "fail";
+	}
+	return "unknown";
+}
+
+inline const char *failure_phase_name(std::optional<ExecutionFailurePhase> phase) noexcept
+{
+	if (!phase)
+		return "-";
+
+	switch (*phase)
+	{
+	case ExecutionFailurePhase::Dispatch:
+		return "dispatch";
+	case ExecutionFailurePhase::Handler:
+		return "handler";
+	case ExecutionFailurePhase::ResultValidation:
+		return "result-validation";
+	}
+	return "unknown";
+}
+
+inline void append_optional_link(std::ostringstream &output, std::optional<LinkId> id)
+{
+	if (id)
+		output << *id;
+	else
+		output << '-';
+}
+
+inline void append_ids(std::ostringstream &output, const std::vector<LinkId> &ids)
+{
+	output << '[';
+	for (std::size_t index = 0; index < ids.size(); ++index)
+	{
+		if (index != 0)
+			output << ',';
+		output << ids[index];
+	}
+	output << ']';
+}
+
+inline void append_event(std::ostringstream &output, const ExecutionEvent &event)
+{
+	output << event_kind_name(event.kind) << " entity=" << event.context.entity << " relation=" << event.context.relation
+	       << " subject=" << event.context.subject << " object=" << event.context.object << " parent=";
+	append_optional_link(output, event.context.parent);
+	output << " frame=";
+	append_optional_link(output, event.context.frame);
+	output << " result=";
+	append_optional_link(output, event.result);
+	output << " phase=" << failure_phase_name(event.failure_phase);
+}
+
+inline void append_trace(std::ostringstream &output, const std::vector<ExecutionEvent> &events, bool truncated)
+{
+	for (const ExecutionEvent &event : events)
+	{
+		append_event(output, event);
+		output << '\n';
+	}
+	output << "trace events=" << events.size() << " complete=" << (truncated ? "false" : "true")
+	       << " truncated=" << (truncated ? "true" : "false");
+}
+
+} // namespace detail
+
+inline InspectionCommand parse_inspection_command(std::string_view line)
+{
+	const std::vector<std::string_view> tokens = detail::tokenize(line);
+	if (tokens.empty())
+		throw InspectionCommandError("inspection command is empty");
+
+	const std::string_view name = tokens.front();
+	if (name == "link")
+	{
+		detail::require_arity(tokens, 2, name);
+		return InspectLinkCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "find")
+	{
+		detail::require_arity(tokens, 3, name);
+		return FindPairCommand{detail::parse_link_id(tokens[1]), detail::parse_link_id(tokens[2])};
+	}
+	if (name == "outgoing")
+	{
+		detail::require_arity(tokens, 2, name);
+		return OutgoingCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "incoming")
+	{
+		detail::require_arity(tokens, 2, name);
+		return IncomingCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "relation")
+	{
+		detail::require_arity(tokens, 2, name);
+		return DecodeRelationCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "query")
+	{
+		detail::require_arity(tokens, 4, name);
+		RelationQuery query{
+		    .relation = detail::parse_constraint(tokens[1]),
+		    .subject = detail::parse_constraint(tokens[2]),
+		    .object = detail::parse_constraint(tokens[3]),
+		};
+		if (!query.relation && !query.subject && !query.object)
+			throw InspectionCommandError("query requires at least one relation/subject/object constraint");
+		return QueryRelationsCommand{query};
+	}
+	if (name == "function")
+	{
+		detail::require_arity(tokens, 2, name);
+		return FunctionDefinitionCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "frame")
+	{
+		detail::require_arity(tokens, 2, name);
+		return CallFrameCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "execute")
+	{
+		detail::require_arity(tokens, 2, name);
+		return ExecuteCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "trace")
+	{
+		detail::require_arity(tokens, 2, name);
+		return TraceExecuteCommand{detail::parse_link_id(tokens[1])};
+	}
+	if (name == "trace-reset")
+	{
+		detail::require_arity(tokens, 1, name);
+		return TraceResetCommand{};
+	}
+
+	throw InspectionCommandError("unknown inspection command: " + std::string(name));
+}
+
+inline InspectionResult execute_inspection_command(InspectionSession &session, const InspectionCommand &command)
+{
+	return std::visit(
+	    [&session](const auto &typed) -> InspectionResult
+	    {
+		    using Command = std::decay_t<decltype(typed)>;
+		    if constexpr (std::is_same_v<Command, InspectLinkCommand>)
+			    return InspectLinkResult{typed.id, session.inspect_link(typed.id)};
+		    else if constexpr (std::is_same_v<Command, FindPairCommand>)
+			    return FindPairResult{typed.begin, typed.end, session.find_pair(typed.begin, typed.end)};
+		    else if constexpr (std::is_same_v<Command, OutgoingCommand>)
+			    return AdjacencyResult{AdjacencyDirection::Outgoing, typed.begin, session.outgoing(typed.begin)};
+		    else if constexpr (std::is_same_v<Command, IncomingCommand>)
+			    return AdjacencyResult{AdjacencyDirection::Incoming, typed.end, session.incoming(typed.end)};
+		    else if constexpr (std::is_same_v<Command, DecodeRelationCommand>)
+			    return DecodeRelationResult{typed.entity, session.decode_relation(typed.entity)};
+		    else if constexpr (std::is_same_v<Command, QueryRelationsCommand>)
+			    return QueryRelationsResult{session.query_relations(typed.query)};
+		    else if constexpr (std::is_same_v<Command, FunctionDefinitionCommand>)
+			    return FunctionDefinitionResult{typed.handle, session.function_definition(typed.handle)};
+		    else if constexpr (std::is_same_v<Command, CallFrameCommand>)
+			    return CallFrameResult{session.call_frame(typed.frame)};
+		    else if constexpr (std::is_same_v<Command, ExecuteCommand>)
+			    return ExecuteResult{session.execute(typed.root)};
+		    else if constexpr (std::is_same_v<Command, TraceExecuteCommand>)
+		    {
+			    const LinkId result = session.trace_execute(typed.root);
+			    return TraceExecuteResult{
+			        result,
+			        std::vector<ExecutionEvent>(session.trace_events().begin(), session.trace_events().end()),
+			        session.trace_truncated(),
+			    };
+		    }
+		    else if constexpr (std::is_same_v<Command, TraceResetCommand>)
+		    {
+			    session.reset_trace();
+			    return TraceResetResult{};
+		    }
+		    else
+			    static_assert(detail::always_false<Command>, "unhandled InspectionCommand alternative");
+	    },
+	    command);
+}
+
+inline std::string render_inspection_result(const InspectionResult &result)
+{
+	return std::visit(
+	    [](const auto &typed)
+	    {
+		    using Result = std::decay_t<decltype(typed)>;
+		    std::ostringstream output;
+		    if constexpr (std::is_same_v<Result, InspectLinkResult>)
+			    output << "link id=" << typed.id << " begin=" << typed.link.begin << " end=" << typed.link.end;
+		    else if constexpr (std::is_same_v<Result, FindPairResult>)
+		    {
+			    output << "find begin=" << typed.begin << " end=" << typed.end << " id=";
+			    detail::append_optional_link(output, typed.id);
+		    }
+		    else if constexpr (std::is_same_v<Result, AdjacencyResult>)
+		    {
+			    output << detail::adjacency_direction_name(typed.direction) << " endpoint=" << typed.endpoint << " ids=";
+			    detail::append_ids(output, typed.ids);
+		    }
+		    else if constexpr (std::is_same_v<Result, DecodeRelationResult>)
+			    output << "relation entity=" << typed.entity_id << " relation=" << typed.entity.relation
+			           << " subject=" << typed.entity.subject << " object=" << typed.entity.object;
+		    else if constexpr (std::is_same_v<Result, QueryRelationsResult>)
+		    {
+			    output << "query matches=" << typed.matches.size();
+			    for (const RelationMatch &match : typed.matches)
+			        output << '\n'
+			               << "entity=" << match.entity_id << " relation=" << match.entity.relation
+			               << " subject=" << match.entity.subject << " object=" << match.entity.object;
+		    }
+		    else if constexpr (std::is_same_v<Result, FunctionDefinitionResult>)
+		    {
+			    output << "function handle=" << typed.handle;
+			    if (!typed.definition)
+				    output << " definition=-";
+			    else
+			    {
+				    output << " entity=" << typed.definition->entity << " parameters=";
+				    detail::append_ids(output, typed.definition->parameters);
+				    output << " body=" << typed.definition->body;
+			    }
+		    }
+		    else if constexpr (std::is_same_v<Result, CallFrameResult>)
+		    {
+			    output << "frame entity=" << typed.frame.entity << " parent=" << typed.frame.parent
+			           << " function=" << typed.frame.function << " bindings=";
+			    detail::append_ids(output, typed.frame.bindings);
+		    }
+		    else if constexpr (std::is_same_v<Result, ExecuteResult>)
+			    output << "execute result=" << typed.result;
+		    else if constexpr (std::is_same_v<Result, TraceExecuteResult>)
+		    {
+			    output << "trace result=" << typed.result << '\n';
+			    detail::append_trace(output, typed.events, typed.truncated);
+		    }
+		    else if constexpr (std::is_same_v<Result, TraceResetResult>)
+			    output << "trace reset";
+		    else
+			    static_assert(detail::always_false<Result>, "unhandled InspectionResult alternative");
+		    return output.str();
+	    },
+	    result);
+}
+
+inline std::string render_current_trace(const InspectionSession &session)
+{
+	std::ostringstream output;
+	const std::vector<ExecutionEvent> events(session.trace_events().begin(), session.trace_events().end());
+	detail::append_trace(output, events, session.trace_truncated());
+	return output.str();
+}
+
+inline std::string run_inspection_command(InspectionSession &session, std::string_view line)
+{
+	return render_inspection_result(execute_inspection_command(session, parse_inspection_command(line)));
+}
+
+} // namespace avm::tooling

--- a/tools/inspection_commands.h
+++ b/tools/inspection_commands.h
@@ -79,10 +79,9 @@ struct TraceResetCommand
 {
 };
 
-using InspectionCommand =
-    std::variant<InspectLinkCommand, FindPairCommand, OutgoingCommand, IncomingCommand, DecodeRelationCommand,
-                 QueryRelationsCommand, FunctionDefinitionCommand, CallFrameCommand, ExecuteCommand, TraceExecuteCommand,
-                 TraceResetCommand>;
+using InspectionCommand = std::variant<InspectLinkCommand, FindPairCommand, OutgoingCommand, IncomingCommand,
+                                       DecodeRelationCommand, QueryRelationsCommand, FunctionDefinitionCommand,
+                                       CallFrameCommand, ExecuteCommand, TraceExecuteCommand, TraceResetCommand>;
 
 struct InspectLinkResult
 {
@@ -148,9 +147,9 @@ struct TraceResetResult
 {
 };
 
-using InspectionResult =
-    std::variant<InspectLinkResult, FindPairResult, AdjacencyResult, DecodeRelationResult, QueryRelationsResult,
-                 FunctionDefinitionResult, CallFrameResult, ExecuteResult, TraceExecuteResult, TraceResetResult>;
+using InspectionResult = std::variant<InspectLinkResult, FindPairResult, AdjacencyResult, DecodeRelationResult,
+                                      QueryRelationsResult, FunctionDefinitionResult, CallFrameResult, ExecuteResult,
+                                      TraceExecuteResult, TraceResetResult>;
 
 namespace detail
 {
@@ -369,8 +368,7 @@ inline InspectionCommand parse_inspection_command(std::string_view line)
 inline InspectionResult execute_inspection_command(InspectionSession &session, const InspectionCommand &command)
 {
 	return std::visit(
-	    [&session](const auto &typed) -> InspectionResult
-	    {
+	    [&session](const auto &typed) -> InspectionResult {
 		    using Command = std::decay_t<decltype(typed)>;
 		    if constexpr (std::is_same_v<Command, InspectLinkCommand>)
 			    return InspectLinkResult{typed.id, session.inspect_link(typed.id)};
@@ -393,11 +391,8 @@ inline InspectionResult execute_inspection_command(InspectionSession &session, c
 		    else if constexpr (std::is_same_v<Command, TraceExecuteCommand>)
 		    {
 			    const LinkId result = session.trace_execute(typed.root);
-			    return TraceExecuteResult{
-			        result,
-			        std::vector<ExecutionEvent>(session.trace_events().begin(), session.trace_events().end()),
-			        session.trace_truncated(),
-			    };
+			    std::vector<ExecutionEvent> events(session.trace_events().begin(), session.trace_events().end());
+			    return TraceExecuteResult{result, std::move(events), session.trace_truncated()};
 		    }
 		    else if constexpr (std::is_same_v<Command, TraceResetCommand>)
 		    {
@@ -405,7 +400,9 @@ inline InspectionResult execute_inspection_command(InspectionSession &session, c
 			    return TraceResetResult{};
 		    }
 		    else
+		    {
 			    static_assert(detail::always_false<Command>, "unhandled InspectionCommand alternative");
+		    }
 	    },
 	    command);
 }
@@ -413,8 +410,7 @@ inline InspectionResult execute_inspection_command(InspectionSession &session, c
 inline std::string render_inspection_result(const InspectionResult &result)
 {
 	return std::visit(
-	    [](const auto &typed)
-	    {
+	    [](const auto &typed) {
 		    using Result = std::decay_t<decltype(typed)>;
 		    std::ostringstream output;
 		    if constexpr (std::is_same_v<Result, InspectLinkResult>)
@@ -468,7 +464,9 @@ inline std::string render_inspection_result(const InspectionResult &result)
 		    else if constexpr (std::is_same_v<Result, TraceResetResult>)
 			    output << "trace reset";
 		    else
+		    {
 			    static_assert(detail::always_false<Result>, "unhandled InspectionResult alternative");
+		    }
 		    return output.str();
 	    },
 	    result);


### PR DESCRIPTION
Superseded by #120. After #116 merged, this branch became conflict-prone because both PRs touched CMake conformance wiring. The command-layer work was rebuilt cleanly from the new `main` in #120, preserving #116 without a merge/rebase compatibility commit. Do not merge this PR.