### PR TITLE
Документация: перевести нормативное ядро AVM на русский

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,80 @@
 <p align="center"><img src="EOSR.jpg"></p>
 
-# AVM — Associative Virtual Machine
+# AVM — ассоциативная виртуальная машина
 
-AVM is an experimental C++20 virtual machine built on the Relations Model and a canonical store of directed links.
+AVM — экспериментальная виртуальная машина на C++20, построенная поверх Модели Отношений и канонического хранилища направленных связей.
 
-**Current public version: 1.3.0.**
+**Текущая публичная версия: 1.3.0.** Архитектурное развитие репозитория уже прошло этапы AVM 1.0–1.4; текущая ветка работ AVM 1.5 посвящена переносу существенной семантики `jsonRVM` в единый link-native runtime.
 
-## Semantic path
+## Главная идея
 
-There is one production semantic path:
+AVM использует один производственный семантический путь:
 
 ```text
-external representation
-  -> projection / adapter
-  -> canonical LinkStore
-  -> Relations Model entity codec
-  -> LinkId program
+внешнее представление
+  -> проекция / адаптер
+  -> канонический LinkStore
+  -> кодек Модели Отношений
+  -> программа как LinkId
   -> BootstrapRuntime / Executor
-  -> result LinkId
+  -> LinkId результата
 ```
 
-JSON is an external projection and compatibility protocol. Anum/MTS grammar and contextual denotation remain canonical in `netkeep80/anum_docs`; AVM consumes only the storage-neutral structural denotation handoff. Neither format is the VM AST or execution core.
+JSON является внешней проекцией и протоколом совместимости. Грамматика Anum/МТС и контекстная денотация остаются канонически определёнными в `netkeep80/anum_docs`; AVM принимает только структурный, независимый от физического хранилища результат проекции. Ни JSON, ни Anum не являются внутренним AST виртуальной машины.
 
-The physical primitive is a canonical directed dyad:
+Физический примитив AVM — канонический направленный дуплет:
 
 ```text
 LinkId -> (begin: LinkId, end: LinkId)
 ```
 
-`LinkId` is opaque. Reads do not materialize missing links, and `intern(a,b)` returns the canonical identity for an exact pair inside one logical store.
+`LinkId` — непрозрачная идентичность. Операции чтения не материализуют отсутствующие связи, а `intern(a,b)` возвращает канонический `LinkId` точной пары в пределах одного логического хранилища.
 
-## AVM 1.0 foundation — complete
+## Модель Отношений поверх дуплетов
 
-AVM 1.0 established and validated:
+Триединая сущность Модели Отношений имеет роли:
 
-- `LinkStore` as the storage contract, with in-memory and persistent reference implementations;
-- canonical Relations Model encoding `(relation, subject, object) = (relation, (subject, object))`;
-- explicit bootstrap vocabulary identity;
-- link-native execution through `BootstrapRuntime` and `Executor`;
-- associative program structures, bindings and call frames represented by links;
-- parser-independent protocol projection boundary;
-- canonical structural Anum L3→L4 bridge with no grammar duplication in AVM;
-- separate JSON value and JSON program/session adapters;
-- persistent reopen/identity conformance independent from VM semantics;
-- installed-package consumer validation on Linux, Windows and macOS;
-- warnings-as-errors, sanitizers, architecture quality guards and benchmark baselines.
+```text
+(relation, subject, object)
+```
 
-The former pointer-based `rel_t` universe, JSON semantic interpreter and temporary protocol-value-only Anum bridge have been removed. Git history preserves them; AVM keeps one semantic path.
+В AVM используется один канонический порядок вложения:
 
-## AVM 1.1 — read-only associative queries — complete
+```text
+subject_object = Link(subject, object)
+entity         = Link(relation, subject_object)
+```
 
-AVM 1.1 added a dependency-free Relations Model query layer:
+то есть:
+
+```text
+(relation, subject, object)
+= (relation, (subject, object))
+```
+
+Такое представление сохраняет все три роли без отдельного физического типа «триплет».
+
+## AVM 1.0 — архитектурный фундамент завершён
+
+AVM 1.0 сформировал и проверил:
+
+- `LinkStore` как единый контракт хранения, с эталонными in-memory и persistent реализациями;
+- каноническое представление `(relation, subject, object) = (relation, (subject, object))`;
+- явные идентичности bootstrap-словаря;
+- link-native исполнение через `BootstrapRuntime` и `Executor`;
+- программы, функции, bindings и call frames как связи;
+- независимую от parser/grammar границу внешних проекций;
+- структурный мост Anum L3→L4 без дублирования грамматики МТС внутри AVM;
+- отдельные адаптеры JSON-значений и JSON-программ;
+- сохранение идентичности после закрытия и повторного открытия persistent backend;
+- проверку установленного пакета на Linux, Windows и macOS;
+- warnings-as-errors, ASan/UBSan, архитектурные CI-guards и benchmark baselines.
+
+Исторические pointer-based `rel_t`, JSON semantic interpreter и временный protocol-only Anum bridge удалены после миграции потребителей. История остаётся в Git; в рабочей архитектуре существует один семантический путь.
+
+## AVM 1.1 — ассоциативные запросы только для чтения завершены
+
+AVM 1.1 добавил независимый от backend слой запросов к Модели Отношений:
 
 ```cpp
 avm::RelationQuery query{
@@ -62,51 +86,65 @@ avm::RelationQuery query{
 const auto matches = avm::query_relation_entities(store, query);
 ```
 
-At least one relation/subject/object field must be constrained. Queries use only the existing `LinkStore` `find/outgoing/incoming/get/contains` contract; they never call `intern` or `create_point`, and they do not introduce a second index universe.
+Хотя бы одно из полей `relation/subject/object` должно быть ограничено. Запросы используют только существующие операции `LinkStore`: `find`, `outgoing`, `incoming`, `get`, `contains`. Они не вызывают `intern` и `create_point` и не создают второй мир индексов.
 
-Relations Model querying is structural rather than registry-based. AVM does not track a hidden list of links "created as entities"; domain restrictions must themselves be represented through links/relations.
+Запросы структурны, а не registry-based. AVM не хранит скрытый список связей, которые «были созданы как сущности». Более узкие домены должны задаваться самими связями и отношениями.
 
-Fan-out benchmarks at 1/8/64/256 demonstrated the expected candidate-expansion cost but did not justify an additional persistent physical index without a concrete workload SLA. Extra indexes remain deferred until measured workloads require them.
+Измерения fan-out 1/8/64/256 показали ожидаемый рост стоимости расширения кандидатов, но не дали оснований добавлять дополнительный persistent physical index без реального workload/SLA.
 
-See [Relations Model query contract](docs/relations-query.md).
+См. [контракт запросов Модели Отношений](docs/relations-query.md).
 
-## AVM 1.2 — structural standard library — complete
+## AVM 1.2 — структурная стандартная библиотека завершена
 
-AVM 1.2 makes canonical dyad structure directly usable by link-native programs.
+AVM 1.2 сделал структуру дуплетов непосредственно доступной link-native программам.
 
-The minimal native structural kernel is:
+Минимальное нативное ядро:
 
 ```text
-link_begin(expr)       -> begin pole
-link_end(expr)         -> end pole
-identity_equal(a,b)    -> canonical Boolean
-link_exists(a,b)       -> canonical Boolean, observational
-pair_intern(a,b)       -> canonical LinkId(a,b), explicit effect
+link_begin(expr)       -> begin-полюс
+link_end(expr)         -> end-полюс
+identity_equal(a,b)    -> каноническое Boolean-значение
+link_exists(a,b)       -> каноническое Boolean-значение, только наблюдение
+pair_intern(a,b)       -> канонический LinkId(a,b), явный эффект
 ```
 
-`link_exists` does not use `nil` as a missing sentinel because `nil` is itself a valid self-link. `pair_intern` is the explicit materialization boundary and is idempotent through `LinkStore::intern`.
+`link_exists` не использует `nil` как признак отсутствия, потому что `nil` сам является допустимой self-link. `pair_intern` — явная граница материализации и идемпотентен благодаря `LinkStore::intern`.
 
-Operations reducible to this kernel are ordinary AVM functions rather than new C++ native handlers. For example:
+Операции, выражаемые через это ядро, реализуются обычными функциями AVM, а не новыми C++ handlers. Например:
 
 ```text
 is_self_link(x) = identity_equal(link_begin(x), link_end(x))
 ```
 
-Function definitions, bindings and call frames remain links. A first function call may therefore materialize canonical execution-state links even when the composed function body contains only observational primitives; this is existing call-frame semantics, not a hidden library effect.
+См. [структурную стандартную библиотеку](docs/structural-standard-library.md).
 
-See [Structural standard library](docs/structural-standard-library.md).
+## AVM 1.3 — наблюдаемость исполнения завершена
 
-## AVM 1.3 — execution observability
+AVM 1.3 добавил детерминированное наблюдение к существующему `Executor::execute` без возможности управлять исполнением.
 
-AVM 1.3 adds deterministic, non-controlling observation to the existing `Executor::execute` path. `ExecutionEvent` uses only canonical AVM data: `Enter`, `Return` and `Fail`, the decoded `ExecutionContext`, optional result `LinkId`, and a finite failure phase (`Dispatch`, `Handler`, `ResultValidation`).
+`ExecutionEvent` содержит только канонические данные AVM:
 
-Observers cannot replace handlers, skip execution or substitute results. Observer exceptions are isolated from program control flow, and observation itself does not materialize links. Nested calls and failure unwind are observed through the same executor recursion, including explicit parent/frame identities.
+```text
+Enter(ExecutionContext)
+Return(ExecutionContext, result LinkId)
+Fail(ExecutionContext, phase)
+```
 
-`BoundedExecutionTrace` is the reusable public host-memory collector. It reserves a configured event capacity before normal execution, exposes immutable events, reports truncation explicitly, and never becomes `Executor` or `LinkStore` semantic state.
+Для отказов используется конечная классификация фаз:
 
-Persistence conformance distinguishes two identity claims: the same `PersistentLinkStore` must produce exactly identical LinkId-based traces after reopen, while independently constructed backends are compared only modulo bijective renaming of opaque LinkIds. AVM never treats raw numeric LinkIds as globally comparable across stores.
+```text
+Dispatch
+Handler
+ResultValidation
+```
 
-The CLI is a real consumer of the same public observation boundary:
+Наблюдатель не может заменить handler, пропустить исполнение или подменить результат. Его исключения изолированы от программы. Наблюдение не материализует связи.
+
+`BoundedExecutionTrace` хранит ограниченный префикс событий в памяти host-среды и явно сообщает о truncation.
+
+Для одного и того же `PersistentLinkStore` после reopen требуется точное совпадение LinkId-based traces. Для независимо построенных backends сравнение выполняется с точностью до биективного переименования непрозрачных `LinkId`.
+
+CLI использует тот же executor:
 
 ```text
 avm program.json
@@ -114,19 +152,61 @@ avm --trace program.json
 avm --trace-limit 64 program.json
 ```
 
-Normal mode preserves the compatibility behavior. Trace mode uses the existing `JsonProgramImporter`, the same `BootstrapRuntime::execute(LinkId)` path and existing JSON result projection; it merely attaches `BoundedExecutionTrace` and renders the retained events. Text labels are tooling presentation, not string opcodes or canonical trace identity. Failing executions render retained `Fail(phase)` events before the normal host diagnostic, and trace truncation is never silent.
+См. [контракт наблюдаемости исполнения](docs/execution-observability.md).
 
-See [Execution observability contract](docs/execution-observability.md).
+## AVM 1.4 — инспекция и диагностический tooling завершены
 
-## Supported core library API
+AVM 1.4 построил слой инспекции поверх существующих публичных API, не создавая второго executor или отдельной семантики.
 
