### PR TITLE
Fix PersistentLinkStore exception safety after failed snapshot write

### DIFF
--- a/docs/persistent-link-store.md
+++ b/docs/persistent-link-store.md
@@ -63,7 +63,21 @@ This strictness prevents a corrupt file from being silently accepted as a differ
 
 For v1 every successful new point or new canonical pair rewrites the complete snapshot. Reusing an existing pair performs no write.
 
-This gives simple deterministic persistence semantics suitable for conformance tests, but it is **not** a crash-consistency guarantee. In particular v1 has no WAL, fsync protocol, atomic snapshot swap, locking or concurrent-writer support. Those concerns belong to a production backend such as a later PMM adapter.
+A new mutation can fail while updating in-memory indexes or while opening/writing/flushing the snapshot. Once a LinkId has been allocated, AVM treats `insert_link + persist` as one guarded mutation commit. If any part of that region throws, the live `PersistentLinkStore` object enters an explicit **faulted state** rather than continuing to expose a potentially partial or uncommitted in-memory view.
+
+After faulting:
+
+- `faulted()` returns `true` without touching the backend;
+- `path()` remains available for diagnostics;
+- all `LinkStore` reads and mutations reject access instead of exposing possibly uncommitted in-memory state;
+- the original exception is still propagated by the mutation that failed;
+- the object is not silently retried or repaired.
+
+An existing-pair `intern(a,b)` is read-like: it returns the already canonical LinkId without rewriting the snapshot, so an unavailable output path does not by itself fault a healthy object until a genuinely new mutation requires persistence.
+
+The correct recovery boundary is to discard the faulted object and explicitly reopen/repair the backing store according to the caller's policy. If a failed direct snapshot write damaged the file, reopen may reject it through the ordinary corruption checks.
+
+This fault-state rule is ordinary **in-process exception safety**, not a crash-consistency guarantee. V1 still has no WAL, fsync protocol, atomic snapshot swap, locking or concurrent-writer support. A process crash or power loss during the direct snapshot rewrite may leave the file incomplete; those durability concerns belong to a production backend such as a later PMM adapter.
 
 ## Why this backend exists
 

--- a/include/avm/persistent_link_store.h
+++ b/include/avm/persistent_link_store.h
@@ -28,14 +28,15 @@ public:
 
 	LinkId create_point() override
 	{
+		require_healthy();
 		const LinkId id = allocate_id();
-		insert_link(id, Link{id, id});
-		persist();
+		commit_new_link(id, Link{id, id});
 		return id;
 	}
 
 	LinkId intern(LinkId begin, LinkId end) override
 	{
+		require_healthy();
 		require_existing_endpoint(begin, "begin");
 		require_existing_endpoint(end, "end");
 
@@ -43,13 +44,13 @@ public:
 			return *existing;
 
 		const LinkId id = allocate_id();
-		insert_link(id, Link{begin, end});
-		persist();
+		commit_new_link(id, Link{begin, end});
 		return id;
 	}
 
 	std::optional<LinkId> find(LinkId begin, LinkId end) const override
 	{
+		require_healthy();
 		const auto it = exact_.find({begin, end});
 		if (it == exact_.end())
 			return std::nullopt;
@@ -58,6 +59,7 @@ public:
 
 	Link get(LinkId id) const override
 	{
+		require_healthy();
 		const auto it = links_.find(id);
 		if (it == links_.end())
 			throw std::out_of_range("unknown LinkId");
@@ -66,6 +68,7 @@ public:
 
 	std::vector<LinkId> outgoing(LinkId begin) const override
 	{
+		require_healthy();
 		const auto it = outgoing_.find(begin);
 		if (it == outgoing_.end())
 			return {};
@@ -74,17 +77,28 @@ public:
 
 	std::vector<LinkId> incoming(LinkId end) const override
 	{
+		require_healthy();
 		const auto it = incoming_.find(end);
 		if (it == incoming_.end())
 			return {};
 		return it->second;
 	}
 
-	bool contains(LinkId id) const override { return links_.contains(id); }
+	bool contains(LinkId id) const override
+	{
+		require_healthy();
+		return links_.contains(id);
+	}
 
-	std::size_t size() const override { return links_.size(); }
+	std::size_t size() const override
+	{
+		require_healthy();
+		return links_.size();
+	}
 
-	const std::filesystem::path &path() const { return path_; }
+	const std::filesystem::path &path() const noexcept { return path_; }
+
+	bool faulted() const noexcept { return faulted_; }
 
 private:
 	using Pair = std::pair<LinkId, LinkId>;
@@ -130,6 +144,12 @@ private:
 		return value;
 	}
 
+	void require_healthy() const
+	{
+		if (faulted_)
+			throw std::runtime_error("persistent LinkStore is faulted after a failed mutation commit");
+	}
+
 	LinkId allocate_id()
 	{
 		if (next_id_ == invalid_link_id || next_id_ == std::numeric_limits<LinkId>::max())
@@ -155,6 +175,20 @@ private:
 		exact_.emplace(pair, id);
 		outgoing_[link.begin].push_back(id);
 		incoming_[link.end].push_back(id);
+	}
+
+	void commit_new_link(LinkId id, Link link)
+	{
+		try
+		{
+			insert_link(id, link);
+			persist();
+		}
+		catch (...)
+		{
+			faulted_ = true;
+			throw;
+		}
 	}
 
 	void persist() const
@@ -234,6 +268,7 @@ private:
 	std::map<Pair, LinkId> exact_;
 	std::map<LinkId, std::vector<LinkId>> outgoing_;
 	std::map<LinkId, std::vector<LinkId>> incoming_;
+	bool faulted_ = false;
 };
 
 } // namespace avm

