### PR TITLE
AVM 1.5: add versioned jsonRVM semantic compatibility inventory

### DIFF
--- a/.github/workflows/jsonrvm-compatibility.yml
+++ b/.github/workflows/jsonrvm-compatibility.yml
@@ -1,0 +1,30 @@
+name: jsonRVM compatibility inventory
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'compat/jsonrvm-semantics.json'
+      - 'compat/jsonrvm-golden.json'
+      - 'docs/jsonrvm-compatibility.md'
+      - 'tools/validate_jsonrvm_compatibility.py'
+      - '.github/workflows/jsonrvm-compatibility.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'compat/jsonrvm-semantics.json'
+      - 'compat/jsonrvm-golden.json'
+      - 'docs/jsonrvm-compatibility.md'
+      - 'tools/validate_jsonrvm_compatibility.py'
+      - '.github/workflows/jsonrvm-compatibility.yml'
+
+jobs:
+  validate:
+    name: Validate semantic inventory
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Validate manifest and frozen assertions
+        run: python3 tools/validate_jsonrvm_compatibility.py

--- a/compat/jsonrvm-golden.json
+++ b/compat/jsonrvm-golden.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "netkeep80/jsonRVM",
+    "commit": "843b3326141e090ccd1a106ba0a4a21ce72805b7",
+    "assertions_from": "modules/console/test/main.cpp"
+  },
+  "cases": [
+    {
+      "id": "CASE-RELATIVE-ADDRESSING",
+      "fixture": "modules/console/test/relative_addressing.json",
+      "test_name": "relative addressing in rmodel",
+      "equivalence": "observable-json-value",
+      "assertions": [
+        {"path": "/$$$$ent/id", "equals": "$$$$ent/id"},
+        {"path": "/$$$$sub/id", "equals": "$$$$ent/$sub"},
+        {"path": "/$$$$obj/id", "equals": "$$$$ent/$obj"},
+        {"path": "/$$$$rel/id", "equals": "$$$$rel/id"},
+        {"path": "/$$$ent/id", "equals": "$$$ent/id"},
+        {"path": "/$$$sub/id", "equals": "$$$ent/$sub"},
+        {"path": "/$$$obj/id", "equals": "$$$ent/$obj"},
+        {"path": "/$$$rel/id", "equals": "$$$rel/id"},
+        {"path": "/$$ent/id", "equals": "$$ent/id"},
+        {"path": "/$$sub/id", "equals": "$$ent/$sub"},
+        {"path": "/$$obj/id", "equals": "$$ent/$obj"},
+        {"path": "/$$rel/id", "equals": "$$rel/id"},
+        {"path": "/$ent/id", "equals": "$ent/id"},
+        {"path": "/$sub/id", "equals": "$ent/$sub"},
+        {"path": "/$obj/id", "equals": "$ent/$obj"},
+        {"path": "/$rel/id", "equals": "$rel/id"}
+      ],
+      "avm_target": "context/reference semantics; compare denoted role identities rather than copying JSON container mechanics"
+    },
+    {
+      "id": "CASE-ABSOLUTE-ADDRESSING",
+      "fixture": "modules/console/test/absolute_addressing.json",
+      "test_name": "absolute addressing in rmodel",
+      "equivalence": "observable-json-value",
+      "assertions": [
+        {"path": "/ent1/id", "equals": "ent1"},
+        {"path": "/ent2/id", "equals": "ent2"},
+        {"path": "/ent3/val/id", "equals": "ent3"}
+      ],
+      "avm_target": "split pure named resolution from external database lookup and add-entity materialization"
+    },
+    {
+      "id": "CASE-WHERE-FILTER",
+      "fixture": "modules/console/test/where_test.json",
+      "test_name": "testing base entity 'where'",
+      "equivalence": "observable-json-value",
+      "assertions": [
+        {"path": "/0", "equals": "4"}
+      ],
+      "avm_target": "ordered collection/filter semantics after canonical list/value denotation"
+    },
+    {
+      "id": "CASE-RUNTIME-VERSION",
+      "fixture": "modules/console/test/version.json",
+      "test_name": "testing call version.json",
+      "equivalence": "legacy-provenance-only",
+      "assertions": [
+        {"path": "/rmvm_version", "equals": "3.0.0"}
+      ],
+      "avm_target": "not a semantic parity requirement; records the pinned legacy runtime version"
+    }
+  ]
+}