-The dependency-free C++ core surface is available through:
+`InspectionSession` объединяет:
+
+- наблюдение связей и сущностей;
+- запросы Модели Отношений;
+- запуск через существующий `BootstrapRuntime`;
+- сбор `BoundedExecutionTrace`;
+- persistent reopen scenarios.
+
+Текстовые inspection-команды являются только интерфейсом tooling: после parsing они превращаются в типизированные команды и используют тот же runtime.
+
+См. [сессию инспекции](docs/inspection-session.md), [команды инспекции](docs/inspection-commands.md) и [persistent inspection session](docs/persistent-inspection-session.md).
+
+## AVM 1.5 — перенос семантики Relations Model из jsonRVM
+
+Текущий этап развития отвечает на более сильный вопрос: может ли AVM быть не просто VM поверх дуплетов, а полноценным link-native исполнителем существенной семантики старого `jsonRVM`?
+
+Representation problem уже решён. Оставшаяся задача — execution semantics.
+
+В `jsonRVM` самостоятельный смысл имеют все роли:
+
+```text
+relation = controller
+subject  = view / receiver / manifestation
+object   = model / input
+```
+
+Кроме этого, старый runtime содержит:
+
+- текущий и родительские контексты `ent/rel/sub/obj`;
+- `$ent/$rel/$sub/$obj` и `$$...`;
+- абсолютные и относительные ссылки;
+- sequence/lambda/projection semantics;
+- `foreach` и дочерние контексты;
+- pure value vocabulary;
+- filesystem/HTTP/time/native эффекты.
+
+AVM 1.5 переносит эти свойства без возврата к JSON interpreter. Главный epic — #122, первый активный gate — #123.
+
+В `main` уже есть versioned semantic inventory и frozen golden corpus, привязанные к конкретному commit `jsonRVM`. См. [совместимость jsonRVM и AVM](docs/jsonrvm-compatibility.md).
+
+## Публичный API ядра
+
+Независимый от JSON C++ API доступен через:
 
 ```cpp
 #include <avm/avm.h>
 ```
 
-A minimal link-native execution looks like this:
+Минимальный пример link-native исполнения:
 
 ```cpp
 #include <avm/avm.h>
@@ -145,11 +225,9 @@ int main()
 }
 ```
 
-The umbrella header intentionally does not include JSON adapters. JSON remains optional and is not part of the dependency-free `avm::core` execution contract.
+Umbrella-header намеренно не включает JSON adapters. JSON не является зависимостью `avm::core`.
 
-## Install and consume with CMake
-
-Install AVM into a prefix:
+## Установка и использование через CMake
 
 ```bash
 cmake -S . -B build-install \
@@ -160,28 +238,30 @@ cmake -S . -B build-install \
 cmake --install build-install
 ```
 
-A consuming CMake project can require the current AVM 1.3 package:
+В consuming project:
 
 ```cmake
 find_package(avm 1.3 CONFIG REQUIRED)
 target_link_libraries(my_program PRIVATE avm::core)
 ```
 
-`avm::core` is a header-only C++20 target. Its installed interface points only at the install prefix and does not depend on repository-relative source or `3p` include paths.
+`avm::core` — header-only C++20 target. Установленный interface указывает только на install prefix и не зависит от repository-relative путей или `3p`.
 
-## Version and compatibility policy
+## Версионирование и совместимость
 
-AVM uses Semantic Versioning for documented public core contracts. CMake and `include/avm/version.h` must match exactly; CI also rejects tagged builds unless the tag is exactly `v<project-version>`.
+AVM использует Semantic Versioning для документированных публичных контрактов ядра. Версии в CMake и `include/avm/version.h` обязаны совпадать. CI отклоняет tagged build, если тег не равен `v<project-version>`.
 
-Compatibility within AVM 1.x applies to documented public contracts exposed through `<avm/avm.h>` and `avm::core`. Header-only implementation details, private layout and incidental helpers are not an ABI promise. See [AVM 1.x release policy](docs/release-policy.md).
+Совместимость внутри AVM 1.x относится к документированным контрактам через `<avm/avm.h>` и `avm::core`. Внутренняя структура header-only реализации не является ABI-обещанием.
+
+См. [политику релизов AVM 1.x](docs/release-policy.md).
 
 ## Backends
 
-`InMemoryLinkStore` is the reference backend. `PersistentLinkStore` proves reopen and identity semantics. Additional physical backends are replaceable implementations of the same `LinkStore` contract.
+`InMemoryLinkStore` — эталонный backend. `PersistentLinkStore` доказывает reopen/identity semantics. Другие физические backends должны реализовывать тот же контракт `LinkStore`.
 
-Backend code must not define VM relations, query semantics, JSON rules, protocol grammar or execution semantics.
+Backend не имеет права определять relations VM, query semantics, JSON rules, Anum grammar или execution semantics.
 
-## Reproducible repository validation
+## Воспроизводимая проверка репозитория
 
 ```bash
 git clone https://github.com/netkeep80/avm.git
@@ -191,37 +271,44 @@ cmake --build build --parallel
 ctest --test-dir build --output-on-failure
 ```
 
-CI installs the package into a staging prefix and builds an external consumer on Linux, Windows and macOS using only `find_package` and `avm::core`. The full portable matrix also runs the trace-enabled CLI conformance cases.
+CI устанавливает пакет во временный prefix и собирает внешний consumer на Linux, Windows и macOS через `find_package` и `avm::core`. Полная portable matrix также выполняет conformance tests CLI и адаптеров.
 
-## Architecture documents
+## Основные документы
 
-- [AVM architecture contract](docs/architecture.md)
-- [Execution kernel](docs/execution-kernel.md)
-- [Execution observability contract](docs/execution-observability.md)
-- [External protocol adapter contract](docs/protocol-adapter-contract.md)
-- [Anum L3→L4 bridge](docs/anum-l3-l4-bridge.md)
-- [Relations Model query contract](docs/relations-query.md)
-- [Structural standard library](docs/structural-standard-library.md)
-- [Persistent LinkStore contract](docs/persistent-link-store.md)
-- [AVM 1.x release policy](docs/release-policy.md)
-- [Project analysis](analysis.md)
-- [Roadmap](plan.md)
+- [Архитектурный контракт AVM](docs/architecture.md)
+- [Ядро исполнения](docs/execution-kernel.md)
+- [Модель link-native программ](docs/program-model.md)
+- [Функции, bindings и call frames](docs/functions-and-frames.md)
+- [Структурная стандартная библиотека](docs/structural-standard-library.md)
+- [Запросы Модели Отношений](docs/relations-query.md)
+- [Наблюдаемость исполнения](docs/execution-observability.md)
+- [Сессия инспекции](docs/inspection-session.md)
+- [Контракт адаптера внешнего протокола](docs/protocol-adapter-contract.md)
+- [Граница проекции](docs/projection-boundary.md)
+- [Мост Anum L3→L4](docs/anum-l3-l4-bridge.md)
+- [Persistent LinkStore](docs/persistent-link-store.md)
+- [Совместимость jsonRVM и AVM](docs/jsonrvm-compatibility.md)
+- [Политика релизов](docs/release-policy.md)
+- [Анализ проекта](analysis.md)
+- [План развития](plan.md)
 
-## Project status
+## Язык документации
 
-AVM 1.0 foundation, AVM 1.1 read-only queries and AVM 1.2 structural standard-library gates are complete. AVM 1.3 provides deterministic observation, failure-phase classification, bounded trace collection, persistence/backend conformance and trace-enabled CLI tooling while preserving the single `LinkStore -> Relations Model -> Executor` execution path.
+Нормативный язык проектной документации AVM — русский. Имена публичного API, identifiers, форматы, команды, имена внешних проектов и кодовые примеры сохраняются в исходном техническом виде.
 
-## Dependencies
+Лицензия и документация вендорного кода не переводятся как часть документации AVM.
 
-Core library:
+## Зависимости
 
-- C++20 compiler
-- CMake 3.20+
+Ядро:
 
-Optional JSON boundary/CLI:
+- компилятор C++20;
+- CMake 3.20+.
 
-- bundled `nlohmann/json`
+Опциональная JSON boundary / CLI:
 
-## License
+- встроенный `nlohmann/json`.
+
+## Лицензия
 
 MIT License. Copyright © 2022 Vertushkin Roman Pavlovich.

--- a/analysis.md
+++ b/analysis.md
@@ -1,174 +1,372 @@
 # Анализ проекта AVM
 
-## Текущее архитектурное состояние
+## Краткий вывод
 
-AVM завершил Architecture Foundation / AVM 1.0 и перешёл к развитию совместимых 1.x facilities. Ядро строится вокруг одного канонического пространства ссылок и исполняет программы по `LinkId`:
+AVM уже прошёл стадию раннего прототипа и имеет устойчивое link-native ядро. Главная архитектурная проблема старой реализации — ситуация, когда данные были представлены связями, а исполнение оставалось отдельным JSON/C++-интерпретатором, — устранена в AVM 1.0.
+
+Текущая задача сложнее: AVM должен доказать, что способен выразить существенную семантику Модели Отношений из `jsonRVM` непосредственно через связи, не возвращая JSON AST, строковый dispatch или скрытое C++-состояние в семантическое ядро.
+
+Поэтому развитие разделяется на две уже пройденные стадии и одну текущую:
 
 ```text
-external representation
-  -> projection / protocol adapter
+AVM 1.0–1.4
+  архитектурный фундамент, запросы, structural stdlib,
+  наблюдаемость и inspection tooling
+
+AVM 1.5
+  перенос семантики Relations Model из jsonRVM
+```
+
+## Текущий канонический путь исполнения
+
+В AVM существует один производственный путь:
+
+```text
+внешнее представление
+  -> проекция / protocol adapter
   -> canonical LinkStore
   -> Relations Model codec
-  -> LinkId program
+  -> LinkId программы
   -> BootstrapRuntime / Executor
-  -> result LinkId
+  -> LinkId результата
 ```
 
-Это единственный semantic path. Удалённые `rel_t`, JSON-interpreter и protocol-only Anum bridge не являются compatibility-ядрами и не должны возвращаться.
+Удалённые исторические механизмы (`rel_t`, JSON semantic interpreter, `func_env`, `param_stack`, protocol-only Anum bridge) не являются compatibility-ядром и не должны возвращаться.
 
-## Foundation, который уже закрыт
+## 1. Физическая модель связей
 
-### Link model и LinkStore
-
-Физический примитив — направленная диада `LinkId -> (begin,end)`. `LinkId` непрозрачен. `find/get/outgoing/incoming` наблюдают существующую структуру; `intern/create_point` являются явными mutation operations.
-
-`InMemoryLinkStore` — reference backend. `PersistentLinkStore` доказал reopen/identity semantics и индексный rebuild; одинаковые observable contracts проверяются в CI.
-
-### Relations Model
-
-Исполнимая сущность кодируется единственным порядком вложения:
+Физический примитив AVM — направленный дуплет:
 
 ```text
-(relation, subject, object) = (relation, (subject, object))
+LinkId -> (begin, end)
 ```
 
-Никакого внешнего type registry для «entity links» нет: принадлежность Relations Model определяется структурой ссылок.
+`LinkId` является непрозрачной идентичностью. Семантический код не зависит от адресов C++ объектов, расположения памяти или внутренней структуры backend.
 
-### Execution
+Канонизация задаётся инвариантом:
 
-`BootstrapRuntime` создаёт bootstrap vocabulary identity. `Executor` принимает entity `LinkId`, декодирует Relations Model entity и dispatch-ит по relation `LinkId`.
+```text
+intern(a,b) == intern(a,b)
+```
 
-Program structures, bindings и call frames представлены ссылками, а не JSON AST или скрытым C++ environment.
+в пределах одного логического хранилища.
 
-### Projection boundary
+Наблюдающие операции:
 
-JSON, Anum и другие форматы находятся вне execution kernel. Конкретный внешний протокол владеет grammar/parsing/context semantics и передаёт AVM только structural projection/denotation.
+```text
+find
+get
+outgoing
+incoming
+contains
+```
 
