### PR TITLE
AVM 1.5: добавить direct-triune primitives и conformance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/raw_carrier.h
     include/avm/relations_model.h
     include/avm/relations_query.h
+    include/avm/triune_primitives.h
     include/avm/version.h)
 
 install(TARGETS avm_core EXPORT avmTargets)
@@ -171,6 +172,7 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_relations_model_test test/relations_model_test.cpp relations_model_tests)
     avm_add_core_test(avm_relations_query_test test/relations_query_test.cpp relations_query_tests)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
+    avm_add_core_test(avm_triune_primitives_test test/triune_primitives_test.cpp triune_primitives_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
     avm_add_core_test(
@@ -226,6 +228,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_relations_model_test
         avm_relations_query_test
         avm_executor_test
+        avm_triune_primitives_test
         avm_execution_observer_test
         avm_execution_trace_test
         avm_execution_trace_persistence_test

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -11,4 +11,5 @@
 #include "avm/raw_carrier.h"
 #include "avm/relations_model.h"
 #include "avm/relations_query.h"
+#include "avm/triune_primitives.h"
 #include "avm/version.h"

--- a/include/avm/triune_primitives.h
+++ b/include/avm/triune_primitives.h
@@ -21,10 +21,13 @@ struct DirectTriuneVocabulary
 
 	static DirectTriuneVocabulary create(LinkStore &store)
 	{
-		return DirectTriuneVocabulary{
-		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
-		    store.create_point(),
-		};
+		DirectTriuneVocabulary vocabulary{};
+		vocabulary.subject_value_relation = store.create_point();
+		vocabulary.pair_find_relation = store.create_point();
+		vocabulary.pair_realize_relation = store.create_point();
+		vocabulary.pair_target_begin_relation = store.create_point();
+		vocabulary.pair_target_end_relation = store.create_point();
+		return vocabulary;
 	}
 
 	void validate(const LinkStore &store) const

--- a/include/avm/triune_primitives.h
+++ b/include/avm/triune_primitives.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#include "avm/executor.h"
+#include "avm/relations_model.h"
+
+#include <initializer_list>
+#include <optional>
+#include <set>
+#include <stdexcept>
+
+namespace avm
+{
+
+struct DirectTriuneVocabulary
+{
+	LinkId subject_value_relation;
+	LinkId pair_find_relation;
+	LinkId pair_realize_relation;
+	LinkId pair_target_begin_relation;
+	LinkId pair_target_end_relation;
+
+	static DirectTriuneVocabulary create(LinkStore &store)
+	{
+		return DirectTriuneVocabulary{
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		};
+	}
+
+	void validate(const LinkStore &store) const
+	{
+		std::set<LinkId> unique;
+		for (const LinkId id : {subject_value_relation, pair_find_relation, pair_realize_relation,
+		                        pair_target_begin_relation, pair_target_end_relation})
+		{
+			if (!store.contains(id))
+				throw std::invalid_argument("direct triune vocabulary contains an unknown LinkId");
+			if (!unique.insert(id).second)
+				throw std::invalid_argument("direct triune vocabulary identities must be distinct");
+		}
+	}
+};
+
+struct PairTarget
+{
+	LinkId descriptor;
+	LinkId begin;
+	LinkId end;
+
+	bool operator==(const PairTarget &) const = default;
+};
+
+namespace detail
+{
+
+inline std::optional<LinkId> find_direct_role_value(const LinkStore &store, LinkId relation, LinkId subject)
+{
+	std::optional<LinkId> value;
+	for (const LinkId candidate : store.outgoing(relation))
+	{
+		const RelationEntity decoded = decode_relation_entity(store, candidate);
+		if (decoded.relation != relation || decoded.subject != subject)
+			continue;
+
+		if (value && *value != decoded.object)
+			throw std::logic_error("direct triune role is not functional for the requested subject");
+		value = decoded.object;
+	}
+	return value;
+}
+
+} // namespace detail
+
+inline LinkId materialize_pair_target(LinkStore &store, const DirectTriuneVocabulary &vocabulary, LinkId begin,
+                                      LinkId end)
+{
+	vocabulary.validate(store);
+	if (!store.contains(begin))
+		throw std::invalid_argument("pair target begin is not present in LinkStore");
+	if (!store.contains(end))
+		throw std::invalid_argument("pair target end is not present in LinkStore");
+
+	const LinkId descriptor = store.create_point();
+	encode_relation_entity(store, RelationEntity{vocabulary.pair_target_begin_relation, descriptor, begin});
+	encode_relation_entity(store, RelationEntity{vocabulary.pair_target_end_relation, descriptor, end});
+	return descriptor;
+}
+
+inline PairTarget decode_pair_target(const LinkStore &store, const DirectTriuneVocabulary &vocabulary,
+                                     LinkId descriptor)
+{
+	vocabulary.validate(store);
+	if (!store.contains(descriptor))
+		throw std::invalid_argument("pair target descriptor is not present in LinkStore");
+
+	const Link descriptor_link = store.get(descriptor);
+	if (descriptor_link != Link{descriptor, descriptor})
+		throw std::invalid_argument("pair target descriptor must be a point identity");
+
+	const auto begin = detail::find_direct_role_value(store, vocabulary.pair_target_begin_relation, descriptor);
+	const auto end = detail::find_direct_role_value(store, vocabulary.pair_target_end_relation, descriptor);
+	if (!begin || !end)
+		throw std::runtime_error("pair target descriptor is incomplete");
+
+	return PairTarget{descriptor, *begin, *end};
+}
+
+inline void register_direct_triune_primitives(Executor &executor, const DirectTriuneVocabulary &vocabulary)
+{
+	vocabulary.validate(executor.store());
+
+	executor.register_native(vocabulary.subject_value_relation,
+	                         [](const ExecutionContext &context, Executor &) { return context.subject; });
+
+	executor.register_native(vocabulary.pair_find_relation,
+	                         [vocabulary](const ExecutionContext &context, Executor &current_executor)
+	                         {
+		                         const PairTarget target =
+		                             decode_pair_target(current_executor.store(), vocabulary, context.object);
+		                         const auto existing = current_executor.store().find(target.begin, target.end);
+		                         if (!existing)
+			                         throw std::runtime_error("pair target is not materialized");
+		                         return *existing;
+	                         });
+
+	executor.register_native(vocabulary.pair_realize_relation,
+	                         [vocabulary](const ExecutionContext &context, Executor &current_executor)
+	                         {
+		                         const PairTarget target =
+		                             decode_pair_target(current_executor.store(), vocabulary, context.object);
+		                         return current_executor.store().intern(target.begin, target.end);
+	                         });
+}
+
+} // namespace avm

--- a/include/avm/triune_primitives.h
+++ b/include/avm/triune_primitives.h
@@ -22,7 +22,8 @@ struct DirectTriuneVocabulary
 	static DirectTriuneVocabulary create(LinkStore &store)
 	{
 		return DirectTriuneVocabulary{
-		    store.create_point(), store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(), store.create_point(), store.create_point(), store.create_point(),
+		    store.create_point(),
 		};
 	}
 

--- a/test/triune_primitives_test.cpp
+++ b/test/triune_primitives_test.cpp
@@ -1,0 +1,123 @@
+#include "avm/bootstrap_runtime.h"
+#include "avm/triune_primitives.h"
+
+#include <cassert>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+class RecordingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override { events.push_back(event); }
+
+	std::vector<avm::ExecutionEvent> events;
+};
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
+	const avm::DirectTriuneVocabulary direct = avm::DirectTriuneVocabulary::create(store);
+	avm::register_direct_triune_primitives(runtime.executor(), direct);
+
+	const avm::LinkId subject_a = store.create_point();
+	const avm::LinkId subject_b = store.create_point();
+	const avm::LinkId object = store.create_point();
+
+	const avm::LinkId subject_entity_a =
+	    avm::encode_relation_entity(store, avm::RelationEntity{direct.subject_value_relation, subject_a, object});
+	const avm::LinkId subject_entity_b =
+	    avm::encode_relation_entity(store, avm::RelationEntity{direct.subject_value_relation, subject_b, object});
+
+	const std::size_t before_subject_a = store.size();
+	assert(runtime.execute(subject_entity_a) == subject_a);
+	assert(store.size() == before_subject_a);
+
+	const std::size_t before_subject_b = store.size();
+	assert(runtime.execute(subject_entity_b) == subject_b);
+	assert(store.size() == before_subject_b);
+	assert(subject_a != subject_b);
+
+	// The bootstrap unit identity is still a legitimate direct-triune subject.
+	const avm::LinkId unit_subject_entity = avm::encode_relation_entity(
+	    store, avm::RelationEntity{direct.subject_value_relation, runtime.vocabulary().unit, object});
+	const std::size_t before_unit_subject = store.size();
+	assert(runtime.execute(unit_subject_entity) == runtime.vocabulary().unit);
+	assert(store.size() == before_unit_subject);
+
+	const avm::LinkId target_begin = store.create_point();
+	const avm::LinkId target_end = store.create_point();
+	const avm::LinkId receiver = store.create_point();
+	assert(!store.find(target_begin, target_end).has_value());
+
+	const avm::LinkId target_descriptor = avm::materialize_pair_target(store, direct, target_begin, target_end);
+	assert(!store.find(target_begin, target_end).has_value());
+	assert(avm::decode_pair_target(store, direct, target_descriptor) ==
+	       (avm::PairTarget{target_descriptor, target_begin, target_end}));
+
+	const avm::LinkId find_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{direct.pair_find_relation, receiver, target_descriptor});
+	assert(!store.find(target_begin, target_end).has_value());
+
+	const std::size_t before_find_miss = store.size();
+	bool find_miss_rejected = false;
+	try
+	{
+		static_cast<void>(runtime.execute(find_entity));
+	}
+	catch (const std::runtime_error &)
+	{
+		find_miss_rejected = true;
+	}
+	assert(find_miss_rejected);
+	assert(store.size() == before_find_miss);
+	assert(!store.find(target_begin, target_end).has_value());
+
+	const avm::LinkId realize_entity = avm::encode_relation_entity(
+	    store, avm::RelationEntity{direct.pair_realize_relation, receiver, target_descriptor});
+	assert(!store.find(target_begin, target_end).has_value());
+
+	const std::size_t before_realize = store.size();
+	const avm::LinkId realized = runtime.execute(realize_entity);
+	assert(store.size() == before_realize + 1);
+	assert(store.find(target_begin, target_end) == realized);
+	assert(store.get(realized) == (avm::Link{target_begin, target_end}));
+
+	const std::size_t before_repeat_realize = store.size();
+	assert(runtime.execute(realize_entity) == realized);
+	assert(store.size() == before_repeat_realize);
+
+	const std::size_t before_find_hit = store.size();
+	assert(runtime.execute(find_entity) == realized);
+	assert(store.size() == before_find_hit);
+
+	RecordingObserver observer;
+	runtime.executor().set_observer(&observer);
+	const avm::LinkId observed_result = runtime.execute(subject_entity_a);
+	assert(observed_result == subject_a);
+	assert(observer.events.size() == 2);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert(observer.events[0].context.entity == subject_entity_a);
+	assert(observer.events[0].context.relation == direct.subject_value_relation);
+	assert(observer.events[0].context.subject == subject_a);
+	assert(observer.events[0].context.object == object);
+	assert(!observer.events[0].result.has_value());
+	assert(observer.events[1].kind == avm::ExecutionEventKind::Return);
+	assert(observer.events[1].context == observer.events[0].context);
+	assert(observer.events[1].result == subject_a);
+
+	// Direct primitives coexist with the existing bootstrap expression path on
+	// the same Executor. No sentinel-based relation overloading is introduced.
+	runtime.executor().set_observer(nullptr);
+	avm::ProgramBuilder builder = runtime.builder();
+	const avm::LinkId true_expression = builder.literal(runtime.vocabulary().true_value);
+	const avm::LinkId not_true = builder.logical_not(true_expression);
+	assert(runtime.execute(not_true) == runtime.vocabulary().false_value);
+
+	return 0;
+}