--- a/test/persistent_link_store_test.cpp
+++ b/test/persistent_link_store_test.cpp
@@ -9,6 +9,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace
@@ -27,7 +28,7 @@ struct FileCleanup
 	~FileCleanup()
 	{
 		std::error_code error;
-		std::filesystem::remove(path, error);
+		std::filesystem::remove_all(path, error);
 	}
 };
 
@@ -52,6 +53,26 @@ void expect_open_failure(const std::filesystem::path &path)
 	assert(rejected);
 }
 
+template <typename Operation> void expect_faulted_rejection(Operation &&operation)
+{
+	bool rejected = false;
+	try
+	{
+		std::forward<Operation>(operation)();
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+}
+
+void replace_file_with_directory(const std::filesystem::path &path)
+{
+	assert(std::filesystem::remove(path));
+	assert(std::filesystem::create_directory(path));
+}
+
 void test_empty_reopen()
 {
 	const std::filesystem::path path = temporary_path("empty");
@@ -61,11 +82,13 @@ void test_empty_reopen()
 		assert(store.size() == 0);
 		const avm::LinkId point = store.create_point();
 		assert(point == 1);
+		assert(!store.faulted());
 	}
 	{
 		avm::PersistentLinkStore reopened(path);
 		assert(reopened.size() == 1);
 		assert(reopened.get(1) == (avm::Link{1, 1}));
+		assert(!reopened.faulted());
 	}
 }
 
@@ -165,12 +188,73 @@ void test_endpoint_validation_survives_reopen()
 		}
 		assert(rejected);
 		assert(store.size() == 1);
+		assert(!store.faulted());
 	}
 	{
 		avm::PersistentLinkStore reopened(path);
 		assert(reopened.size() == 1);
 		assert(reopened.get(1) == (avm::Link{1, 1}));
 	}