-Ключевая граница:
+не должны материализовать отсутствующие связи.
+
+Явные операции изменения:
+
+```text
+create_point
+intern
+realize
+```
+
+должны быть видимы как write/effect boundary.
+
+## 2. Модель Отношений
+
+Триединая сущность:
+
+```text
+(relation, subject, object)
+```
+
+представляется двумя каноническими дуплетами:
+
+```text
+subject_object = Link(subject, object)
+entity         = Link(relation, subject_object)
+```
+
+или математически:
+
+```text
+(relation, subject, object)
+= (relation, (subject, object))
+```
+
+Это важный результат, но он решает только задачу представления. Он не определяет автоматически семантику исполнения `relation`, `subject` и `object`.
+
+`LinkStore` не знает, что такое relation, subject или object. Эти роли принадлежат слою Модели Отношений.
+
+## 3. Исполнение
+
+`Executor` принимает `LinkId` сущности, декодирует её через Relations Model codec, формирует явный `ExecutionContext` и dispatch-ит по `LinkId` отношения.
+
+Ключевые свойства:
+
+- никаких строковых opcode в semantic path;
+- JSON не является instruction type;
+- native C++ handlers допустимы только как bootstrap boundary;
+- пользовательские program structures существуют в `LinkStore`;
+- bindings и call frames представлены связями;
+- backend не определяет execution semantics.
+
+AVM 1.0 доказал, что программа может быть данными той же асети, в которой находятся остальные сущности.
+
+## 4. Программы, функции и call frames
+
+Link-native program model включает:
+
+- vocabulary identities;
+- literals/quote;
+- parameters;
+- sequence;
+- Boolean relations;
+- lazy `IF`;
+- function handles и definitions;
+- call expressions;
+- bindings;
+- parent-linked call frames.
+
+Состояние вызовов больше не хранится только в `std::map<string,...>` или JSON body.
+
+Это устраняет старый разрыв гомоиконичности, когда программа физически существовала в другом мире, чем данные.
+
+## 5. JSON и Anum как внешние проекции
+
+JSON и Anum находятся за пределами execution kernel.
+
+Для Anum особенно важна граница L3/L4:
 
 ```text
 raw(A) != den(A)
-load(A) does not imply den(A)
-find(A) is observational
-realize(A) explicitly materializes denotation
+load(A) не означает materialize(den(A))
+find(A) только наблюдает
+realize(A) явно материализует denotation
 ```
 
-Canonical Anum semantics находятся в `netkeep80/anum_docs`; AVM structural bridge не содержит Anum parser или recursive grammar.
+Каноническая грамматика и контекстная семантика Anum/МТС находятся в `netkeep80/anum_docs`. AVM не должен становиться второй реализацией МТС.
 
-### Release/package validation
+`RawCarrier` хранит непрозрачный сырой носитель независимо от `LinkStore`. `ProjectionDescription` описывает структурную денотацию независимо от parser. `find_projection` и `realize_projection` разделяют read/write semantics.
 
-AVM 1.0 public package прошёл installed-consumer и portable validation на Linux, Windows и macOS, а также strict warnings, sanitizers и benchmark gates. Поэтому package portability больше не является незакрытым foundation-risk.
+## 6. Backends и persistence
 
-## AVM 1.1: read-only associative query layer
+`InMemoryLinkStore` — эталонный backend.
 
-Первое post-1.0 направление — запросы поверх уже существующей Relations Model структуры.
+`PersistentLinkStore` доказывает:
 
-Новая граница:
+- стабильность `LinkId` после reopen;
+- восстановление canonical pair identity;
+- детерминированное восстановление `outgoing/incoming` indexes;
+- отказ от принятия повреждённого snapshot;
+- явное faulted-state поведение после exception внутри mutation region.
+
+Это reference persistence backend, а не обещание production-grade crash consistency. WAL, atomic snapshot swap, locking и concurrent writer protocol требуют отдельного backend design.
+
+## 7. AVM 1.1 — запросы
+
+`RelationQuery` позволяет ограничивать `relation`, `subject` и/или `object` и строит кандидатов только на существующих `find/outgoing/incoming` индексах.
+
+Запросы:
+
+- не вызывают `intern`/`create_point`;
+- не предполагают contiguous `LinkId`;
+- не создают hidden entity registry;
+- детерминированы;
+- одинаково работают для in-memory и persistent backend.
+
+Fan-out benchmarks показали стоимость расширения кандидатов, но пока нет реального SLA, оправдывающего новый физический индекс.
+
+## 8. AVM 1.2 — структурная стандартная библиотека
+
+Нативное structural kernel минимально:
 
 ```text
-RelationQuery(relation?, subject?, object?)
--> existing LinkStore indexes
--> decode/filter
--> deterministic RelationMatch[]
+link_begin
+link_end
+identity_equal
+link_exists
+pair_intern
 ```
 
-Запросы принципиально не создают отдельный индексный universe. Используются только `find`, `outgoing`, `incoming`, `get`, `contains`.
+Наблюдающие операции отделены от явного эффекта `pair_intern`.
 
-### Почему нет hidden entity registry
+Более сложные операции должны по возможности выражаться ordinary AVM functions, а не разрастанием native handler registry.
 
-`decode_relation_entity` структурен. Если существует point:
+## 9. AVM 1.3 — наблюдаемость
+
+Наблюдение встроено в существующий `Executor::execute` и не управляет исполнением.
+
+События:
 
 ```text
-x = (x,x)
+Enter
+Return
+Fail
 ```
 
-то он также структурно читается как:
+с конечной классификацией failure phase:
 
 ```text
-(x, x, x)
+Dispatch
+Handler
+ResultValidation
 ```
 
-Промежуточный `(subject,object)` link тоже может одновременно удовлетворять более широкому Relations Model query. Это следствие универсальности Link primitive, а не ошибка типов.
+`BoundedExecutionTrace` — tooling-collector в host memory. Он не является состоянием VM и не создаёт альтернативный executor.
 
-Если поверх этого создать C++-набор «только те LinkId, которые когда-то вернул encode_relation_entity», возникнет второе понятие identity/classification, которого нет в Relations Model. Поэтому AVM 1.1 queries остаются структурными. Более узкие домены должны выражаться дополнительными relations/constraints в самой асети.
+Для persistent reopen требуется точное совпадение LinkId-based trace. Для независимых stores используется сравнение с точностью до биективного переименования непрозрачных IDs.
 
-### Query strategies
+## 10. AVM 1.4 — inspection tooling
 
-Без нового storage API доступны четыре индексных пути:
+`InspectionSession` и typed inspection commands используют существующие:
+
+- `LinkStore`;
+- Relations Model query API;
+- `BootstrapRuntime`;
+- `BoundedExecutionTrace`.
+
+Текстовый parser команд заканчивается типизированным представлением команды. Он не является новым языком VM и не определяет execution semantics.
+
+Это важная архитектурная граница: debugger/inspection tooling может быть богатым, не превращаясь во второй runtime.
+
+## 11. Главная проблема AVM 1.5
+
+После завершения foundation становится видно, что старый `jsonRVM` содержит семантику, которую текущий minimal bootstrap ещё не выражает полностью.
+
+В `jsonRVM` роли имеют самостоятельный смысл:
 
 ```text
-relation constrained
-  -> outgoing(relation)
-
-subject + object constrained
-  -> find(subject,object)
-  -> incoming(pair)
-
-subject constrained
-  -> outgoing(subject)
-  -> incoming(pair)
-
-object constrained
-  -> incoming(object)
-  -> incoming(pair)
+relation = controller
+subject  = view / receiver / manifestation
+object   = model / input
+entity   = проявление отношения
 ```
 
-Все candidates затем структурно декодируются и фильтруются. Missing pair не материализуется.
+Текущий AVM исторически начинал с удобного частного случая:
 
-All-wildcard query пока запрещён: `LinkStore` не имеет public enumeration contract. Сканирование guessed диапазона `1..size()` было бы нарушением opaque LinkId semantics.
+```text
+(relation, unit, object) -> result
+```
 
-## Сильные стороны текущей архитектуры
+Этого достаточно для минимальной VM, но недостаточно для полной семантики Relations Model.
 
-1. **Один physical/semantic core.** Нет конкурирующих identity universes.
-2. **Canonical link identity.** Семантика не зависит от адресов C++ объектов.
-3. **Read/write separation.** Queries и projection-find не материализуют данные.
-4. **External protocol boundary.** JSON/Anum не проникают в executor.
-5. **Backend replaceability.** In-memory/persistent проверяются одним observable contract.
-6. **Structural Relations Model.** Entity semantics не требуют side registry.
-7. **CI as architecture gate.** Cross-platform builds, package consumer, sanitizers, static guards and benchmarks защищают фундамент.
+Дополнительные semantic gaps:
 
-## Текущие риски AVM 1.1
+- текущий `ent/rel/sub/obj` контекст;
+- parent context chain;
+- `$ent/$rel/$sub/$obj` и `$$...`;
+- named/absolute/relative references;
+- distinction observation vs lvalue realization;
+- sequence/lambda/projection semantics;
+- `foreach` child contexts;
+- canonical value denotation для чисел, текста и collections;
+- explicit effect/capability boundary для FS/HTTP/time/native/database lookup.
 
-### 1. Query cost growth
+## 12. Почему нельзя просто перенести `base.rm.h`
 
-Subject/object queries могут проходить через fan-out существующих `outgoing/incoming` indexes. До добавления новых physical indexes нужна измеряемая проблема, подтверждённая benchmark/workload.
+Механическое переписывание старых операторов в `register_native` сохранило бы внешнюю видимость части функций, но потеряло бы архитектурный смысл проекта.
 
-### 2. Enumeration contract
+Старый `jsonRVM` смешивает:
 
-Полностью unconstrained queries нельзя корректно реализовать через `size()` и предположение о contiguous IDs как semantic API. Если enumeration понадобится, её следует добавить отдельным explicit `LinkStore` contract и проверить на всех backends.
+- syntax;
+- AST;
+- runtime values;
+- mutable context;
+- references/lvalues;
+- program storage;
+- host effects
 
-### 3. Bootstrap/native boundary
+в `nlohmann::json`.
 
-Native handlers остаются допустимым bootstrap mechanism, но registry не должен становиться вторым program store.
+В AVM эти аспекты должны быть разделены по контрактам.
 
-### 4. Protocol integrations
+Поэтому AVM 1.5 начинается не с массового переноса операторов, а с semantic inventory и differential corpus.
 
-Новые adapters должны оставаться thin projection layers. String dispatch, external AST или protocol-specific query semantics не должны создавать второй runtime path.
+## 13. Текущий AVM 1.5 plan
 
-## Что больше не является актуальной проблемой
+Epic: #122.
 
-- `src/main.cpp` как semantic core;
-- singleton/global `rel_t` storage;
-- pointer identity;
-- JSON expression interpreter как VM execution model;
-- LinksPlatform как обязательная semantic dependency;
-- protocol-value-only Anum bridge;
-- portable installed-package validation как незавершённый AVM 1.0 gate.
+Последовательность gates:
 
-## Приоритет
+1. #123 — semantic inventory `jsonRVM` и differential corpus;
+2. #124 — triune execution contract;
+3. #125 — link-native execution contexts;
+4. #126 — reference/addressing algebra и frontend compilation;
+5. #127 — sequence/lambda/projection semantics и порядок эффектов;
+6. #128 — canonical value denotation и pure vocabulary;
+7. #129 — explicit capabilities/effects;
+8. #130 — convergence JSON/Anum на одном denotation contract;
+9. #131 — end-to-end differential migration slice.
 
-Текущий приоритет — #83/#84: доказать полезный read-only Relations Model query layer на существующих индексах, получить backend/reopen conformance и performance baselines. Только после измерений решать, нужен ли новый явный LinkStore index/enumeration contract.
+Первый slice #123 уже находится в `main`: `compat/jsonrvm-semantics.json`, `compat/jsonrvm-golden.json` и validator CI фиксируют provenance и начальную semantic classification.
 
-## Основная документация
+## 14. Сильные стороны архитектуры
 
+1. **Один физический примитив.** Все структуры сводятся к связям.
+2. **Один semantic execution path.** Нет legacy interpreter fallback.
+3. **Непрозрачная идентичность.** Семантика не зависит от pointer/address layout.
+4. **Canonical pair identity.** Повторная материализация одной пары идемпотентна.
+5. **Read/write separation.** Поиск и запрос не создают данные.
+6. **Program-as-data.** Program graph, bindings и frames существуют в асети.
+7. **Backend neutrality.** Persistence не определяет VM semantics.
+8. **Protocol boundary.** JSON и Anum не проникают в executor.
+9. **Наблюдаемость без второго runtime.** Trace/inspection являются consumers существующего execution path.
+10. **CI как архитектурный gate.** Guards запрещают возврат удалённых side channels.
+
+## 15. Основные риски
+
+### 15.1. Ошибка при переносе triune semantics
+
+Если `subject` снова будет сведён к техническому `unit`, AVM останется хорошей VM над links, но не станет полноценным исполнителем Relations Model.
+
+### 15.2. Скрытая материализация references
+
+Reference lookup не должен создавать то, что он ищет. Lvalue/write semantics должны быть отдельной операцией.
+
+### 15.3. Второй мир values
+
+Нельзя вводить `std::variant<json,...>` или аналогичный host value universe как внутренний semantic slot, иначе data/program homogeneity снова будет нарушена.
+
+### 15.4. Эффекты внутри pure relations
+
+FS/HTTP/time/database/native operations должны иметь explicit capability boundary. Иначе deterministic semantics и future scheduling становятся неаудируемыми.
+
+### 15.5. Преждевременная параллельность
+
+Старый `jsonRVM` экспериментировал с параллельными projection paths. В AVM parallel scheduler допустим только после определения purity, effect ordering и deterministic failure model.
+
+## 16. Что сейчас не следует делать
+
+До завершения AVM 1.5 foundation не стоит приоритетно развивать:
+
+- GUI debugger;
+- distributed execution;
+- JIT;
+- большой HTTP/FS ecosystem;
+- speculative parallel scheduler;
+- отдельную внутреннюю реализацию МТС;
+- backend-specific semantic indexes;
+- второй compatibility interpreter.
+
+## Основные документы
+
+- `README.md` — обзор и состояние проекта;
 - `docs/architecture.md` — базовый архитектурный контракт;
