### PR TITLE
AVM 1.4: prove persistent inspection session reopen identity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,15 @@ if(AVM_BUILD_CORE_TESTS)
     avm_enable_test_assertions(avm_inspection_session_test)
     add_test(NAME inspection_session_tests COMMAND avm_inspection_session_test)
 
+    add_executable(
+        avm_persistent_inspection_session_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/persistent_inspection_session_test.cpp")
+    target_link_libraries(avm_persistent_inspection_session_test PRIVATE avm_core)
+    target_include_directories(avm_persistent_inspection_session_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
+    avm_apply_quality(avm_persistent_inspection_session_test)
+    avm_enable_test_assertions(avm_persistent_inspection_session_test)
+    add_test(NAME persistent_inspection_session_tests COMMAND avm_persistent_inspection_session_test)
+
     add_executable(avm_vertical_slice_test "${CMAKE_CURRENT_SOURCE_DIR}/test/vertical_slice_test.cpp")
     avm_add_json_includes(avm_vertical_slice_test)
     avm_apply_quality(avm_vertical_slice_test)
@@ -232,6 +241,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_protocol_adapter_boundary_test
         avm_persistent_link_store_test
         avm_inspection_session_test
+        avm_persistent_inspection_session_test
         avm_vertical_slice_test
         avm_json_value_codec_test)
 endif()

--- a/docs/persistent-inspection-session.md
+++ b/docs/persistent-inspection-session.md
@@ -1,0 +1,74 @@
+# Persistent inspection session contract
+
+AVM 1.4 inspection tooling remains backend-neutral. A persistent session is therefore not a new session class or backend adapter: the same typed `InspectionSession` is constructed over an already opened `PersistentLinkStore` and an explicit persisted `BootstrapVocabulary`.
+
+## Reopen boundary
+
+A caller/tool owns the persistent store and the identities required to use it:
+
+```text
+persistent file
+  -> PersistentLinkStore open/validate/rebuild indexes
+  -> explicit BootstrapVocabulary LinkIds
+  -> explicit program/root/function LinkIds
+  -> InspectionSession(store, vocabulary)
+  -> existing read/query/execute/trace APIs
+```
+
+`InspectionSession` does not know a filesystem path and does not open, repair or reinterpret the backend. Corruption/version errors remain the responsibility of `PersistentLinkStore` and occur before a session can be constructed.
+
+## Identity
+
+For one logical persistent store, LinkIds are exact across close/reopen. Tooling therefore reuses the caller-supplied vocabulary/root/handle IDs verbatim.
+
+The persistent-session contract does not define numeric LinkIds as portable across independent stores. The AVM 1.3 backend-neutral renaming rule still applies when comparing independently constructed stores.
+
+## No hidden bootstrap
+
+Constructing an inspection session over a complete explicit vocabulary must not create replacement bootstrap identities. A read-only session that is opened, inspected and destroyed must leave `LinkStore::size()` unchanged.
+
+The session also keeps no hidden symbolic database of selected roots or handles. File path, selected root, command history and trace capacity are host tooling configuration unless a future explicit persistence projection is designed.
+
+## Converged execution state
+
+Function calls can materialize canonical binding/frame links as part of ordinary AVM execution. Persistent trace equality is therefore asserted only after that existing link-native state has converged.
+
+The conformance sequence is:
+
+1. create a persistent store and bootstrap vocabulary;
+2. materialize a function/program and execute the function once to converge canonical call state;
+3. capture a complete bounded call trace and final store size;
+4. close the store;
+5. reopen with the exact saved vocabulary/root/handle LinkIds;
+6. construct `InspectionSession` and prove construction/read operations do not grow the store;
+7. execute an already materialized root without reparsing frontend data;
+8. trace the converged function call and require exact `ExecutionEvent` equality;
+9. repeat reopen again and require the same identities, trace and store size.
+
+This reuses the AVM 1.3 rule that the same persistent logical store has exact trace identity after reopen.
+
+## Inspection guarantees
+
+Across reopen the session must preserve direct observations of:
+
+- `LinkId -> (begin,end)`;
+- exact pair lookup;
+- Relations Model decode and constrained query results;
+- function definition identity;
+- call-frame structural decode after execution;
+- deterministic execution result;
+- bounded trace events/failure phases.
+
+`reset_trace()` changes only host tooling state and never the persistent store.
+
+## Non-goals
+
+Persistent inspection does not add:
+
+- hidden bootstrap or identity migration;
+- a shell sidecar database;
+- implicit persistence of trace/history/bookmarks;
+- backend-specific VM semantics;
+- repair/recovery logic above `PersistentLinkStore`;
+- cross-store numeric LinkId equivalence;
+- frontend reparsing as a requirement for reopened execution.

--- a/test/persistent_inspection_session_test.cpp
+++ b/test/persistent_inspection_session_test.cpp
@@ -1,0 +1,201 @@
+#include "inspection_session.h"
+
+#include "avm/persistent_link_store.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+std::filesystem::path temporary_path()
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() /
+	       ("avm-persistent-inspection-" + std::to_string(nonce) + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove(path, error);
+	}
+};
+
+std::vector<avm::ExecutionEvent> copy_complete_trace(const avm::tooling::InspectionSession &session)
+{
+	assert(!session.trace_truncated());
+	return std::vector<avm::ExecutionEvent>(session.trace_events().begin(), session.trace_events().end());
+}
+
+struct PersistentInspectionBaseline
+{
+	avm::BootstrapVocabulary vocabulary;
+	avm::LinkId point_a;
+	avm::LinkId point_b;
+	avm::LinkId pair;
+	avm::LinkId relation;
+	avm::LinkId relation_entity;
+	avm::LinkId function;
+	avm::LinkId definition;
+	avm::LinkId call_root;
+	avm::LinkId boolean_root;
+	avm::LinkId expected_result;
+	std::vector<avm::ExecutionEvent> call_trace;
+	std::size_t store_size;
+};
+
+PersistentInspectionBaseline create_baseline(const std::filesystem::path &path)
+{
+	avm::PersistentLinkStore store(path);
+	avm::BootstrapRuntime runtime(store);
+	const avm::BootstrapVocabulary vocabulary = runtime.vocabulary();
+	avm::ProgramBuilder builder = runtime.builder();
+
+	const avm::LinkId point_a = store.create_point();
+	const avm::LinkId point_b = store.create_point();
+	const avm::LinkId pair = store.intern(point_a, point_b);
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId relation_entity = avm::encode_relation_entity(store, {relation, point_a, point_b});
+
+	const avm::LinkId formal = store.create_point();
+	const avm::LinkId function = builder.create_function_handle();
+	const avm::LinkId parameter = builder.parameter(formal);
+	const avm::LinkId definition = builder.define_function(function, {formal}, parameter);
+	const avm::LinkId true_literal = builder.literal(vocabulary.true_value);
+	const avm::LinkId call_root = builder.call(function, {true_literal});
+	const avm::LinkId boolean_root = builder.logical_not(builder.literal(vocabulary.false_value));
+
+	assert(runtime.execute(call_root) == vocabulary.true_value);
+	const std::size_t converged_size = store.size();
+	assert(runtime.execute(call_root) == vocabulary.true_value);
+	assert(store.size() == converged_size);
+
+	avm::tooling::InspectionSession session(store, vocabulary, 256);
+	assert(store.size() == converged_size);
+	assert(session.trace_events().empty());
+
+	assert(session.inspect_link(pair) == (avm::Link{point_a, point_b}));
+	assert(session.find_pair(point_a, point_b) == pair);
+	assert(session.decode_relation(relation_entity) == (avm::RelationEntity{relation, point_a, point_b}));
+
+	const auto found_definition = session.function_definition(function);
+	assert(found_definition);
+	assert(found_definition->entity == definition);
+	assert(found_definition->handle == function);
+
+	const avm::RelationQuery query{
+	    .relation = relation,
+	    .subject = point_a,
+	    .object = point_b,
+	};
+	const auto matches = session.query_relations(query);
+	assert(matches.size() == 1);
+	assert(matches.front().entity_id == relation_entity);
+	assert(store.size() == converged_size);
+
+	assert(session.trace_execute(call_root) == vocabulary.true_value);
+	assert(store.size() == converged_size);
+	const std::vector<avm::ExecutionEvent> call_trace = copy_complete_trace(session);
+	assert(!call_trace.empty());
+
+	return PersistentInspectionBaseline{
+	    vocabulary,
+	    point_a,
+	    point_b,
+	    pair,
+	    relation,
+	    relation_entity,
+	    function,
+	    definition,
+	    call_root,
+	    boolean_root,
+	    vocabulary.true_value,
+	    call_trace,
+	    store.size(),
+	};
+}
+
+void verify_reopened_session(const std::filesystem::path &path, const PersistentInspectionBaseline &baseline)
+{
+	avm::PersistentLinkStore store(path);
+	assert(store.size() == baseline.store_size);
+
+	avm::tooling::InspectionSession session(store, baseline.vocabulary, 256);
+	assert(store.size() == baseline.store_size);
+	assert(session.trace_events().empty());
+
+	const avm::Link expected_pair{baseline.point_a, baseline.point_b};
+	assert(session.inspect_link(baseline.pair) == expected_pair);
+	assert(session.find_pair(baseline.point_a, baseline.point_b) == baseline.pair);
+
+	const avm::RelationEntity expected_entity{baseline.relation, baseline.point_a, baseline.point_b};
+	assert(session.decode_relation(baseline.relation_entity) == expected_entity);
+	const avm::RelationQuery query{
+	    .relation = baseline.relation,
+	    .subject = baseline.point_a,
+	    .object = baseline.point_b,
+	};
+	const auto matches = session.query_relations(query);
+	assert(matches.size() == 1);
+	assert(matches.front().entity_id == baseline.relation_entity);
+
+	const auto definition = session.function_definition(baseline.function);
+	assert(definition);
+	assert(definition->entity == baseline.definition);
+	assert(store.size() == baseline.store_size);
+
+	assert(session.execute(baseline.boolean_root) == baseline.expected_result);
+	assert(store.size() == baseline.store_size);
+
+	assert(session.trace_execute(baseline.call_root) == baseline.expected_result);
+	assert(copy_complete_trace(session) == baseline.call_trace);
+	assert(store.size() == baseline.store_size);
+
+	std::optional<avm::LinkId> frame;
+	for (const avm::ExecutionEvent &event : session.trace_events())
+	{
+		if (event.context.frame)
+		{
+			frame = event.context.frame;
+			break;
+		}
+	}
+	assert(frame);
+	const avm::DecodedCallFrame decoded_frame = session.call_frame(*frame);
+	assert(decoded_frame.entity == *frame);
+	assert(decoded_frame.function == baseline.function);
+	assert(store.size() == baseline.store_size);
+
+	session.reset_trace();
+	assert(session.trace_events().empty());
+	assert(store.size() == baseline.store_size);
+}
+
+void verify_persistent_session_survives_multiple_reopens()
+{
+	const std::filesystem::path path = temporary_path();
+	FileCleanup cleanup{path};
+	const PersistentInspectionBaseline baseline = create_baseline(path);
+
+	verify_reopened_session(path, baseline);
+	verify_reopened_session(path, baseline);
+}
+
+} // namespace
+
+int main()
+{
+	verify_persistent_session_survives_multiple_reopens();
+	return 0;
+}