--- a/compat/jsonrvm-semantics.json
+++ b/compat/jsonrvm-semantics.json
@@ -1,0 +1,361 @@
+{
+  "schema_version": 1,
+  "source": {
+    "repository": "netkeep80/jsonRVM",
+    "commit": "843b3326141e090ccd1a106ba0a4a21ce72805b7",
+    "runtime_version": "3.0.0"
+  },
+  "categories": [
+    "canonical-semantic",
+    "projection-syntax",
+    "effect-adapter",
+    "implementation-artifact",
+    "defer"
+  ],
+  "entries": [
+    {
+      "id": "RM-TRIUNE-001",
+      "name": "triune entity roles",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/common/include/vm.rm.h", "doc/Dictionary.md", "doc/relations-model-ru.md"],
+      "behavior": "Execution is defined around entity, relation/controller, subject/view and object/model roles.",
+      "current_avm": "partial",
+      "decision": "preserve semantic roles over canonical RelationEntity links instead of reducing all execution to subject=unit expressions",
+      "target_issue": 124
+    },
+    {
+      "id": "CTX-CURRENT-001",
+      "name": "current execution context roles",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/common/include/vm.rm.h", "doc/Dictionary.md"],
+      "behavior": "vm_ctx exposes current ent, rel, sub and obj identities/values.",
+      "current_avm": "partial",
+      "decision": "provide frontend-neutral canonical context access relations",
+      "target_issue": 125
+    },
+    {
+      "id": "CTX-PARENT-001",
+      "name": "parent execution context traversal",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/common/include/vm.rm.h", "modules/console/test/relative_addressing.json", "doc/Dictionary.md"],
+      "behavior": "Nested contexts expose parent levels through $, $$, $$$ and $$$$ forms; the implementation hard-codes four textual depths.",
+      "current_avm": "partial",
+      "decision": "preserve unbounded compositional parent traversal; drop hard-coded textual depth as implementation artifact",
+      "target_issue": 125
+    },
+    {
+      "id": "REF-PRONOUN-001",
+      "name": "context pronoun syntax",
+      "category": "projection-syntax",
+      "source_paths": ["modules/common/include/vm.rm.h", "modules/console/test/relative_addressing.json"],
+      "behavior": "$ent/$rel/$sub/$obj and repeated-$ prefixes select context roles before further path traversal.",
+      "current_avm": "missing",
+      "decision": "compile textual pronouns to canonical reference expressions; no runtime string dispatch",
+      "target_issue": 126
+    },
+    {
+      "id": "REF-ABSOLUTE-001",
+      "name": "named/absolute entity addressing",
+      "category": "projection-syntax",
+      "source_paths": ["modules/common/include/vm.rm.h", "modules/console/test/absolute_addressing.json"],
+      "behavior": "A reference can begin from a named entity in the VM model and traverse nested members.",
+      "current_avm": "missing",
+      "decision": "compile names and structural traversal into canonical reference algebra; name resolution policy stays outside Executor",
+      "target_issue": 126
+    },
+    {
+      "id": "REF-LAZY-DB-001",
+      "name": "lazy named entity retrieval",
+      "category": "effect-adapter",
+      "source_paths": ["modules/common/include/vm.rm.h", "modules/common/include/database_api.h"],
+      "behavior": "Missing named entities may be fetched through database_api during reference resolution.",
+      "current_avm": "missing",
+      "decision": "do not hide external lookup inside pure resolve; expose it through capability/effect policy",
+      "target_issue": 129
+    },
+    {
+      "id": "REF-LVALUE-001",
+      "name": "lvalue path creation",
+      "category": "projection-syntax",
+      "source_paths": ["modules/common/include/vm.rm.h"],
+      "behavior": "Write-oriented reference traversal may create missing JSON object/array members through operator[].",
+      "current_avm": "missing",
+      "decision": "split observational resolve/find from explicit write/realize semantics",
+      "target_issue": 126
+    },
+    {
+      "id": "EXEC-ARRAY-SEQ-001",
+      "name": "array/lambda-vector sequential execution",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/common/include/vm.rm.h", "doc/Dictionary.md"],
+      "behavior": "JSON arrays used as executable structures are evaluated in order in the current/nested context.",
+      "current_avm": "partial",
+      "decision": "preserve ordered sequence semantics using canonical link lists; JSON array is only frontend syntax",
+      "target_issue": 127
+    },
+    {
+      "id": "EXEC-OBJECT-PAR-001",
+      "name": "object/lambda-structure parallel projection",
+      "category": "defer",
+      "source_paths": ["modules/common/include/vm.rm.h", "doc/Dictionary.md", "analysis.md"],
+      "behavior": "Independent JSON object members are intended/executed with parallel execution policies in parts of the old interpreter.",
+      "current_avm": "missing",
+      "decision": "first define deterministic projection and effect ordering; only later enable parallel scheduling for proven-pure operations",
+      "target_issue": 127
+    },
+    {
+      "id": "EXEC-FOREACH-OBJ-001",
+      "name": "foreach object",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "foreachobj executes the subject program for every object-array item using child contexts and ordered results.",
+      "current_avm": "missing",
+      "decision": "model as canonical map/foreach over ordered link lists with deterministic fail-fast behavior",
+      "target_issue": 127
+    },
+    {
+      "id": "EXEC-FOREACH-SUB-001",
+      "name": "foreach subject",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "foreachsub executes the object program for every subject-array item using child contexts.",
+      "current_avm": "missing",
+      "decision": "preserve only after triune subject/object contract is fixed; express through canonical iteration semantics",
+      "target_issue": 127
+    },
+    {
+      "id": "CTRL-IF-001",
+      "name": "conditional execution",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "if/then/else relations select and execute one branch based on relation/object Boolean state.",
+      "current_avm": "implemented-partial-parity",
+      "decision": "retain AVM link-native if as baseline and add differential cases after value/context contracts stabilize",
+      "target_issue": 131
+    },
+    {
+      "id": "CTRL-WHILE-001",
+      "name": "while execution",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "while repeatedly executes a relation-controlled body while the condition remains true.",
+      "current_avm": "missing",
+      "decision": "defer implementation until sequence/context/effect ordering is explicit, but retain as semantic compatibility target",
+      "target_issue": 127
+    },
+    {
+      "id": "CTRL-SWITCH-001",
+      "name": "typed switch",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "switch/bool, switch/number and switch/string select a branch from a JSON object and execute it in the parent context.",
+      "current_avm": "missing",
+      "decision": "preserve selection semantics, replace JSON object/string keys by canonical value/key relations after value denotation exists",
+      "target_issue": 128
+    },
+    {
+      "id": "ERROR-THROW-CATCH-001",
+      "name": "language-level throw/catch",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h", "modules/common/include/vm.rm.h"],
+      "behavior": "throw emits a JSON value; catch executes object in parent context, captures JSON exception into relation state, then executes subject handler.",
+      "current_avm": "partial-runtime-errors-only",
+      "decision": "separate deterministic semantic failure classes from host exceptions; decide explicit program-level error values after value contract",
+      "target_issue": 131
+    },
+    {
+      "id": "VALUE-COPY-001",
+      "name": "copy/view",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "= copies object into subject; view executes object model in an outer context to project a view.",
+      "current_avm": "partial",
+      "decision": "identity/copy is pure value semantics; view depends on the triune projection contract and must not use mutable host references",
+      "target_issue": 124
+    },
+    {
+      "id": "VALUE-ARITH-001",
+      "name": "numeric arithmetic",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "base vocabulary registers +, -, *, :, pow, sqrt and sum over JSON numeric values.",
+      "current_avm": "missing",
+      "decision": "introduce canonical numeric denotation first, then port a minimal pure arithmetic subset",
+      "target_issue": 128
+    },
+    {
+      "id": "VALUE-COMPARE-001",
+      "name": "equality/comparison/boolean operators",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "==, !=, <, >, && and XOR operate on JSON values with type-dependent rules.",
+      "current_avm": "partial",
+      "decision": "keep Boolean baseline; specify structural/value equality and ordering per canonical denotation instead of inheriting nlohmann::json behavior",
+      "target_issue": 128
+    },
+    {
+      "id": "VALUE-COLLECTION-001",
+      "name": "collection operations",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "size, where, union and sequence/integer operate over JSON arrays/objects.",
+      "current_avm": "partial",
+      "decision": "map only semantics that remain meaningful over canonical ordered lists/structural links; JSON object behavior is not automatically normative",
+      "target_issue": 128
+    },
+    {
+      "id": "VALUE-GETSET-001",
+      "name": "get/set/erase JSON container mutation",
+      "category": "implementation-artifact",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "get/set/erase directly read or mutate JSON arrays/objects and can create members on null containers.",
+      "current_avm": "missing",
+      "decision": "do not port container mutation literally; replace needed behavior by reference resolve plus explicit immutable projection/materialization semantics",
+      "target_issue": 126
+    },
+    {
+      "id": "VALUE-STRING-001",
+      "name": "string conversion and operations",
+      "category": "canonical-semantic",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "string/=, string/+=, find, split and join operate on JSON strings and arrays.",
+      "current_avm": "missing",
+      "decision": "defer concrete operators until canonical byte/text denotation is selected; serialization format must not define semantic identity implicitly",
+      "target_issue": 128
+    },
+    {
+      "id": "VALUE-TYPE-PRED-001",
+      "name": "JSON type predicates and constructors",
+      "category": "implementation-artifact",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "is_array/is_object/is_string/is_number/... and json/array/object/null expose nlohmann::json's runtime type universe.",
+      "current_avm": "not-applicable",
+      "decision": "do not reproduce JSON type tags in core; add only structural/value shape predicates justified by canonical denotation",
+      "target_issue": 128
+    },
+    {
+      "id": "DISPLAY-PRINT-001",
+      "name": "print",
+      "category": "effect-adapter",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "print writes JSON rendering directly to stdout.",
+      "current_avm": "tooling-only",
+      "decision": "treat host output as an explicit effect or frontend rendering concern, never as pure VM semantics",
+      "target_issue": 129
+    },
+    {
+      "id": "DISPLAY-MARKUP-001",
+      "name": "tag/xml/html generation",
+      "category": "projection-syntax",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "tag/xml/html combine JSON object attributes, nested execution and string rendering.",
+      "current_avm": "missing",
+      "decision": "defer until canonical text and projection semantics exist; keep markup syntax outside core",
+      "target_issue": 128
+    },
+    {
+      "id": "EFFECT-TIME-001",
+      "name": "sleep and steady clock",
+      "category": "effect-adapter",
+      "source_paths": ["modules/console/include/base.rm.h"],
+      "behavior": "sleep/ms blocks the host thread; steady_clock relations expose wall/process monotonic time values.",
+      "current_avm": "missing",
+      "decision": "require explicit clock/sleep capability and deterministic fake clock in tests",
+      "target_issue": 129
+    },
+    {
+      "id": "EFFECT-FS-001",
+      "name": "filesystem vocabulary",
+      "category": "effect-adapter",
+      "source_paths": ["modules/vocabulary/fs/src/fs.rm.cpp"],
+      "behavior": "filesystem operations are registered as external vocabulary relations over host files/paths.",
+      "current_avm": "missing",
+      "decision": "port only through explicit filesystem capability after canonical request/result values exist",
+      "target_issue": 129
+    },
+    {
+      "id": "EFFECT-HTTP-001",
+      "name": "HTTP vocabulary",
+      "category": "effect-adapter",
+      "source_paths": ["modules/vocabulary/http/include/http.rm.h", "tests/http.rm.test.json"],
+      "behavior": "HTTP client/server integration exposes network effects through vocabulary modules.",
+      "current_avm": "missing",
+      "decision": "defer actual networking; define deterministic capability contract and fake provider first",
+      "target_issue": 129
+    },
+    {
+      "id": "EFFECT-DLL-001",
+      "name": "dynamic vocabulary loading",
+      "category": "effect-adapter",
+      "source_paths": ["modules/console/include/dll.rm.h", "modules/common/include/vm.rm.h"],
+      "behavior": "native dictionaries are loaded dynamically and register binary views through import_relations_model_to.",
+      "current_avm": "missing",
+      "decision": "preserve extensibility through canonical relation identities plus explicit native capability/plugin registration; dynamic symbol names are not semantic identities",
+      "target_issue": 129
+    },
+    {
+      "id": "IMPL-JSON-MUTEX-001",
+      "name": "JSON container mutexes",
+      "category": "implementation-artifact",
+      "source_paths": ["modules/common/include/vm.rm.h"],
+      "behavior": "object/array/null reference mutation uses dedicated std::mutex instances for the mutable JSON representation.",
+      "current_avm": "not-applicable",
+      "decision": "do not port; concurrency belongs to LinkStore/backend/scheduler contracts",
+      "target_issue": 127
+    },
+    {
+      "id": "IMPL-JSON-AST-001",
+      "name": "JSON as program/value/context universe",
+      "category": "implementation-artifact",
+      "source_paths": ["modules/common/include/vm.rm.h", "modules/console/include/base.rm.h"],
+      "behavior": "nlohmann::json simultaneously stores VM model, executable structures, values and mutable execution state.",
+      "current_avm": "removed-by-foundation",
+      "decision": "keep JSON exclusively as compatibility frontend/projection; canonical runtime remains LinkId-only",
+      "target_issue": 130
+    }
+  ],
+  "corpus_candidates": [
+    {
+      "id": "CASE-RELATIVE-ADDRESSING",
+      "source": "modules/console/test/relative_addressing.json",
+      "covers": ["CTX-CURRENT-001", "CTX-PARENT-001", "REF-PRONOUN-001"],
+      "status": "selected",
+      "notes": "Exercises $ent/$sub/$obj/$rel and parent depths through $$$$; should be normalized into smaller golden cases before AVM implementation."
+    },
+    {
+      "id": "CASE-ABSOLUTE-ADDRESSING",
+      "source": "modules/console/test/absolute_addressing.json",
+      "covers": ["REF-ABSOLUTE-001", "REF-LAZY-DB-001", "REF-LVALUE-001"],
+      "status": "selected",
+      "notes": "Separates pure named lookup from add_entity/materializing behavior."
+    },
+    {
+      "id": "CASE-BOOLEAN-BRANCH",
+      "source": "modules/console/include/base.rm.h",
+      "covers": ["CTRL-IF-001", "VALUE-COMPARE-001"],
+      "status": "derive-fixture",
+      "notes": "AVM already has Boolean/if behavior; build a frozen jsonRVM fixture to establish differential semantics rather than source-shape equality."
+    },
+    {
+      "id": "CASE-FOREACH-CONTEXT",
+      "source": "modules/console/include/base.rm.h",
+      "covers": ["EXEC-FOREACH-OBJ-001", "CTX-CURRENT-001", "CTX-PARENT-001"],
+      "status": "derive-fixture",
+      "notes": "Use a small deterministic array and context-dependent body; avoid effects."
+    },
+    {
+      "id": "CASE-ARITHMETIC",
+      "source": "modules/console/include/base.rm.h",
+      "covers": ["VALUE-ARITH-001"],
+      "status": "derive-fixture",
+      "notes": "Freeze simple integer cases after AVM canonical integer denotation is decided."
+    },
+    {
+      "id": "CASE-MISSING-REFERENCE",
+      "source": "modules/common/include/vm.rm.h",
+      "covers": ["REF-PRONOUN-001", "REF-ABSOLUTE-001"],
+      "status": "derive-fixture",
+      "notes": "Capture deterministic semantic failure class; do not require raw JSON exception text parity."
+    }
+  ]
+}