-- `docs/execution-kernel.md` — execution kernel;
-- `docs/protocol-adapter-contract.md` — внешний protocol boundary;
-- `docs/anum-l3-l4-bridge.md` — canonical Anum structural bridge;
-- `docs/relations-query.md` — AVM 1.1 query contract;
-- `docs/persistent-link-store.md` — persistent backend contract;
-- `plan.md` — dependency-ordered roadmap.
+- `docs/execution-kernel.md` — ядро исполнения;
+- `docs/program-model.md` — link-native program model;
+- `docs/functions-and-frames.md` — функции, bindings и call frames;
+- `docs/projection-boundary.md` — граница description/find/realize;
+- `docs/anum-l3-l4-bridge.md` — структурный мост Anum;
+- `docs/relations-query.md` — запросы Модели Отношений;
+- `docs/execution-observability.md` — observer/trace contract;
+- `docs/inspection-session.md` — inspection tooling;
+- `docs/jsonrvm-compatibility.md` — semantic migration contract;
+- `plan.md` — dependency-ordered план развития.
 
 ## Вывод
 
-AVM 1.0 сформировал устойчивый link-native фундамент. AVM 1.1 расширяет его не новым runtime, а наблюдаемыми facilities поверх тех же canonical links. Критерий дальнейшего развития остаётся прежним: новые возможности должны сохранять единый путь `LinkStore -> Relations Model -> Executor` и не вводить скрытые identity/storage semantics.
+AVM уже доказал возможность построения настоящей link-native виртуальной машины над двумерной асетью. Следующий качественный переход — не увеличение количества операторов, а восстановление полноценной семантики Модели Отношений поверх этого фундамента.
+
+Критерий успеха AVM 1.5: нетривиальная программа старого `jsonRVM` должна после внешней проекции исполняться через единственный `LinkStore -> Relations Model -> Executor` path и давать эквивалентный наблюдаемый результат без JSON semantic interpreter.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,145 +1,181 @@
-# AVM 1.0 architecture contract
+# Архитектурный контракт AVM
 
-This document defines the engineering boundaries for the AVM 1.0 foundation. It intentionally does not define the whole Meta-Theory of Links (MTS); it defines how AVM stores and executes associative structures.
+Этот документ задаёт инженерные границы ядра AVM. Он намеренно не определяет всю Метатеорию Связей (МТС): его задача — определить, как AVM хранит и исполняет ассоциативные структуры.
 
-## Layers
+## Уровни
 
 ```text
-A0  Link model       LinkId -> (begin, end)
-A1  LinkStore        canonical identity, queries and explicit writes
-A2  Relations Model  (relation, subject, object) <-> nested dyads
-A3  Execution        context + relation dispatch + program evaluation
-A4  Projection       JSON, Anum and other external representations
-A5  Backend          in-memory, persistent adapters or another store
+A0  Модель связи       LinkId -> (begin, end)
+A1  LinkStore          каноническая идентичность, запросы и явные записи
+A2  Модель Отношений   (relation, subject, object) <-> вложенные дуплеты
+A3  Исполнение         контекст + dispatch отношения + вычисление программы
+A4  Проекция           JSON, Anum и другие внешние представления
+A5  Backend            in-memory, persistent adapter или другое хранилище
 ```
 
-A higher layer must not silently redefine a lower layer.
+Верхний уровень не должен скрыто переопределять семантику нижнего.
 
-## A0. Link model
+## A0. Модель связи
 
-The physical primitive of the AVM 1.0 core is a directed dyad:
+Физический примитив ядра AVM — направленный дуплет:
 
 ```text
 LinkId -> (begin: LinkId, end: LinkId)
 ```
 
-`LinkId` is an opaque identity. Semantic code must not derive meaning from a C++ pointer value or from the physical layout of a backend.
+`LinkId` — непрозрачная идентичность. Семантический код не должен выводить смысл из значения C++ pointer или физического layout backend.
 
-An independent identity is bootstrapped as a self-link `(x, x)`. This keeps the reference in-memory implementation link-only instead of introducing a second physical atom record type.
+Независимая идентичность bootstrap-ится как self-link `(x, x)`. Благодаря этому эталонная in-memory реализация остаётся полностью link-only и не вводит второй физический тип записи «атом».
 
 ## A1. LinkStore
 
-The canonical storage contract separates reads from writes.
+Канонический контракт хранения разделяет чтение и запись.
 
-| Operation | May mutate | Meaning |
+| Операция | Может изменять store | Смысл |
 |---|---:|---|
-| `create_point()` | yes | Introduce a new independent self-link identity |
-| `intern(begin,end)` | yes | Return the canonical link for a pair, creating it when missing |
-| `find(begin,end)` | no | Find an existing exact pair |
-| `get(id)` | no | Read endpoints |
-| `outgoing(begin)` | no | Read links that begin at an identity |
-| `incoming(end)` | no | Read links that end at an identity |
+| `create_point()` | да | Создать новую независимую self-link identity |
+| `intern(begin,end)` | да | Вернуть каноническую связь пары, создав её при отсутствии |
+| `find(begin,end)` | нет | Найти уже существующую точную пару |
+| `get(id)` | нет | Прочитать полюса связи |
+| `outgoing(begin)` | нет | Получить связи с указанным begin |
+| `incoming(end)` | нет | Получить связи с указанным end |
 
-The important invariant is:
+Ключевой инвариант:
 
 ```text
-find(a, b) never creates Link(a, b)
+find(a, b) никогда не создаёт Link(a, b)
 ```
 
-and canonicalization means:
+Канонизация означает:
 
 ```text
 intern(a, b) == intern(a, b)
 ```
 
-inside one logical store.
+в пределах одного логического store.
 
-## A2. Relations Model compatibility
+## A2. Совместимость с Моделью Отношений
 
-An executable entity is represented as the triplet:
+Триединая сущность имеет форму:
 
 ```text
 (relation, subject, object)
 ```
 
-AVM uses one canonical nesting order:
+AVM использует единственный канонический порядок вложения:
 
 ```text
 subject_object = Link(subject, object)
 entity         = Link(relation, subject_object)
 ```
 
-therefore:
+следовательно:
 
 ```text
 (relation, subject, object)
 = (relation, (subject, object))
 ```
 
-The Relations Model codec is responsible for this mapping. `LinkStore` itself does not know what a relation, subject or object is.
+За это отображение отвечает Relations Model codec. Сам `LinkStore` не знает, какие связи играют роли relation, subject или object.
 
-## A3. Execution
+Важно различать **представление** и **семантику исполнения**. Lossless encoding триплета через два дуплета не определяет автоматически, что означает исполнение всех трёх ролей. Этот более сильный контракт развивается в AVM 1.5.
 
-The executor accepts a root/entity `LinkId`, not a JSON AST. It decodes a Relations Model entity, constructs an explicit execution context and dispatches by relation identity.
+## A3. Исполнение
 
-Native C++ handlers are allowed as a bootstrap vocabulary, but their keys are relation `LinkId`s in the associative store. Program structures, bindings and call frames belong to the associative representation; the native registry must not become a second program database.
+`Executor` принимает root/entity `LinkId`, а не JSON AST. Он декодирует сущность Модели Отношений, формирует явный execution context и выполняет dispatch по identity отношения.
 
-The historical pointer-based `rel_t` storage/runtime and JSON-centric `eval()`/`interpret()` semantic path have been removed after migration of their consumers. They are available only through Git history and are not compatibility APIs of AVM 1.0.
+Native C++ handlers допускаются как bootstrap vocabulary, но ключом является relation `LinkId` в ассоциативном store. Program structures, bindings и call frames принадлежат ассоциативному представлению; native registry не должен становиться второй базой программ.
 
-## A4. Projection
+Исторический pointer-based `rel_t` storage/runtime и JSON-centric `eval()`/`interpret()` semantic path удалены после миграции consumers. Они доступны только в Git history и не являются compatibility API AVM.
 
-JSON and Anum are external representations.
+### Частный и общий случаи исполнения
+
+Первый bootstrap program model использует удобную форму:
 
 ```text
-external representation
+(relation, unit, payload)
+```
+
+Это допустимый частный случай, но не определение всей Модели Отношений. AVM 1.5 расширяет контракт до meaningful execution произвольной сущности:
+
+```text
+(relation, subject, object)
+```
+
+без требования `subject == unit`.
+
+## A4. Проекция
+
+JSON и Anum являются внешними представлениями:
+
+```text
+внешнее представление
 -> parser / codec / projection
 -> LinkStore + Relations Model
 -> execution
 ```
 
-The executor must not depend on `nlohmann::json` as its internal instruction type.
+`Executor` не должен зависеть от `nlohmann::json` как внутреннего instruction/value type.
 
-For Anum, AVM follows the separation used by the Anum/MTS work:
+Для Anum AVM следует разделению L3/L4:
 
 ```text
 raw(A) != den(A)
-load(A) does not imply materializing den(A)
-find(A) is non-mutating
-realize(A) is an explicit materializing operation
+load(A) не означает материализацию den(A)
+find(A) не изменяет store
+realize(A) является явной materializing operation
 ```
 
-The Anum parser and context projection belong outside the storage layer.
+Anum parser, grammar, quotation/context semantics находятся вне storage layer. Канонический источник этих правил — `netkeep80/anum_docs`.
 
 ## A5. Backend
 
-Storage backends implement the same `LinkStore` semantics. They do not define VM relations, JSON rules or Anum semantics.
+Физические backends реализуют один и тот же `LinkStore` contract. Они не определяют VM relations, JSON rules, Anum semantics или правила исполнения.
 
-`InMemoryLinkStore` is the reference backend. Persistent adapters are backend follow-ups and must pass the same observable conformance contract; they are not prerequisites for VM semantics.
+`InMemoryLinkStore` — эталонный backend. `PersistentLinkStore` — reference persistence implementation, доказывающая reopen/identity semantics.
 
-## Core invariants
+Production-grade crash consistency, WAL, locking, concurrent writers и другие физические свойства должны развиваться как backend contracts, не изменяя semantic kernel.
 
-1. One physical core primitive: a directed dyad.
-2. Opaque link identity.
-3. Canonical identity for an exact pair.
-4. Read/query operations do not materialize missing links.
-5. Relations Model triplets use exactly `(relation, (subject, object))`.
-6. JSON is a projection, not the VM instruction storage.
-7. Execution consumes link identities.
-8. Program structures and call state belong to the associative model.
-9. Backend implementation is independent from VM semantics.
-10. Legacy paths are deleted after migration; Git is the history store.
+## Основные инварианты
 
-## Foundation sequence
+1. Один физический примитив ядра — направленный дуплет.
+2. `LinkId` является непрозрачной identity.
+3. Точная пара имеет каноническую identity в одном logical store.
+4. Read/query operations не материализуют missing links.
+5. Триплет Модели Отношений имеет единственный порядок `(relation, (subject, object))`.
+6. JSON является проекцией, а не внутренним хранилищем инструкций VM.
+7. Исполнение принимает identities связей.
+8. Program structures и call state принадлежат ассоциативной модели.
+9. Backend implementation не определяет VM semantics.
+10. External protocol parsing не находится внутри semantic core.
+11. Observation/inspection не создают второй executor.
+12. Legacy paths удаляются после миграции; историю хранит Git.
+13. Эффекты и materialization должны быть явными.
+14. Полная triune semantics не сводится к `subject = unit`.
+
+## Эволюция архитектуры
+
+Фундамент AVM 1.0 строился в порядке:
 
 ```text
-architecture contract
+архитектурный контракт
 -> LinkStore
 -> Relations Model codec
 -> execution kernel
 -> program-as-links
 -> external protocol boundary
 -> persistence / vertical slice / performance hardening
--> AVM 1.0 release readiness
+-> release readiness
 ```
 