--- a/test/persistent_inspection_session_test.cpp
+++ b/test/persistent_inspection_session_test.cpp
@@ -17,8 +17,7 @@ namespace
 std::filesystem::path temporary_path()
 {
 	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
-	return std::filesystem::temp_directory_path() /
-	       ("avm-persistent-inspection-" + std::to_string(nonce) + ".bin");
+	return std::filesystem::temp_directory_path() / ("avm-persistent-inspection-" + std::to_string(nonce) + ".bin");
 }
 
 struct FileCleanup


### PR DESCRIPTION
Closes #111. Parent #106. Depends on merged typed session #113 and persistent/reopen contracts from AVM 1.0/1.3.

## Purpose
Prove that the existing typed `InspectionSession` already works correctly over `PersistentLinkStore` across close/reopen, without adding a backend-specific session class, hidden bootstrap or shadow tooling database.

This PR intentionally changes no `include/avm`, `src` or `tools` implementation code. It is a conformance/documentation gate only.

## Persistent path

```text
PersistentLinkStore open
  -> explicit persisted BootstrapVocabulary
  -> explicit root/function/entity LinkIds
  -> existing InspectionSession(store, vocabulary)
  -> existing read/query/execute/trace APIs
```

The session never receives a file path and cannot mask persistence-format/corruption errors; those remain `PersistentLinkStore` responsibilities before session construction.