+}
+
+void test_failed_create_faults_live_store()
+{
+	const std::filesystem::path path = temporary_path("fault-create");
+	FileCleanup cleanup{path};
+	avm::PersistentLinkStore store(path);
+	const avm::LinkId first = store.create_point();
+	assert(first == 1);
+	assert(!store.faulted());
+
+	replace_file_with_directory(path);
+	bool failed = false;
+	try
+	{
+		static_cast<void>(store.create_point());
+	}
+	catch (const std::runtime_error &)
+	{
+		failed = true;
+	}
+	assert(failed);
+	assert(store.faulted());
+	assert(store.path() == path);
+
+	expect_faulted_rejection([&store] { static_cast<void>(store.size()); });
+	expect_faulted_rejection([&store, first] { static_cast<void>(store.contains(first)); });
+	expect_faulted_rejection([&store, first] { static_cast<void>(store.get(first)); });
+	expect_faulted_rejection([&store, first] { static_cast<void>(store.outgoing(first)); });
+	expect_faulted_rejection([&store, first] { static_cast<void>(store.incoming(first)); });
+	expect_faulted_rejection([&store, first] { static_cast<void>(store.find(first, first)); });
+	expect_faulted_rejection([&store] { static_cast<void>(store.create_point()); });
+}
+
+void test_existing_intern_does_not_persist_but_new_intern_faults()
+{
+	const std::filesystem::path path = temporary_path("fault-intern");
+	FileCleanup cleanup{path};
+	avm::PersistentLinkStore store(path);
+	const avm::LinkId first = store.create_point();
+	const avm::LinkId second = store.create_point();
+	const avm::LinkId pair = store.intern(first, second);
+	assert(!store.faulted());
+
+	replace_file_with_directory(path);
+	assert(store.intern(first, second) == pair);
+	assert(!store.faulted());
+
+	bool failed = false;
+	try
+	{
+		static_cast<void>(store.intern(second, first));
+	}
+	catch (const std::runtime_error &)
+	{
+		failed = true;
+	}
+	assert(failed);
+	assert(store.faulted());
+	expect_faulted_rejection([&store, first, second] { static_cast<void>(store.intern(first, second)); });
 }
 
 } // namespace
@@ -181,5 +265,7 @@ int main()
 	test_reopen_identity_and_indexes();
 	test_corruption_rejection();
 	test_endpoint_validation_survives_reopen();
+	test_failed_create_faults_live_store();
+	test_existing_intern_does_not_persist_but_new_intern_faults();
 	return 0;
 }


### PR DESCRIPTION
Closes #118.

## Bug
`PersistentLinkStore::create_point()` and new-pair `intern()` advance in-memory mutation state before the operation is durably represented by the v1 snapshot. A filesystem/write failure — or even a host allocation/index insertion exception after ID allocation — can therefore leave the live object in a state that the caller was told failed.

That is ordinary in-process exception safety, distinct from crash-atomic durability.

## Fix
After a new LinkId has been allocated, the entire `insert_link + persist` section is one guarded mutation region. Any exception from index insertion/allocation or snapshot persistence transitions the live `PersistentLinkStore` into an explicit faulted state:
- the original exception is rethrown;
- `faulted()` exposes the state without backend access;
- `path()` remains available for diagnostics;
- every LinkStore read/mutation rejects access once faulted, so partial/uncommitted in-memory state cannot be mistaken for committed persistent state;
- callers recover by discarding the object and explicitly reopening/repairing according to policy.

Allocation-space exhaustion before a new ID is issued does not enter the guarded mutation region.

Existing-pair `intern(a,b)` remains read-like: it returns the canonical existing LinkId without calling `persist()`, so an unavailable output path does not fault a healthy store until a genuinely new mutation is attempted.

## Deterministic conformance
The persistent backend test replaces a successfully written backing file with a directory while the live store remains open. This deterministically makes the next snapshot open fail on the CI filesystems.

It proves:
- failed `create_point` marks the object faulted;
- subsequent `size/contains/get/outgoing/incoming/find/create_point` reject instead of exposing post-failure state;
- existing-pair `intern` performs no write and remains healthy after path sabotage;
- a genuinely new `intern` then fails and faults the object;
- successful/reopen paths remain non-faulted and unchanged.

## Scope / non-goals
This does **not** claim WAL, fsync durability, atomic snapshot replacement, crash consistency or concurrent writers. Direct v1 snapshot rewrite may still damage the file during a process/power failure; reopen corruption checks remain the recovery boundary.

## Diff veto
Only the persistent reference backend, its focused test and persistence contract documentation change. LinkStore interface, VM semantics, Relations Model, Executor, JSON/Anum adapters and tooling are untouched.