--- a/docs/jsonrvm-compatibility.md
+++ b/docs/jsonrvm-compatibility.md
@@ -1,6 +1,20 @@
 # jsonRVM / AVM compatibility
 
-This document fixes the first compatibility contract between the triplet-based Relations Model used by `jsonRVM` and the dyadic associative network used by AVM.
+Parent issue: #123. Epic: #122.
+
+## Provenance
+
+This audit is pinned to:
+
+```text
+repository: netkeep80/jsonRVM
+commit:     843b3326141e090ccd1a106ba0a4a21ce72805b7
+runtime:    jsonRVM 3.0.0
+```
+
+The machine-readable companion is `compat/jsonrvm-semantics.json`.
+
+The goal is not source compatibility with the old C++/JSON interpreter. The goal is to identify which observable Relations Model semantics must survive in AVM, which old syntax belongs in a projection frontend, which operations are explicit host effects, and which details must be dropped as implementation artifacts.
 
 ## Relations Model entity
 
@@ -20,7 +34,7 @@ The JSON projection uses:
 }
 ```
 
-The execution meaning belongs to the Relations Model/executor layer. This document only defines the structural projection into AVM links.
+The conceptual model additionally treats relation as controller, subject as view/receiver and object as model/input. That execution meaning is richer than structural encoding alone and is the subject of #124.
 
 ## Canonical dyadic projection
 
@@ -41,8 +55,6 @@ Therefore:
 
 No separate physical triplet record is required by the AVM core.
 
-## Round-trip
-
 For a materialized triplet `t`:
 
 ```text