-The dependency-ordered status is maintained in `plan.md` and the AVM 1.0 GitHub roadmap issues.
+Следующие версии сохраняют тот же фундамент:
+
+```text
+AVM 1.1  read-only Relations queries
+AVM 1.2  structural standard library
+AVM 1.3  execution observability
+AVM 1.4  inspection tooling
+AVM 1.5  semantic migration from jsonRVM
+```
+
+Актуальный dependency-ordered status поддерживается в `plan.md` и GitHub issues.

--- a/docs/boolean-runtime.md
+++ b/docs/boolean-runtime.md
@@ -1,19 +1,19 @@
-# AVM 1.0 associative Boolean runtime
+# Ассоциативный Boolean runtime AVM
 
-The bootstrap runtime executes the first link-native AVM program subset without JSON semantics or string operator dispatch.
+Bootstrap runtime исполняет первый link-native subset программ AVM без JSON semantics и строкового dispatch операторов.
 
-## Truth tables are data
+## Таблицы истинности являются данными
 
-Boolean semantics are materialized in `LinkStore` as Relations Model entities. Native C++ handlers do not encode the truth table with `if`/`switch` statements; they evaluate arguments and perform associative lookup.
+Boolean semantics материализуются в `LinkStore` как сущности Модели Отношений. Native C++ handlers не кодируют таблицы истинности через `if`/`switch`: они вычисляют аргументы и выполняют ассоциативный поиск.
 
-Unary NOT rows are represented as:
+Строки унарного NOT:
 
 ```text
 (not, true,  false)
 (not, false, true)
 ```
 
-Binary functions use a canonical argument-pair LinkId as the subject:
+Бинарные функции используют канонический `LinkId` пары аргументов как subject:
 
 ```text
 key = Link(left, right)
@@ -21,17 +21,17 @@ key = Link(left, right)
 (or,  key, result)
 ```
 
-The lookup path uses `LinkStore::find(left, right)` and therefore does not materialize missing argument keys while evaluating a query.
+Lookup использует `LinkStore::find(left, right)` и поэтому не материализует отсутствующий key во время запроса.
 
-## Executable expressions
+## Исполнимые expressions
 
-Program expressions keep the #35 shape:
+Bootstrap expressions используют форму:
 
 ```text
 (relation, unit, payload)
 ```
 
-The bootstrap handlers currently cover:
+Handlers покрывают:
 
 - quote/literal;
 - sequence;
@@ -40,27 +40,38 @@ The bootstrap handlers currently cover:
 - OR;
 - IF.
 
-Expression handlers reject Relations Model rows whose subject is not the `unit` execution marker. This keeps truth-table data and executable application nodes in the same relation namespace without conflating their roles.
+Expression handlers отклоняют Relations Model rows, у которых subject не равен execution marker `unit`. Благодаря этому truth-table data и executable application nodes могут использовать один relation namespace без смешения ролей.
+
+Это ограничение относится именно к bootstrap expression protocol. AVM 1.5 расширяет общий execution contract для meaningful non-unit subject.
 
 ## Lazy IF
 
-`IF` uses two associative condition rows:
+`IF` использует две ассоциативные строки выбора:
 
 ```text
 (if, true,  true)
 (if, false, false)
 ```
 
-Execution is:
+Исполнение:
 
-1. evaluate only the condition expression;
-2. resolve its Boolean selector through the stored relation;
-3. execute exactly one selected branch.
+1. вычислить только condition expression;
+2. определить Boolean selector через сохранённое отношение;
+3. исполнить ровно одну выбранную branch.
 
-The test suite proves laziness by placing an entity with an unregistered relation in the unselected branch. The expression succeeds while the same entity fails when moved into the selected branch.
+Тесты доказывают lazy semantics: entity с незарегистрированной relation помещается в невыбранную branch. Expression успешно завершается, тогда как та же entity приводит к ошибке, если становится выбранной.
 
-## Mutation rule
+## Правило мутаций
 
-All truth-table rows are materialized during `BootstrapRuntime` construction. Executing an already constructed Boolean program performs read-only table lookup; tests assert that `LinkStore::size()` does not change for nested Boolean evaluation or invalid Boolean lookup.
+Truth-table rows материализуются при создании `BootstrapRuntime`. Исполнение уже построенной Boolean program выполняет read-only lookup таблиц; тесты проверяют, что `LinkStore::size()` не меняется при nested Boolean evaluation и invalid Boolean lookup.
 
-Runtime frame/binding materialization is intentionally not part of this gate. Calls and parameters are implemented by #37.
+Материализация runtime bindings/call frames является отдельной существующей семантикой функции и не скрывается внутри Boolean relations.
+
+## Инварианты
+
+- truth tables представлены links, а не C++ branching logic;
+- Boolean lookup не создаёт missing keys;
+- lazy `IF` не исполняет unselected branch;
+- Boolean results являются canonical vocabulary identities;
+- runtime dispatch идёт по relation `LinkId`;
+- JSON/string operators не участвуют в semantic path.

--- a/docs/execution-kernel.md
+++ b/docs/execution-kernel.md
@@ -1,11 +1,11 @@
-# AVM execution kernel
+# Ядро исполнения AVM
 
-The AVM 1.0 execution kernel runs a Relations Model entity by its `LinkId`. It does not parse JSON and it does not dispatch operators by textual names.
+Ядро исполнения AVM запускает сущность Модели Отношений по её `LinkId`. Оно не разбирает JSON и не выполняет dispatch операторов по текстовым именам.
 
-## Execution path
+## Путь исполнения
 
 ```text
-entity LinkId
+LinkId сущности
     |
     v
 decode_relation_entity
@@ -14,49 +14,68 @@ decode_relation_entity
 ExecutionContext
     |
     v
-relation LinkId -> bootstrap/native handler or link-native program structure
+relation LinkId -> bootstrap/native handler или link-native program structure
     |
     v
-result LinkId
+LinkId результата
 ```
 
-## Execution context
+## Контекст исполнения
 
-The context is explicit and carries the instantiated Relations Model entity and call-state needed by execution. Hidden global C++ state is not an execution contract.
+Контекст явный и несёт инстанцированную сущность Модели Отношений и call-state, необходимые для исполнения. Скрытое глобальное состояние C++ не является частью execution contract.
 
-At minimum, relation dispatch is derived from the canonical decoded entity:
+Минимально relation dispatch выводится из канонически декодированной сущности:
 
 ```text
 entity
 relation
 subject
 object
-parent/context when applicable
+parent/context, когда применимо
 ```
 
-Program bindings and call frames belong to the associative model rather than a second external environment.
+Program bindings и call frames принадлежат ассоциативной модели, а не внешнему environment.
 
 ## Bootstrap boundary
 
-A native handler may be registered by a relation `LinkId`:
+Native handler может быть зарегистрирован по relation `LinkId`:
 
 ```text
-relation identity -> C++ handler
+identity отношения -> C++ handler
 ```
 
-This is a bootstrap mechanism, not a second program database. Native handlers provide the minimal bridge needed to execute the associative vocabulary. New language behavior must preserve relation-identity dispatch and must not create a parallel JSON/string-dispatch runtime.
+Это bootstrap-механизм, а не вторая база программ. Native handlers дают минимальный мост, необходимый для выполнения ассоциативного vocabulary. Новая семантика обязана сохранять dispatch по identity отношения и не создавать параллельный JSON/string-dispatch runtime.
 
-## Invariants
+## Результат и материализация
 
-1. `Executor::execute` accepts an entity `LinkId`, not a JSON expression.
-2. Relation dispatch uses relation identity, not strings such as `"Not"` or `"If"`.
-3. Entities are decoded through the canonical Relations Model codec.
-4. Unknown relations fail explicitly and observational operations do not mutate the store.
-5. A native handler returns an existing/canonical `LinkId` according to the operation contract.
-6. Execution context and call state are explicit or represented in links; they are not hidden singleton state.
-7. The executor depends on `LinkStore` semantics, not on a physical storage backend.
-8. JSON/program-session adapters remain outside the execution kernel.
+Handler возвращает `LinkId` согласно контракту конкретной relation. Возврат результата сам по себе не означает разрешение произвольной скрытой записи в `LinkStore`.
 
-## Removed historical path
+Наблюдающие relations должны оставаться read-only по смыслу. Relations с эффектом обязаны иметь явный effect/materialization contract.
 
-The historical `rel_t` universe and JSON-centric `eval()`/`interpret()` compatibility runtime were removed after their consumers migrated. They are not supported AVM 1.0 APIs and should not be reintroduced as a fallback path; Git history retains them for archaeology.
+Это особенно важно для AVM 1.5, где необходимо различить:
+
+```text
+identity исполняемой entity
+subject/view
+object/model
+result
+manifestation/projection
+effect/materialization
+```
+
+## Инварианты
+
+1. `Executor::execute` принимает entity `LinkId`, а не JSON expression.
+2. Relation dispatch использует identity отношения, а не строки вроде `"Not"` или `"If"`.
+3. Сущности декодируются через канонический Relations Model codec.
+4. Unknown relation приводит к явной ошибке; наблюдающие операции не изменяют store.
+5. Native handler возвращает существующий/канонический `LinkId` согласно контракту операции.
+6. Execution context и call state являются явными или представлены links; они не скрыты в singleton-state.
+7. Executor зависит от семантики `LinkStore`, а не от конкретного physical backend.
+8. JSON/program-session adapters находятся вне execution kernel.
+9. Observer/trace/inspection tooling не определяют альтернативную execution semantics.
+10. `subject = unit` является bootstrap-частным случаем, а не окончательным определением триединой сущности.
+
+## Удалённый исторический путь
+
+Исторические `rel_t` и JSON-centric `eval()`/`interpret()` runtime были удалены после миграции consumers. Они не являются поддерживаемыми API и не должны возвращаться как fallback path; для исследования старой реализации существует Git history.

--- a/docs/functions-and-frames.md
+++ b/docs/functions-and-frames.md
@@ -1,10 +1,10 @@
-# AVM 1.0 functions, bindings and call frames
+# Функции, bindings и call frames в AVM
 
-This layer moves function runtime state out of the legacy C++ `func_env` / `param_stack` side channel and into the same `LinkStore` used by program and data entities.
+Этот слой переносит runtime-state функций из исторического C++ side channel `func_env` / `param_stack` в тот же `LinkStore`, где находятся программы и данные.
 
-## Function definitions
+## Определения функций
 
-A function still uses the program-model encoding introduced by #35:
+Функция использует encoding, заданный link-native program model:
 
 ```text
 parameters = List(formal1, formal2, ...)
@@ -12,23 +12,25 @@ payload    = Link(parameters, bodyRoot)
 definition = (function, handle, payload)
 ```
 
-The handle is an independently created LinkId, so a recursive body can refer to its own function before the immutable definition entity is materialized.
+`handle` — независимо созданный `LinkId`. Поэтому recursive body может ссылаться на собственную функцию ещё до материализации immutable definition entity.
 
-Executing a definition validates the stored shape and returns `nil`. Definition availability itself is structural: a link-native call references the handle directly. A future JSON compatibility importer is responsible for preserving textual declaration order while resolving names to handles.
+Выполнение definition валидирует сохранённую структуру и возвращает `nil`. Доступность определения структурна: link-native call напрямую ссылается на handle.
+
+JSON compatibility importer отвечает только за сохранение textual declaration order и resolution имён в handles; сама runtime-функция не зависит от textual names.
 
 ## Bindings
 
-Each evaluated actual argument is bound to its formal parameter with a Relations Model entity:
+Каждый вычисленный actual argument связывается со своим formal parameter сущностью Модели Отношений:
 
 ```text
 (binding, formal, actualValue)
 ```
 
-There is no `map<string, value>` in the new runtime. Formal identity is a LinkId and actual values are LinkIds.
+В новом runtime нет `map<string, value>`. Formal identity — это `LinkId`, actual values — тоже `LinkId`.
 
 ## Call frames
 