### PR DESCRIPTION
Closes #140. Part of #124 / #122.

## Что реализовано

Добавлен public core API `include/avm/triune_primitives.h` без нового executor:

- `DirectTriuneVocabulary` — отдельные identities для `subject_value`, `pair_find`, `pair_realize` и typed PairTarget roles;
- `materialize_pair_target(...)` — явная link-native materialization descriptor identity;
- `decode_pair_target(...)` — observational decode typed role-facts;
- `register_direct_triune_primitives(existing_executor, vocabulary)` — регистрация в уже существующий `Executor` / `BootstrapRuntime::executor()`.

## Важная коррекция исходного #140

Прямой `(pair_find, subject, object) -> find(subject,object)` архитектурно невозможен как честный miss-test, потому что canonical entity `Link(rel, Link(subject,object))` уже материализует inner pair `(subject,object)`.

Поэтому target пары отделён от обязательной inner pair entity. `PairTarget` — отдельная point identity с typed facts:

```text
(pair_target_begin_relation, descriptor, begin)
(pair_target_end_relation, descriptor, end)
```

Создание descriptor не создаёт `Link(begin,end)`.

## Семантика

```text
(subject_value, subject, object) -> subject
(pair_find, receiver, pair_target) -> existing Link(begin,end), без записи
(pair_realize, receiver, pair_target) -> intern(begin,end), явная запись
```

`unit` не используется как hidden mode sentinel: он остаётся допустимым обычным subject direct relation.

## Conformance

Новый `triune_primitives_test` проверяет:

- non-unit subject реально влияет на result;
- одинаковые relation/object + разные subject дают разные results;
- bootstrap `unit` является допустимым direct subject;
- pure subject relation не меняет store;
- PairTarget roundtrip не materialize-ит target pair;
- `pair_find` miss детерминированно падает без mutation;
- `pair_realize` создаёт target ровно один раз и идемпотентен;
- `pair_find` hit остаётся observational;
- observer сохраняет исходный context и отдельный Return result;
- direct primitives и существующий Boolean bootstrap работают через один `Executor`.

## Veto

- generic `Executor` не изменён;
- второго executor/runtime нет;
- JSON/Anum отсутствуют в semantic path;
- canonical `(rel,(sub,obj))` codec не меняется;
- `pair_find` не вызывает `intern`;
- `subject` остаётся immutable `LinkId` input role.