## Convergence and exact identity
The test builds a persisted link-native function/program, executes the function once to converge the existing binding/frame links, then captures a complete call trace and final store size.

It closes/reopens the same logical store twice. On every reopen it requires:
- exact stored LinkId `(begin,end)` identity;
- exact pair lookup;
- exact Relations decode/query entity identity;
- exact function-definition identity;
- session construction with explicit vocabulary causes no store growth;
- an already materialized Boolean root executes without frontend reparsing or store growth;
- the converged function call returns the same LinkId;
- the entire `ExecutionEvent` sequence equals the baseline exactly, including numeric LinkIds;
- call-frame structural decode remains valid;
- trace reset changes no persistent state;
- final store size remains exactly unchanged.

This intentionally uses exact equality only for reopen of the same persistent logical store, consistent with the AVM 1.3 opaque-LinkId contract.

## CI
`persistent_inspection_session_test` joins `avm_core_tests`, so it runs under strict warnings-as-errors, ASan+UBSan and full portable Linux/Windows/macOS builds.

## Vetoes
- no new session/backend API;
- no hidden bootstrap/replacement identities;
- no shell sidecar database;
- no implicit trace/history persistence;
- no numeric LinkId portability claim across independent stores;
- no frontend reparsing required for reopened execution;
- no persistence repair layer above `PersistentLinkStore`.