-Bindings are collected into a canonical link list and attached to an immutable call frame:
+Bindings собираются в канонический link-list и присоединяются к immutable call frame:
 
 ```text
 bindings = List(binding1, binding2, ...)
@@ -36,54 +38,74 @@ payload  = Link(functionHandle, bindings)
 frame    = (frame, parentFrameOrNil, payload)
 ```
 
-`ExecutionContext` carries the current frame LinkId. Every recursive execution of a child expression preserves that frame unless a function call deliberately creates a child frame.
+`ExecutionContext` несёт текущий frame `LinkId`. Рекурсивное исполнение child expression сохраняет frame, пока function call явно не создаст дочерний frame.
 
-Nested calls therefore form a parent-frame chain entirely in the associative store. Parameter resolution walks the chain from the current frame toward `nil`, validating that every referenced binding really has `binding_relation`.
+Nested calls формируют parent-frame chain целиком в ассоциативном store. Parameter resolution идёт от текущего frame к `nil` и проверяет, что каждая используемая строка binding действительно имеет `binding_relation`.
 
-## Call execution
+## Выполнение call
 
-For `(call, unit, payload)` the runtime performs:
+Для `(call, unit, payload)` runtime выполняет:
 
-1. decode function handle and argument-expression list;
-2. locate the immutable function definition;
-3. verify arity;
-4. verify the current frame depth against the configured recursion limit;
-5. evaluate actual arguments in the caller frame;
-6. materialize binding entities;
-7. materialize a child frame linked to the caller frame;
-8. execute the function body with the child frame.
+1. декодирует function handle и список argument expressions;
+2. находит immutable function definition;
+3. проверяет arity;
+4. проверяет текущую глубину frame относительно recursion limit;
+5. вычисляет actual arguments в caller frame;
+6. материализует binding entities;
+7. материализует child frame, связанный с caller frame;
+8. исполняет body функции в child frame.
 
-This preserves lexical parameter identity without a global C++ stack. Recursive calls work because the function body already contains the same handle LinkId.
+Так lexical parameter identity сохраняется без глобального C++ stack. Recursive calls работают, потому что body уже содержит тот же function-handle `LinkId`.
 
-## Recursion guard
+## Ограничение рекурсии
 
-`BootstrapRuntime` accepts a maximum call depth, defaulting to 1000. Depth is derived by traversing parent-frame links rather than by reading a C++ container size. Malformed frame chains, non-frame parents and invalid frame payloads fail explicitly.
+`BootstrapRuntime` принимает максимальную call depth; значение по умолчанию — 1000.
 
-The frame vocabulary identity itself is a self-link, like all bootstrap identities. It must not be confused with a frame instance; `decode_call_frame` rejects it explicitly. This invariant is covered by tests because the relation identity naturally appears in `LinkStore::outgoing(frame_relation)`.
+Depth вычисляется обходом parent-frame links, а не размером C++ container. Malformed frame chains, non-frame parents и invalid frame payloads приводят к явным ошибкам.
 
-## Test coverage
+Vocabulary identity отношения `frame` сама является self-link, как и другие bootstrap identities. Её нельзя путать с экземпляром frame; `decode_call_frame` явно отклоняет этот случай. Тест нужен потому, что relation identity естественно появляется в `LinkStore::outgoing(frame_relation)`.
 
-`function_runtime_tests` covers:
+## Материализация execution state
 
-- one- and two-parameter functions;
-- Boolean expressions inside a function body;
+Bindings и frames являются реальными links. Поэтому function call может увеличивать `LinkStore`, даже если body содержит только наблюдающие operations.
+
+Это не скрытый host-language side effect, а явная часть текущего link-native call-state contract.
+
+AVM 1.5 должен учитывать это при формализации более общего execution context и distinguishing pure value computation от materialized manifestation/call state.
+
+## Покрытие тестами
+
+`function_runtime_tests` проверяет:
+
+- функции с одним и двумя параметрами;
+- Boolean expressions внутри body;
 - nested calls;
-- finite recursion;
-- unbounded recursion hitting the depth guard;
+- конечную recursion;
+- unbounded recursion и depth guard;
 - arity mismatch;
 - undefined functions;
 - unbound parameters;
-- malformed frames and definitions;
-- physical presence of binding/frame entities in `LinkStore`.
+- malformed frames/definitions;
+- физическое наличие binding/frame entities в `LinkStore`.
 
-`frame_runtime_tests` separately covers:
+`frame_runtime_tests` отдельно проверяет:
 
-- decoded root-frame structure;
+- структуру декодированного root frame;
 - formal→actual binding rows;
-- executing a parameter against an explicit frame LinkId;
-- parent/child frame linkage for nested calls;
-- rejection of the frame vocabulary self-link;
-- rejection of non-binding entries and invalid parent frames;
-- rejection of a zero recursion-depth configuration.
+- execution parameter с явным frame `LinkId`;
+- parent/child linkage nested calls;
+- отклонение frame vocabulary self-link;
+- отклонение non-binding entries и invalid parents;
+- запрет zero recursion-depth configuration.
 
-Together with the existing suites, this keeps function semantics independently testable without JSON or the legacy LinksPlatform path.
+Совместно с остальными suites это делает function semantics независимо тестируемой без JSON и без legacy LinksPlatform path.
+
+## Инварианты
+
+- function definitions находятся в links;
+- bindings находятся в links;
+- call frames находятся в links;
+- runtime parameters не хранятся в string maps;
+- recursion depth выводится из frame chain;
+- textual function names принадлежат projection layer;
+- function execution использует тот же `Executor` и canonical `LinkStore`.

--- a/docs/program-model.md
+++ b/docs/program-model.md
@@ -1,32 +1,32 @@
-# AVM 1.0 link-native program model
+# Link-native модель программ AVM
 
-This document defines the first bootstrap program representation for AVM 1.0. It is an engineering protocol built on the canonical `LinkStore` and Relations Model codec. It is not declared to be a fundamental MTS vocabulary.
+Этот документ определяет bootstrap-представление программ AVM. Это инженерный протокол поверх канонического `LinkStore` и Relations Model codec; он не объявляется фундаментальным vocabulary МТС.
 
-## Core invariant
+## Основной инвариант
 
-After projection/import, executable program structure lives in the same link store as data:
+После проекции/import исполнимая структура программы живёт в том же хранилище связей, что и данные:
 
 ```text
-program representation ∈ LinkStore
+представление программы ∈ LinkStore
 ```
 
-The executor must not require operator names, JSON nodes, C++ function-definition maps or parameter-name maps to understand the structure.
+Executor не должен требовать текстовые имена операторов, JSON nodes, C++ maps определений функций или maps имён параметров для понимания структуры программы.
 
 ## Bootstrap vocabulary
 
-`BootstrapVocabulary` materializes opaque LinkId identities for:
+`BootstrapVocabulary` материализует непрозрачные `LinkId` identities для:
 
-- `unit` — marker used as the subject of executable expression entities;
-- `nil` — terminator for link-list chains;
-- Boolean values `true_value` and `false_value`;
-- expression relations: quote, parameter, sequence, NOT, AND, OR, IF and CALL;
-- runtime structure relations: function, binding and frame.
+- `unit` — marker, используемый как subject bootstrap expression entities;
+- `nil` — terminator цепочек link-list;
+- Boolean values `true_value` и `false_value`;
+- expression relations: quote, parameter, sequence, NOT, AND, OR, IF и CALL;
+- runtime structure relations: function, binding и frame.
 
-The IDs are deliberately opaque. Textual names are projection-level labels and do not participate in core identity or dispatch.
+IDs намеренно непрозрачны. Текстовые имена существуют только на уровне проекции и не участвуют в core identity или dispatch.
 
-## Expression shape
+## Форма expression
 
-Executable expression nodes are Relations Model entities:
+Bootstrap executable expression nodes являются сущностями Модели Отношений:
 
 ```text
 Expression(relation, payload)
@@ -34,7 +34,7 @@ Expression(relation, payload)
     = Link(relation, Link(unit, payload))
 ```
 
-Examples:
+Примеры:
 
 ```text
 Literal(value)     = (quote, unit, value)
@@ -46,24 +46,30 @@ IF(c,t,e)          = (if, unit, List(c,t,e))
 Sequence(e...)     = (sequence, unit, List(e...))
 ```
 
-Repeated materialization of the same immutable structure reuses the canonical LinkId because all constituent dyads are interned.
+Повторная материализация одной immutable structure возвращает тот же канонический `LinkId`, поскольку все составляющие дуплеты intern-ятся.
 
-## Lists
+## Списки
 
-Argument, parameter and sequence collections use a canonical dyad chain:
+Коллекции аргументов, параметров и последовательностей используют каноническую цепочку дуплетов:
 
 ```text
 List()      = nil
 List(a,b,c) = Link(a, Link(b, Link(c, nil)))
 ```
 
-`decode_link_list` detects cycles, missing LinkIds and a configurable maximum item count. List decoding therefore does not rely on recursion or on JSON arrays.
+`decode_link_list` обнаруживает:
 
-## Functions
+- cycles;
+- missing `LinkId`;
+- превышение configurable maximum item count.
 
-A function handle is an independently created point. This indirection is important: the body may reference the handle before the immutable function definition is materialized, which makes recursive program graphs representable without mutable link identities.
+Таким образом, decoding списка не зависит от JSON arrays и не требует рекурсивного внешнего AST.
 
-A definition is:
+## Функции
+
+Function handle — независимо созданный point. Эта косвенность важна: body может ссылаться на handle до материализации immutable function definition, поэтому recursive program graph представим без mutable link identities.
+
+Definition:
 
 ```text
 params = List(formal1, formal2, ...)
@@ -71,9 +77,9 @@ payload = Link(params, bodyRoot)
 definition = (function, handle, payload)
 ```
 
-A handle has at most one definition. Repeating an identical definition is idempotent; attempting to attach a different definition to the same handle is an error.
+Один handle имеет не более одного определения. Повтор одинакового definition идемпотентен; попытка привязать другое definition к тому же handle является ошибкой.
 
-A call expression is:
+Call expression:
 
 ```text
 args = List(actualExpr1, actualExpr2, ...)
@@ -81,10 +87,20 @@ payload = Link(functionHandle, args)
 call = (call, unit, payload)
 ```
 
