### PR TITLE
CI: gate tagged artifact on full portable matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
   release-artifact:
     name: Tagged Linux artifact
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [core, package-consumer, json-compat, cli-roundtrip, sanitizers]
+    needs: [core, package-consumer, json-compat, cli-roundtrip, sanitizers, portable]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
Closes #121.

## Fix
Add `portable` to the `release-artifact.needs` list so a tagged Linux artifact cannot become eligible until the supported Ubuntu/Windows/macOS portable matrix is green.

## Scope
The final diff is one CI dependency change. Ordinary pull-request jobs and artifact contents are unchanged.

## Release invariant
A Linux-only published artifact may still be produced, but publication eligibility remains gated by the full supported-platform test matrix.