@@ -50,46 +62,235 @@ encode(t) -> entity LinkId
 decode(entity LinkId) -> t
 ```
 
-must preserve all three roles exactly.
+preserves all three roles exactly. Because both inner and outer pairs are canonical links, repeated encoding returns the same identities inside one logical store.
 
-Because both inner and outer pairs are canonical links, repeated encoding returns the same identities inside one logical store.
+`find_relation_entity(relation, subject, object)` is intentionally different from encode/materialize: it finds the inner `(subject, object)` pair first and then the outer pair, without creating either on a miss.
 
-## Non-mutating lookup
-
-Finding a triplet is intentionally different from encoding/materializing it.
-
-```text
-find_relation_entity(relation, subject, object)
-```
-
-performs:
-
-```text
-find(subject, object)
-then, only if it exists,
-find(relation, subject_object)
-```
-
-It must not create the inner `(subject, object)` pair while checking whether the triplet exists.
-
-This is the same engineering distinction later required by the Anum boundary:
+This is the same boundary later required by Anum:
 
 ```text
 description/query != realization/write
 ```
 
-## Recursive use
+## Central finding of the semantic audit
 
-Every role is a `LinkId`, so an encoded entity can itself be used as the relation, subject or object of another entity. This preserves the recursive/homoiconic character of the Relations Model without adding another storage primitive.
+The historical blocker was **not** the mathematical encoding of a triplet as dyads. That part is straightforward and already works in AVM.
 
-## Execution is the next layer
+The hard part is that `jsonRVM` makes `nlohmann::json` serve several roles at once:
 
-This codec does not:
+1. program syntax;
+2. runtime scalar/collection values;
+3. mutable execution context;
+4. the in-memory Relations Model/database view.
 
-- dispatch a relation;
-- parse JSON;
-- interpret `$ref` paths;
-- define MVC behavior;
-- implement Anum semantics.
+As a result, execution semantics are entangled with JSON references, mutable containers, host concurrency and external modules. A dyad store alone does not solve that problem.
 
-Those operations build on top of the structural identity established here.
+AVM 1.0–1.4 has already removed the worst coupling by making `LinkId` the execution identity and by storing programs, functions and frames as links. AVM 1.5 therefore focuses on **semantic migration**, not another storage rewrite.
+
+## Classification rules
+
+Every audited behavior receives one of five categories in `compat/jsonrvm-semantics.json`.
+
+### `canonical-semantic`
+
+The behavior belongs to Relations Model / VM meaning and should survive independently of surface syntax. Examples: triune roles, parent execution contexts, ordered sequence execution and pure arithmetic semantics.
+
+### `projection-syntax`
+
+The old form is useful source syntax, but AVM must compile/project it to canonical links before execution. Examples: `$ent`, `$$obj`, JSON `$ref`, named/path addressing and markup-oriented surface structures.
+
+### `effect-adapter`
+
+The behavior touches external process state and needs an explicit capability/effect boundary. Examples: filesystem, HTTP, clock/sleep, stdout, dynamic plugins and lazy external entity retrieval.
+
+### `implementation-artifact`
+
+The behavior exists because `jsonRVM` uses mutable JSON as its runtime. It must not become AVM semantics. Examples: JSON type tags, container mutexes and literal `operator[]`-driven member creation.
+
+### `defer`
+
+The idea can be valuable but is unsafe to port before lower-level contracts exist. The main current example is automatic parallel execution of object-like projections: AVM first needs purity/effect ordering.
+
+## What jsonRVM actually executes
+
+### Triune execution context
+
+`vm_ctx` carries references to:
+
+```text
+ent
+rel
+sub
+obj
+$
+```
+
+where `$` is a parent/outer execution context. The old runtime frequently mutates `$.sub` or `$.rel`, and some relations execute nested entities in `$.$` or `$.$.$` contexts.
+
+Current AVM structurally decodes all three entity roles, but most bootstrap expressions intentionally use `subject = unit`. That is a good minimal kernel, not yet a full replacement for the original triune execution meaning. This is why #124 comes before broad vocabulary migration.
+
+### Context pronouns and parent traversal
+
+`jsonRVM::string_ref_to` recognizes `$ent/$rel/$sub/$obj` and hard-coded `$$`, `$$$`, `$$$$` variants. The `relative_addressing.json` fixture exercises all four roles across multiple parent depths.
+
+The **meaning** is worth preserving. The textual representation and hard-coded four-level depth are not. AVM should model parent traversal compositionally and let a frontend compile `$...` syntax into canonical reference structures (#125/#126).
+
+### Named and absolute references
+
+The `absolute_addressing.json` fixture demonstrates named entities, nested paths and `add_entity`. The old resolver can also call `database_api::get_entity` when a named entity is absent.
+
+That one code path currently conflates:
+
+- pure lookup;
+- syntax/path parsing;
+- external lazy retrieval;
+- lvalue creation/mutation.
+
+AVM must split those concerns:
+
+```text
+parse/project reference
+ -> non-mutating canonical resolve/find
+ -> optional explicit external lookup effect
+ -> optional explicit realization/write
+```
+
+A read miss must never create links.
+
+### Sequence, projection and foreach
+
+The old dictionary describes executable arrays as lambda-vectors evaluated in order. `base.rm.h` also implements `foreachobj` and `foreachsub` by creating child contexts for collection elements.
+
+This behavior belongs to canonical semantics, but JSON arrays do not. AVM already has canonical link lists and `sequence`; #127 extends that foundation to deterministic projection and foreach semantics.
+
+### Parallel object execution
+
+The old implementation/project analysis describes automatic parallel execution for object-like projections using C++ execution policies and mutex-protected mutable JSON containers.
+
+That scheduler behavior is deliberately **not** copied now. Parallelism changes observable results when operations materialize links or perform effects. AVM first classifies operations as pure, observational, materializing or externally effectful; parallel scheduling can be added only where order independence is explicit.
+
+### Pure value vocabulary
+
+`import_relations_model_to` registers a broad base vocabulary:
+
+- conversions: `int`, `integer`, `float`, `double`, `null`;
+- data operations: `where`, `union`, `size`, `get`, `set`, `erase`, `sequence/integer`;
+- arithmetic: `*`, `:`, `+`, `-`, `pow`, `sqrt`, `sum`;
+- logic/comparison: `^`, `==`, `!=`, `<`, `>`, `&&`;
+- strings: conversion, append, find, split, join;
+- control: foreach, if variants, then/else, while, typed switch, throw/catch;
+- rendering: print, tag, XML, HTML;
+- time: sleep and steady-clock values.
+
+This vocabulary cannot be ported operation-by-operation before AVM defines canonical value denotations. `nlohmann::json` coercion and type behavior is not automatically normative. #128 owns that boundary.
+
+### External vocabulary
+
+Filesystem, HTTP and dynamic dictionary loading are separate modules. They are useful capabilities, not evidence that core execution should call host APIs implicitly. #129 introduces explicit capabilities and deterministic fake providers before any large effect-vocabulary migration.
+
+## Initial compatibility matrix
+
+| ID | Old behavior | Category | AVM now | Decision | Gate |
+|---|---|---|---|---|---|
+| RM-TRIUNE-001 | `ent/rel/sub/obj` roles | canonical | partial | preserve full triune contract | #124 |
+| CTX-CURRENT-001 | current context roles | canonical | partial | canonical context access | #125 |
+| CTX-PARENT-001 | `$` parent chain | canonical | partial | unbounded compositional traversal | #125 |
+| REF-PRONOUN-001 | `$ent`, `$$obj`, ... | projection | missing | compile to reference links | #126 |
+| REF-ABSOLUTE-001 | named/path addressing | projection | missing | canonical reference algebra | #126 |
+| REF-LAZY-DB-001 | lazy DB retrieval | effect | missing | explicit lookup capability | #129 |
+| REF-LVALUE-001 | create-on-write traversal | projection/write | missing | split resolve and write | #126 |
+| EXEC-ARRAY-SEQ-001 | ordered executable arrays | canonical | partial | canonical link sequence | #127 |
+| EXEC-OBJECT-PAR-001 | parallel object projection | defer | missing | wait for effect/purity model | #127 |
+| EXEC-FOREACH-OBJ-001 | `foreachobj` | canonical | missing | deterministic link-list map | #127 |
+| EXEC-FOREACH-SUB-001 | `foreachsub` | canonical | missing | after triune contract | #127 |
+| CTRL-IF-001 | Boolean conditional | canonical | partial | differential parity baseline | #131 |
+| CTRL-WHILE-001 | while | canonical | missing | after ordering contract | #127 |
+| CTRL-SWITCH-001 | typed switch | canonical | missing | canonical keys/values | #128 |
+| ERROR-THROW-CATCH-001 | program error handling | canonical | partial | deterministic semantic failures | #131 |
+| VALUE-COPY-001 | copy/view | canonical | partial | identity + explicit projection | #124 |
+| VALUE-ARITH-001 | arithmetic | canonical | missing | canonical numeric denotation first | #128 |
+| VALUE-COMPARE-001 | compare/Boolean | canonical | partial | structural/value equality | #128 |
+| VALUE-COLLECTION-001 | size/where/union | canonical | partial | canonical list semantics | #128 |
+| VALUE-GETSET-001 | JSON get/set/erase | artifact | none | do not port literally | #126 |
+| VALUE-STRING-001 | string operations | canonical | missing | canonical byte/text denotation | #128 |
+| VALUE-TYPE-PRED-001 | JSON type predicates | artifact | n/a | only justified structural predicates | #128 |
+| DISPLAY-PRINT-001 | stdout | effect | tooling only | explicit effect/frontend | #129 |
+| DISPLAY-MARKUP-001 | tag/XML/HTML | projection | missing | after text/projection semantics | #128 |
+| EFFECT-TIME-001 | clock/sleep | effect | missing | explicit clock capability | #129 |
+| EFFECT-FS-001 | filesystem | effect | missing | explicit FS capability | #129 |
+| EFFECT-HTTP-001 | HTTP | effect | missing | fake provider first | #129 |
+| EFFECT-DLL-001 | native dictionary loading | effect | missing | plugin/capability boundary | #129 |
+| IMPL-JSON-MUTEX-001 | JSON mutexes | artifact | n/a | drop | #127 |
+| IMPL-JSON-AST-001 | JSON as code/data/context | artifact | removed | keep removed | #130 |
+
+The JSON manifest is authoritative for tooling; this table is the human summary.
+
+## Differential corpus: first selected cases
+
+### CASE-RELATIVE-ADDRESSING
+
+Source: `modules/console/test/relative_addressing.json`.
+
+It exercises every context role and parent-depth form from `$...` through `$$$$...`. The old fixture is large, so migration should split it into smaller golden cases with explicit expected semantic identities.
+
+Expected AVM property: resolving a context pronoun is observational and leaves `LinkStore::size()` unchanged.
+
+### CASE-ABSOLUTE-ADDRESSING
+
+Source: `modules/console/test/absolute_addressing.json`.
+
+This fixture deliberately mixes pure named lookup and `add_entity` behavior. AVM must separate them instead of preserving the old coupling.
+
+### CASE-BOOLEAN-BRANCH
+
+AVM already has canonical Boolean values and link-native `if`, so this is the cheapest differential execution baseline once a frozen legacy input/output fixture is extracted.
+
+### CASE-FOREACH-CONTEXT
+
+A small old-style array/foreach program should prove child-context propagation before larger projection migration.
+
+### CASE-ARITHMETIC
+
+Freeze only simple integer cases after #128 chooses an integer denotation. Raw JSON numeric representation is not the equality criterion.
+
+### CASE-MISSING-REFERENCE
+
+Capture semantic failure category/context, but do not require byte-for-byte JSON exception formatting.
+
+## Explicit non-goals of compatibility
+
+AVM does **not** promise:
+
+- the same numeric LinkIds in independent stores;
+- the same internal JSON tree;
+- the same C++ exception type/text;
+- `nlohmann::json` coercion quirks;
+- automatic JSON member creation on reads;
+- a hard four-level context limit;
+- implicit database/network/filesystem access;
+- automatic parallel execution before an effect model exists.
+
+## Relation to Anum / MTS serialization
+
+`anum_docs` gives a useful boundary rule that AVM applies to both future frontends:
+
+```text
+raw(A) != den(A)
+find(A) does not create den(A)
+realize(A) is explicit
+interpret(F) does not imply realize(F)
+```
+
+JSON text and Anum raw structure may be different, but after projection they must be able to denote the same canonical link structures. That is #130.
+
+## Next implementation order
+
+1. #124: make non-unit subject semantically meaningful without mutable host references.
+2. #125: canonical current/parent execution contexts.
+3. #126: reference algebra and non-mutating lookup.
+4. #127/#128: projection/sequence and canonical values.
+5. #129: explicit effects.
+6. #130: frontend convergence.
+7. #131: end-to-end differential program.
+
+The purpose of this inventory is to keep those gates honest: every migrated feature points back to an observable legacy behavior, while every discarded behavior has an explicit reason instead of disappearing accidentally.

--- a/tools/validate_jsonrvm_compatibility.py
+++ b/tools/validate_jsonrvm_compatibility.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Validate the versioned jsonRVM -> AVM compatibility inventory.
+
+This tool validates metadata and frozen legacy assertions only. It never
+interprets jsonRVM programs, so it cannot become a second execution path.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "compat" / "jsonrvm-semantics.json"
+GOLDEN = ROOT / "compat" / "jsonrvm-golden.json"
+
+ALLOWED_CATEGORIES = {
+    "canonical-semantic",
+    "projection-syntax",
+    "effect-adapter",
+    "implementation-artifact",
+    "defer",
+}
+ALLOWED_STATUSES = {"selected", "derive-fixture"}
+ALLOWED_EQUIVALENCE = {"observable-json-value", "legacy-provenance-only"}
+REQUIRED_ENTRY_FIELDS = {
+    "id",
+    "name",
+    "category",
+    "source_paths",
+    "behavior",
+    "current_avm",
+    "decision",
+    "target_issue",
+}
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"jsonRVM compatibility manifest: {message}")
+
+
+def load_json(path: pathlib.Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        fail(f"cannot read valid JSON from {path.relative_to(ROOT)}: {exc}")
+    if not isinstance(value, dict):
+        fail(f"{path.relative_to(ROOT)} root must be an object")
+    return value
+
+
+def require_nonempty_string(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        fail(f"{field} must be a non-empty string")
+    return value
+
+
+def require_source(source: object, prefix: str, require_runtime: bool) -> str:
+    if not isinstance(source, dict):
+        fail(f"{prefix} must be an object")
+    if source.get("repository") != "netkeep80/jsonRVM":
+        fail(f"{prefix}.repository must remain netkeep80/jsonRVM")
+    commit = require_nonempty_string(source.get("commit"), f"{prefix}.commit")
+    if len(commit) != 40 or any(ch not in "0123456789abcdef" for ch in commit):
+        fail(f"{prefix}.commit must be a lowercase 40-character Git commit SHA")
+    if require_runtime:
+        require_nonempty_string(source.get("runtime_version"), f"{prefix}.runtime_version")
+    return commit
+
+
+def validate_manifest(data: dict[str, object]) -> tuple[str, int, set[str]]:
+    if data.get("schema_version") != 1:
+        fail("compat/jsonrvm-semantics.json schema_version must be 1")
+
+    commit = require_source(data.get("source"), "source", require_runtime=True)
+
+    declared_categories = data.get("categories")
+    if set(declared_categories or []) != ALLOWED_CATEGORIES:
+        fail("categories must exactly match the version-1 classification vocabulary")
+
+    entries = data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        fail("entries must be a non-empty array")
+
+    entry_ids: set[str] = set()
+    for index, entry in enumerate(entries):
+        prefix = f"entries[{index}]"
+        if not isinstance(entry, dict):
+            fail(f"{prefix} must be an object")
+        missing = REQUIRED_ENTRY_FIELDS - entry.keys()
+        if missing:
+            fail(f"{prefix} misses fields: {', '.join(sorted(missing))}")
+
+        entry_id = require_nonempty_string(entry["id"], f"{prefix}.id")
+        if entry_id in entry_ids:
+            fail(f"duplicate entry id {entry_id}")
+        entry_ids.add(entry_id)
+
+        require_nonempty_string(entry["name"], f"{prefix}.name")
+        require_nonempty_string(entry["behavior"], f"{prefix}.behavior")
+        require_nonempty_string(entry["current_avm"], f"{prefix}.current_avm")
+        require_nonempty_string(entry["decision"], f"{prefix}.decision")
+
+        if entry["category"] not in ALLOWED_CATEGORIES:
+            fail(f"{prefix}.category is unknown: {entry['category']!r}")
+
+        paths = entry["source_paths"]
+        if not isinstance(paths, list) or not paths:
+            fail(f"{prefix}.source_paths must be a non-empty array")
+        for path_index, path in enumerate(paths):
+            require_nonempty_string(path, f"{prefix}.source_paths[{path_index}]")
+
+        issue = entry["target_issue"]
+        if not isinstance(issue, int) or issue < 122:
+            fail(f"{prefix}.target_issue must reference the AVM 1.5 issue family")
+
+    corpus = data.get("corpus_candidates")
+    if not isinstance(corpus, list) or not corpus:
+        fail("corpus_candidates must be a non-empty array")
+
+    case_ids: set[str] = set()
+    selected_case_ids: set[str] = set()
+    for index, case in enumerate(corpus):
+        prefix = f"corpus_candidates[{index}]"
+        if not isinstance(case, dict):
+            fail(f"{prefix} must be an object")
+        case_id = require_nonempty_string(case.get("id"), f"{prefix}.id")
+        if case_id in case_ids:
+            fail(f"duplicate corpus case id {case_id}")
+        case_ids.add(case_id)
+        require_nonempty_string(case.get("source"), f"{prefix}.source")
+        require_nonempty_string(case.get("notes"), f"{prefix}.notes")
+
+        status = case.get("status")
+        if status not in ALLOWED_STATUSES:
+            fail(f"{prefix}.status must be one of {sorted(ALLOWED_STATUSES)}")
+        if status == "selected":
+            selected_case_ids.add(case_id)
+
+        covers = case.get("covers")
+        if not isinstance(covers, list) or not covers:
+            fail(f"{prefix}.covers must be a non-empty array")
+        unknown = [entry_id for entry_id in covers if entry_id not in entry_ids]
+        if unknown:
+            fail(f"{prefix}.covers references unknown entries: {', '.join(unknown)}")
+
+    return commit, len(entries), selected_case_ids
+
+
+def validate_golden(data: dict[str, object], source_commit: str, selected_case_ids: set[str]) -> int:
+    if data.get("schema_version") != 1:
+        fail("compat/jsonrvm-golden.json schema_version must be 1")
+
+    golden_commit = require_source(data.get("source"), "golden.source", require_runtime=False)
+    if golden_commit != source_commit:
+        fail("semantic inventory and golden assertions must pin the same jsonRVM commit")
+
+    source = data["source"]
+    assert isinstance(source, dict)
+    require_nonempty_string(source.get("assertions_from"), "golden.source.assertions_from")
+
+    cases = data.get("cases")
+    if not isinstance(cases, list) or not cases:
+        fail("golden.cases must be a non-empty array")
+
+    golden_ids: set[str] = set()
+    for index, case in enumerate(cases):
+        prefix = f"golden.cases[{index}]"
+        if not isinstance(case, dict):
+            fail(f"{prefix} must be an object")
+        case_id = require_nonempty_string(case.get("id"), f"{prefix}.id")
+        if case_id in golden_ids:
+            fail(f"duplicate golden case id {case_id}")
+        golden_ids.add(case_id)
+
+        require_nonempty_string(case.get("fixture"), f"{prefix}.fixture")
+        require_nonempty_string(case.get("test_name"), f"{prefix}.test_name")
+        require_nonempty_string(case.get("avm_target"), f"{prefix}.avm_target")
+        if case.get("equivalence") not in ALLOWED_EQUIVALENCE:
+            fail(f"{prefix}.equivalence must be one of {sorted(ALLOWED_EQUIVALENCE)}")
+
+        assertions = case.get("assertions")
+        if not isinstance(assertions, list) or not assertions:
+            fail(f"{prefix}.assertions must be a non-empty array")
+        assertion_paths: set[str] = set()
+        for assertion_index, assertion in enumerate(assertions):
+            assertion_prefix = f"{prefix}.assertions[{assertion_index}]"
+            if not isinstance(assertion, dict):
+                fail(f"{assertion_prefix} must be an object")
+            path = require_nonempty_string(assertion.get("path"), f"{assertion_prefix}.path")
+            if not path.startswith("/"):
+                fail(f"{assertion_prefix}.path must be an absolute JSON pointer used only as a legacy oracle path")
+            if path in assertion_paths:
+                fail(f"duplicate assertion path {path} in {case_id}")
+            assertion_paths.add(path)
+            if "equals" not in assertion:
+                fail(f"{assertion_prefix} must contain equals")
+
+    missing_golden = selected_case_ids - golden_ids
+    if missing_golden:
+        fail(f"selected corpus cases lack frozen golden assertions: {', '.join(sorted(missing_golden))}")
+
+    return len(cases)
+
+
+def main() -> int:
+    manifest = load_json(MANIFEST)
+    source_commit, entry_count, selected_case_ids = validate_manifest(manifest)
+    golden_count = validate_golden(load_json(GOLDEN), source_commit, selected_case_ids)
+
+    corpus = manifest["corpus_candidates"]
+    assert isinstance(corpus, list)
+    print(
+        "jsonRVM compatibility inventory OK: "
+        f"{entry_count} semantic entries, {len(corpus)} corpus candidates, "
+        f"{golden_count} frozen legacy cases, source {source_commit[:12]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Part of #123. Parent epic #122.

## Purpose
Turn the existing structural jsonRVM/AVM compatibility note into a versioned semantic migration contract before AVM starts porting the legacy vocabulary.

## What this slice adds
- pins the audit to `netkeep80/jsonRVM@843b3326141e090ccd1a106ba0a4a21ce72805b7` / runtime 3.0.0;
- classifies legacy behavior as `canonical-semantic`, `projection-syntax`, `effect-adapter`, `implementation-artifact`, or `defer`;
- records current AVM coverage, migration decision and owning AVM 1.5 gate for each entry;
- selects initial differential-corpus candidates for context addressing, named addressing, Boolean branching, foreach contexts, arithmetic and missing references;
- freezes legacy doctest assertions for relative addressing, absolute addressing, `where`, and runtime provenance without embedding or executing the old interpreter;
- expands `docs/jsonrvm-compatibility.md` while preserving the already-established `(rel,sub,obj) <-> Link(rel,Link(sub,obj))` structural contract;
- adds a metadata-only Python validator and focused CI workflow. The validator checks manifest/golden consistency but does not interpret jsonRVM programs and cannot become a second execution path.

## Main architectural conclusion
The tuple-to-dyad representation is no longer the blocker. The remaining migration problem is semantic: jsonRVM conflates program syntax, values, mutable context and model storage in `nlohmann::json`. AVM 1.5 therefore preserves observable Relations Model semantics while keeping JSON/Anum as frontends, effects explicit, and Executor LinkId-native.

## #123 status after this slice
#123 remains open. This PR establishes the stable semantic IDs, source provenance and first frozen oracle assertions. Follow-up work still needs to derive the remaining Boolean/foreach/arithmetic/missing-reference golden cases and then use those IDs as conformance targets for #124–#131.

## Vetoes
- no production Executor/runtime changes;
- no JSON interpreter or legacy fallback;
- no copied jsonRVM execution code;
- no implicit materialization;
- no claim of raw JSON representation parity.