-At this stage the model only represents calls. Frame materialization, binding lookup and recursion semantics are implemented in the next runtime gate (#37).
+Runtime materializes bindings и call frames отдельными link-native structures, описанными в `functions-and-frames.md`.
 
-## Boundary with JSON and Anum
+## Граница bootstrap-модели
 
-This layer does not parse JSON and does not parse Anum/abits. A projection layer may map external names and syntax to vocabulary LinkIds and construct this graph, but execution receives only LinkIds and runtime vocabulary.
+Форма `(relation, unit, payload)` — инженерный bootstrap protocol для программ AVM 1.0–1.4. Она не отменяет общую триединую форму Relations Model:
 
-That boundary is intentional: AVM storage/execution semantics must not become another parser implementation, and future Anum integration should connect through the projection/load/find/realize boundary described by #26.
+```text
+(relation, subject, object)
+```
+
+AVM 1.5 должен определить meaningful execution для произвольного `subject`, сохранив bootstrap expressions как частный случай общего контракта.
+
+## Граница с JSON и Anum
+
+Этот слой не разбирает JSON и не разбирает Anum/abits. Projection layer может сопоставлять внешние имена и syntax с vocabulary `LinkId` и строить link graph, но исполнение получает только `LinkId` и runtime vocabulary.
+
+Эта граница намеренная: storage/execution semantics AVM не должны становиться ещё одной реализацией parser. Интеграция Anum подключается через separation description/load/find/realize и структурный L3→L4 boundary.

--- a/plan.md
+++ b/plan.md
@@ -1,132 +1,128 @@
-# AVM roadmap
+# План развития AVM
 
-## Planning rule
+## Правило планирования
 
-Work proceeds through dependency-ordered gates. A new layer starts only after its dependencies have a stable contract and green CI gates.
+Работа ведётся последовательными gates с явными зависимостями. Новый слой начинается только после того, как его зависимости получили стабильный контракт и зелёные CI-проверки.
 
-The invariant remains:
+Неизменный архитектурный инвариант:
 
 ```text
-external projection
-  -> canonical LinkStore
-  -> Relations Model codec
-  -> LinkId program
+внешняя проекция
+  -> канонический LinkStore
+  -> кодек Модели Отношений
+  -> программа как LinkId
   -> BootstrapRuntime / Executor
-  -> result LinkId
+  -> LinkId результата
 ```
 
-No second semantic path, hidden program database, legacy storage universe or backend-specific semantic index is allowed.
+Запрещены второй semantic path, скрытая база программ, legacy storage universe и backend-specific semantic index.
 
-## AVM 1.0 foundation — complete ✅
+## AVM 1.0 — архитектурный фундамент завершён ✅
 
-### Gate 1 — architecture contract ✅
+### Gate 1 — архитектурный контракт ✅
 
-- one physical primitive: directed dyad;
-- opaque `LinkId` identity;
-- canonical pair identity;
-- reads do not materialize data;
-- backend semantics separated from VM semantics.
+- один физический примитив: направленный дуплет;
+- непрозрачный `LinkId`;
+- каноническая идентичность пары;
+- чтение не материализует отсутствующие данные;
+- семантика backend отделена от семантики VM.
 
-### Gate 2 — canonical LinkStore ✅
+### Gate 2 — канонический LinkStore ✅
 
-- reference `InMemoryLinkStore`;
-- explicit `find` vs `intern` separation;
-- canonical identity/query conformance;
-- semantic code independent of pointer identity/layout.
+- эталонный `InMemoryLinkStore`;
+- явное разделение `find` и `intern`;
+- conformance canonical identity/query;
+- семантика не зависит от pointer identity или layout.
 
-### Gate 3 — Relations Model codec ✅
+### Gate 3 — кодек Модели Отношений ✅
 
 ```text
-(relation, subject, object) = (relation, (subject, object))
+(relation, subject, object)
+= (relation, (subject, object))
 ```
 
-### Gate 4 — execution kernel ✅
+### Gate 4 — ядро исполнения ✅
 
-- `Executor` consumes entity `LinkId`;
-- relation dispatch by `LinkId`;
-- explicit execution context;
-- bootstrap native handlers are not a second program database.
+- `Executor` принимает entity `LinkId`;
+- dispatch идёт по relation `LinkId`;
+- execution context явный;
+- bootstrap native handlers не являются второй базой программ.
 
 ### Gate 5 — program-as-links ✅
 
-- programs, bindings and frames represented by links;
-- link-native vertical slice;
-- legacy pointer-based `rel_t` semantic/storage universe removed.
+- programs, bindings и frames представлены links;
+- есть link-native vertical slice;
+- legacy pointer-based `rel_t` semantic/storage universe удалён.
 
-### Gate 6 — external protocol boundary ✅
+### Gate 6 — граница внешних протоколов ✅
 
-- parser/grammar/context remain external;
-- AVM consumes structural projection/denotation;
-- `raw(A)` separated from `den(A)`;
-- `find` observational, `realize` explicit.
+- parser/grammar/context остаются вне AVM core;
+- AVM получает structural projection/denotation;
+- `raw(A)` отделён от `den(A)`;
+- `find` наблюдающий, `realize` явный и материализующий.
 
-The canonical Anum/MTS semantics are maintained in `netkeep80/anum_docs`; AVM contains only the structural L3→L4 bridge.
+Каноническая семантика Anum/МТС поддерживается в `netkeep80/anum_docs`; AVM содержит только structural L3→L4 boundary.
 
 ### Gate 7 — integration hardening ✅
 
 - persistent reopen/identity conformance;
 - end-to-end link-native vertical slice;
 - benchmark baselines;
-- documentation alignment;
-- warnings-as-errors, sanitizers and architecture guards.
+- warnings-as-errors;
+- ASan/UBSan;
+- архитектурные CI guards.
 
-### Gate 8 — AVM 1.0 release readiness ✅
+### Gate 8 — готовность AVM 1.0 к релизу ✅
 
-Validated on the same public package/core contracts:
+Проверены:
 
-- Linux, Windows and macOS portable builds/tests;
-- installed-package consumer on Linux, Windows and macOS;
-- stable public `avm::core` package;
-- one documented execution path;
-- no legacy semantic path.
+- Linux/Windows/macOS portable builds/tests;
+- installed-package consumer на Linux/Windows/macOS;
+- публичный `avm::core`;
+- один документированный execution path;
+- отсутствие legacy semantic fallback.
 
-## AVM 1.1 — associative query facilities — complete ✅
+## AVM 1.1 — ассоциативные запросы завершены ✅
 
 Epic: #83.
 
-### Gate 9 — constrained Relations Model queries ✅
+### Gate 9 — ограниченные запросы Модели Отношений ✅
 
-Implemented through #84/#85.
-
-Public query shape:
+Реализовано через #84/#85.
 
 ```text
 relation? / subject? / object?
--> existing find/outgoing/incoming paths
+-> существующие find/outgoing/incoming
 -> structural decode/filter
--> deterministic RelationMatch list
+-> deterministic RelationMatch[]
 ```
 
-Properties:
+Свойства:
 
-- at least one constraint;
-- no `intern` / `create_point` in queries;
-- no guessed full-store enumeration;
-- deterministic ordering/deduplication;
-- InMemory/Persistent/reopen equivalence;
-- installed public package consumption.
+- минимум одно ограничение;
+- `intern`/`create_point` не вызываются;
+- нет guessed full-store enumeration;
+- детерминированные ordering/deduplication;
+- эквивалентность InMemory/Persistent/reopen;
+- public installed-package consumption.
 
-### Gate 10 — measured query/index evolution ✅ decision
+### Gate 10 — измеряемое развитие индексов ✅ решение принято
 
-Fan-out scaling was measured at 1/8/64/256 in #86/#87. Existing-index query cost grows with candidate expansion, but no concrete AVM workload/SLA currently justifies another physical/persistent index.
+Fan-out scaling измерен на 1/8/64/256 в #86/#87.
 
-Decision:
+Решение:
 
-- keep canonical `find/outgoing/incoming` as the only primitive lookup/index contract;
-- defer extra indexes until real workload evidence demonstrates a need;
-- any future extension must compare against the recorded scaling baseline and prove InMemory/Persistent conformance.
+- сохранить `find/outgoing/incoming` единственным primitive lookup/index contract;
+- дополнительные indexes отложить до появления реального workload/SLA;
+- любое будущее расширение обязано сравниваться с записанным baseline и доказать InMemory/Persistent conformance.
 
-No backend-specific map is promoted into semantic code merely for convenience.
-
-## AVM 1.2 — link-native structural standard library — complete ✅
+## AVM 1.2 — структурная стандартная библиотека завершена ✅
 
 Epic: #88.
 
-### Gate 11 — read-only structural primitives ✅
+### Gate 11 — наблюдающие structural primitives ✅
 
-Implemented through #89/#90.
-
-Native observational kernel:
+Реализовано через #89/#90:
 
 ```text
 link_begin(expr)
@@ -135,37 +131,34 @@ identity_equal(a,b)
 link_exists(a,b)
 ```
 
-Properties:
+Свойства:
 
-- arguments are evaluated ordinary AVM expressions;
-- handlers observe `LinkStore::get/find` only;
-- no missing-link materialization;
-- canonical Boolean results for predicates;
-- `link_exists` does not overload `nil` as a missing sentinel;
-- persisted 1.1 vocabulary can upgrade without changing older LinkIds.
+- аргументы вычисляются как обычные AVM expressions;
+- handlers используют только наблюдающие `LinkStore::get/find`;
+- отсутствующие связи не материализуются;
+- predicates возвращают canonical Boolean values;
+- `nil` не используется как missing sentinel.
 
-### Gate 12 — explicit canonical pair effect ✅
+### Gate 12 — явный эффект канонической пары ✅
 
-Implemented through #91/#92.
+Реализовано через #91/#92:
 
 ```text
 pair_intern(a,b) -> canonical LinkId(a,b)
 ```
 
-Properties:
+Свойства:
 
-- the handler delegates to canonical `LinkStore::intern`;
-- missing pair creates exactly one link;
-- existing/repeated materialization is idempotent;
-- no point synthesis in the effect handler;
-- vocabulary migration supports complete 15-ID, 19-ID and current 20-ID generations with prevalidation before writes;
-- persistent reopen preserves the materialized LinkId.
+- handler делегирует `LinkStore::intern`;
+- missing pair создаётся ровно один раз;
+- repeated materialization идемпотентна;
+- persistent reopen сохраняет LinkId.
 
-### Gate 13 — standard-library composition ✅
+### Gate 13 — композиция стандартной библиотеки ✅
 
-Implemented through #93/#94.
+Реализовано через #93/#94.
 
-Higher-level structural operations are ordinary AVM functions instead of new native handlers:
+Высокоуровневые structural operations — обычные AVM functions:
 
 ```text
 is_self_link(x) = identity_equal(link_begin(x), link_end(x))
@@ -174,48 +167,34 @@ pair_matches(x,b,e) = AND(identity_equal(link_begin(x), b),
                           identity_equal(link_end(x), e))
 ```
 
-Properties:
+Новые native relations добавляются только для действительно неразложимых observation/effect boundaries.
 
-- function bodies are ordinary link-native expressions;
-- function handles have no native handlers;
-- composed functions may call other composed functions;
-- definitions survive persistent reopen through explicit handles;
-- effect accounting keeps existing link-native binding/call-frame materialization visible instead of hiding it in an ephemeral host-language stack;
-- no new production relation identity or storage API merely for a reducible library operation.
-
-## AVM 1.3 — execution observability and debugger boundary
+## AVM 1.3 — наблюдаемость исполнения завершена ✅
 
 Epic: #95.
 
-### Gate 14 — deterministic non-controlling execution observer ✅
+### Gate 14 — детерминированный неуправляющий observer ✅
 
-Implemented through #96/#97.
-
-Public event model:
+Реализовано через #96/#97.
 
 ```text
 Enter(ExecutionContext)
 Return(ExecutionContext, result LinkId)
-Fail(ExecutionContext)
+Fail(ExecutionContext, phase)
 ```
 
-Properties:
+Свойства:
 
-- canonical LinkId/context data only;
-- no timestamps, host pointers, textual opcode names, JSON/Anum or backend data;
-- observer receives no mutable `Executor`, `LinkStore`, context or result reference;
-- observer exceptions cannot replace program success/failure;
-- nested calls are observed through the same `Executor::execute` recursion;
-- observer presence/absence does not change program result or store effects;
-- pre-context failures emit no context event;
-- installed package consumer validates the API on Linux/Windows/macOS;
-- strict warnings, ASan+UBSan and portable matrix are green.
+- только canonical LinkId/context data;
+- нет timestamps, host pointers, textual opcode names, JSON/Anum или backend data;
+- observer не получает mutable `Executor`, `LinkStore`, context или result;
+- исключения observer не меняют program control flow;
+- nested calls наблюдаются через тот же `Executor::execute`;
+- observation не материализует links.
 
-### Gate 15 — deterministic failure phase and unwind observation ✅
+### Gate 15 — классификация фаз отказа ✅
 
-Implemented through #98/#99.
-
-`Fail` carries a finite AVM-owned phase taxonomy:
+Реализовано через #98/#99:
 
 ```text
 Dispatch
@@ -223,114 +202,269 @@ Handler
 ResultValidation
 ```
 
-Properties:
+Классификация отражает boundary AVM, а не тип или текст host exception.
 
-- phase identifies the canonical execution boundary that failed, not exception text/type;
-- no `std::exception_ptr`, host exception object or backend/protocol diagnostic in `ExecutionEvent`;
-- unknown relation, throwing handler and invalid returned LinkId are distinguishable;
-- nested failure is observed through ordinary stack-shaped `Executor::execute` events;
-- original exception type/message behavior remains unchanged;
-- observer exceptions remain suppressed for every failure phase;
-- repeated failure against unchanged state produces identical events;
-- observation does not materialize links.
+### Gate 16 — ограниченный collector trace ✅
 
-### Gate 16 — bounded reusable execution trace collector ✅
-
-Implemented through #100/#101.
-
-Public tooling contract:
+Реализовано через #100/#101:
 
 ```text
 BoundedExecutionTrace(max_events)
-  -> stores exact ExecutionEvent prefix
-  -> complete when all events fit
-  -> truncated when configured capacity is exceeded
 ```
 
-Properties:
+Он хранит точный префикс `ExecutionEvent`, явно сообщает truncation и не становится VM state.
 
-- capacity/storage reservation is established before normal attachment/execution;
-- capacity exhaustion never fabricates events and is reported explicitly by `truncated()`;
-- zero capacity is defined;
-- `reset()` preserves configured capacity while clearing events/truncation;
-- event access is immutable;
-- collector owns no `Executor`, `LinkStore`, backend, parser/protocol or persistence target;
-- collector attachment does not change program results or LinkStore effects;
-- failure phases from Gate 15 pass through unchanged;
-- installed public package uses the collector on Linux/Windows/macOS;
-- strict warnings, ASan+UBSan and portable matrix are green.
+### Gate 17 — persistent/backend-neutral trace conformance ✅
 
-### Gate 17 — persistent reopen and backend-neutral trace equivalence ✅
-
-Implemented through #102/#103.
-
-Two identity claims are intentionally distinct:
+Реализовано через #102/#103.
 
 ```text
-same PersistentLinkStore after reopen
-  -> exact ExecutionEvent equality, including numeric LinkIds
+тот же PersistentLinkStore после reopen
+  -> точное совпадение событий и LinkId
 
-independent InMemory/Persistent stores
-  -> equivalence modulo bijective renaming of opaque LinkIds
+независимые InMemory/Persistent stores
+  -> эквивалентность с точностью до биективного переименования LinkId
 ```
 
-Properties:
+### Gate 18 — trace-enabled CLI consumer ✅
 
-- link-native function binding/frame state is converged before baseline capture;
-- persistent close/reopen preserves exact success/failure traces and store size;
-- repeated reopen remains exact and idempotent;
-- backend-neutral comparison preserves equality/aliasing relationships across every LinkId-bearing field;
-- deterministic first-occurrence normalization exists only as test/conformance tooling;
-- raw LinkId numbers are never treated as globally comparable across independent stores;
-- failure phases and event kinds remain exact under normalized comparison;
-- truncated traces are rejected from completeness/equivalence claims;
-- no new LinkStore API/index, persistence format, event field or semantic registry.
+Реализовано через #104/#105.
 
-### Gate 18 — trace-enabled CLI consumer (current)
-
-Child: #104.
-
-Use the already existing JSON compatibility frontend and public AVM 1.3 observation API to provide a real tooling consumer without forking execution:
+CLI использует существующий `JsonProgramImporter`, `BootstrapRuntime::execute` и public observer boundary:
 
 ```text
-JSON input
-  -> existing JsonProgramImporter
-  -> LinkId root
-  -> attach BoundedExecutionTrace to the existing BootstrapRuntime/Executor
-  -> execute(root)
-  -> result LinkId
-  -> existing JSON result projection
-  -> tooling-only trace presentation
+avm program.json
+avm --trace program.json
+avm --trace-limit 64 program.json
 ```
 
-Requirements:
+Второго evaluator не создано.
 
-- legacy `avm program.json` behavior remains unchanged;
-- explicit `--trace` mode prints ordered LinkId-based events;
-- explicit bounded trace limit reports truncation rather than silently dropping events;
-- function execution exposes frame-bearing events;
-- failures render retained `Fail(phase)` events and preserve failure exit status/host diagnostics;
-- non-expression JSON remains valid in normal value-roundtrip mode but is rejected in trace mode rather than receiving fabricated execution events;
-- textual event/phase labels are presentation only, not opcodes or canonical trace identity;
-- CLI uses the existing `JsonProgramImporter`, `BootstrapRuntime::execute` and JSON result projection rather than copied evaluator logic;
-- stale hard-coded CLI version banner is replaced by the AVM 1.3 public version contract;
-- CTest validates trace CLI behavior in the strict CLI lane and portable Linux/Windows/macOS builds.
+## AVM 1.4 — inspection tooling завершён ✅
 
-Completion of this gate closes AVM 1.3 observability: observer, failure taxonomy, bounded collector, persistence/backend conformance and an actual tooling consumer all share the single canonical execution path.
+Цель AVM 1.4 — дать разработчику возможность исследовать асеть и исполнение без появления debugger-specific semantics.
 
-## Later AVM 1.x directions
+### Gate 19 — typed inspection session ✅
 
-After the observability boundary:
+`InspectionSession` объединяет только существующие публичные contracts:
 
-1. interactive debugger/REPL control semantics, if needed, as a separate design problem;
-2. additional thin protocol/front-end adapters;
-3. packaging/integration tooling;
+- read-only link/entity inspection;
+- `RelationQuery`;
+- `BootstrapRuntime` execution;
+- `BoundedExecutionTrace`.
+
+Inspection layer не владеет отдельным executor или storage semantics.
+
+### Gate 20 — persistent inspection session conformance ✅
+
+Проверено, что после reopen:
+
+- LinkId identities стабильны для того же store;
+- query/inspection результаты сохраняются;
+- execution и trace используют тот же runtime path.
+
+### Gate 21 — typed scripted inspection commands ✅
+
+Текстовый syntax parsing заканчивается типизированной командой. Исполнение команд происходит через `InspectionSession` и canonical API.
+
+String commands являются tooling presentation, а не VM opcodes.
+
+### Gate 22 — hardening persistent mutation/release path ✅
+
+- `PersistentLinkStore` переходит в faulted state при exception внутри guarded `insert_link + persist` mutation region;
+- после failed mutation частичное in-memory состояние невозможно принять за committed store state;
+- tagged release artifact теперь зависит от полной portable Linux/Windows/macOS matrix.
+
+## AVM 1.5 — перенос семантики Relations Model из jsonRVM 🚧
+
+Epic: #122.
+
+### Почему нужен новый этап
+
+AVM 1.0–1.4 доказал архитектуру VM над каноническими связями. Но minimal bootstrap главным образом исполняет expressions вида:
+
+```text
+(relation, unit, object) -> result
+```
+
+В исходной Модели Отношений все роли имеют самостоятельную семантику:
+
+```text
+relation = controller
+subject  = view / receiver / manifestation
+object   = model / input
+```
+
+Кроме того, `jsonRVM` содержит контексты, references, lambda/projection semantics и большой vocabulary.
+
+Representation theorem `(r,s,o) = (r,(s,o))` уже реализована. AVM 1.5 переносит **семантику исполнения**.
+
+### Gate 23 — semantic inventory и differential corpus #123 🚧
+
+Первый slice уже merged через #132.
+
+В `main` находятся:
+
+- `compat/jsonrvm-semantics.json` — versioned classification manifest;
+- `compat/jsonrvm-golden.json` — frozen legacy assertions;
+- `docs/jsonrvm-compatibility.md` — migration contract;
+- `tools/validate_jsonrvm_compatibility.py` — metadata/golden consistency validator;
+- отдельный CI gate.
+
+Manifest привязан к конкретному commit `netkeep80/jsonRVM`.
+
+Оставшаяся работа:
+
+- уточнить mutation/context/failure metadata;
+- добавить репрезентативные deterministic cases для Boolean/branch;
+- sequence/foreach child contexts;
+- arithmetic;
+- missing-reference failures;
+- pure relation composition.
+
+Массовый перенос `base.rm.h` до завершения классификации запрещён.
+
+### Gate 24 — triune execution contract #124
+
+Нужно определить каноническую link-native семантику:
+
+```text
+execute(entity = (relation, subject, object), context)
+```
+
+без требования `subject == unit`.
+
+Должны быть различены:
+
+- identity исполняемой entity;
+- input/model;
+- subject/view/receiver;
+- вычисленный result;
+- manifestation/projection;
+- materialization/effect.
+
+Pure execution не должен скрыто мутировать existing links.
+
+### Gate 25 — link-native execution contexts #125
+
+Нужно представить наблюдаемую семантику:
+
+```text
+ent
+rel
+sub
+obj
+parent context
+```
+
+и подготовить canonical relations для frontend pronouns `$ent/$rel/$sub/$obj` и parent traversal.
+
+Context не должен существовать только как C++ map/JSON object.
+
+### Gate 26 — reference/addressing algebra #126
+
+Frontend syntax:
+
+```text
+$ent
+$rel
+$sub
+$obj
+$$...
+named/path references
+```
+
+должен компилироваться в canonical link-native reference expressions.
+
+Главный инвариант:
+
+```text
+resolve/find — наблюдение
+write/realize — отдельная явная операция
+```
+
+Runtime не должен интерпретировать JSON Pointer strings.
+
+### Gate 27 — sequence/lambda/projection semantics #127
+
+Нужно определить:
+
+- ordered sequence;
+- child context creation;
+- foreach/map semantics;
+- projection result aggregation;
+- fail-fast/failure propagation;
+- deterministic effect ordering.
+
+Automatic parallelism откладывается до появления formal purity/effect model.
+
+### Gate 28 — canonical value denotation и pure vocabulary #128
+
+Требуется link-native представление значений, необходимое для совместимости с `jsonRVM`:
+
+- Boolean;
+- числа;
+- text/bytes;
+- ordered collections;
+- structural equality/order where justified.
+
+Нельзя вводить второй host-language value universe как semantic core.
+
+После контракта переносится минимальный pure vocabulary: arithmetic, comparisons, selected collection/string operations.
+
+### Gate 29 — explicit capability/effect boundary #129
+
+FS/HTTP/time/native/database lookup не должны скрываться внутри pure relation handlers.
+
+Нужно определить:
+
+```text
+canonical request
+-> explicit capability
+-> deterministic result/effect outcome
+```
+
+и fake providers для CI.
+
+### Gate 30 — convergence JSON/Anum #130
+
+JSON и Anum должны сходиться к одному canonical denotation/find/realize contract.
+
+Frontend-specific syntax не определяет runtime identity или execution semantics.
+
+### Gate 31 — end-to-end differential migration #131
+
+Минимум одна нетривиальная программа старого `jsonRVM` должна:
+
+1. быть зафиксирована как deterministic golden case;
+2. спроецироваться в canonical links;
+3. исполниться единственным `BootstrapRuntime/Executor` path;
+4. дать эквивалентный observable result/error/context behavior;
+5. не требовать старый JSON interpreter.
+
+## Документационный gate #134 🚧
+
+Нормативный язык project-owned документации AVM — русский.
+
+Технические identifiers, API names, formats и code snippets сохраняются в исходном виде. `LICENSE` и явно vendor-owned документация не переводятся.
+
+Этот gate не меняет runtime semantics.
+
+## Дальнейшие направления после AVM 1.5
+
+Только после semantic migration имеет смысл приоритетно рассматривать:
+
+1. interactive debugger с отдельным control contract;
+2. дополнительные frontends;
+3. production persistence backends;
 4. visualization/GUI;
-5. production physical backends and persistence experiments;
-6. standard-library growth by link-native composition, with new native primitives only for irreducible observation/effect boundaries.
+5. distributed execution/storage;
+6. scheduler/parallel execution после purity/effect model;
+7. JIT или native compilation;
+8. дальнейшее расширение standard library через link-native composition.
 
-Every extension must reuse the existing `LinkStore -> Relations Model -> Executor` architecture.
+## Правило зависимостей
 
-## Dependency rule
+Если gate зависит от незавершённого PR, независимая подготовка допустима, но dependent code не merge-ится до зелёного dependency gate.
 
-If a gate depends on an unfinished PR, independent preparation may proceed, but dependent code is not merged before the dependency is green. Legacy code is deleted after consumer migration; Git stores history.
+После миграции consumers legacy implementation удаляется, а не сохраняется вторым production path. Историю хранит Git.


### PR DESCRIPTION
Part of #134.

## Что сделано

Переписаны на русский язык основные нормативные документы AVM:

- `README.md`;
- `analysis.md`;
- `plan.md`;
- `docs/architecture.md`;
- `docs/execution-kernel.md`;
- `docs/program-model.md`;
- `docs/boolean-runtime.md`;
- `docs/functions-and-frames.md`.

## Дополнительная актуализация

`README`, `analysis` и `plan` синхронизированы с фактическим состоянием `main`:

- AVM 1.0–1.4 отмечены как завершённые архитектурные этапы;
- AVM 1.5 и epic #122 описаны как текущая линия развития;
- #123–#131 включены в dependency-ordered roadmap;
- `(relation, unit, payload)` явно описан как bootstrap-частный случай, а не полная triune semantics.

## Языковое правило

Русским становится объясняющий prose. Публичные API identifiers, имена relations, форматы, команды, code snippets и точные имена внешних проектов сохраняются без искусственного перевода.

## Scope veto

PR меняет только Markdown. Runtime semantics, C++ API, build, tests, storage/protocol formats не изменяются.

Следующим отдельным PR будет переведён оставшийся `docs/*.md` слой и добавлено проверяемое правило языка документации.