### PR TITLE
CI: отменять stale runs superseded PR commits

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   benchmark:
     name: Performance baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ on:
       - '.gitignore'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
   quality:
     name: Quality gates

--- a/.github/workflows/documentation-language.yml
+++ b/.github/workflows/documentation-language.yml
@@ -20,6 +20,10 @@ on:
       - 'tools/validate_documentation_language.py'
       - '.github/workflows/documentation-language.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Проверить русский язык документации

--- a/.github/workflows/jsonrvm-compatibility.yml
+++ b/.github/workflows/jsonrvm-compatibility.yml
@@ -7,6 +7,7 @@ on:
       - 'compat/jsonrvm-semantics.json'
       - 'compat/jsonrvm-semantics-details.json'
       - 'compat/jsonrvm-golden.json'
+      - 'compat/jsonrvm-oracle-golden.json'
       - 'docs/jsonrvm-compatibility.md'
       - 'tools/validate_jsonrvm_compatibility.py'
       - '.github/workflows/jsonrvm-compatibility.yml'
@@ -16,9 +17,14 @@ on:
       - 'compat/jsonrvm-semantics.json'
       - 'compat/jsonrvm-semantics-details.json'
       - 'compat/jsonrvm-golden.json'
+      - 'compat/jsonrvm-oracle-golden.json'
       - 'docs/jsonrvm-compatibility.md'
       - 'tools/validate_jsonrvm_compatibility.py'
       - '.github/workflows/jsonrvm-compatibility.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:

--- a/.github/workflows/jsonrvm-legacy-oracle.yml
+++ b/.github/workflows/jsonrvm-legacy-oracle.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/jsonrvm-legacy-oracle.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   legacy-oracle:
     name: Проверить deterministic legacy semantics

--- a/.github/workflows/jsonrvm-oracle-golden-verify.yml
+++ b/.github/workflows/jsonrvm-oracle-golden-verify.yml
@@ -10,6 +10,10 @@ on:
       - '.github/workflows/jsonrvm-oracle-golden-verify.yml'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   oracle-golden:
     name: Перепроверить live oracle golden

--- a/compat/jsonrvm-legacy-fixtures/concurrency-probe.tmp
+++ b/compat/jsonrvm-legacy-fixtures/concurrency-probe.tmp
@@ -1,0 +1,1 @@
+temporary concurrency probe

--- a/compat/jsonrvm-legacy-fixtures/concurrency-probe.tmp
+++ b/compat/jsonrvm-legacy-fixtures/concurrency-probe.tmp
@@ -1,1 +1,0 @@
-temporary concurrency probe


### PR DESCRIPTION
Closes #143.

## Проблема

Последовательные commits одного PR создавали отдельные CI/Benchmark/focused runs. Старые queued/in-progress matrices продолжали занимать hosted runners даже после появления нового head, что особенно мешало AVM 1.5.

## Решение

Для основных workflow добавлена top-level concurrency group:

```text
workflow name + event name + PR number / ref
```

То есть:

- новый commit того же PR отменяет старый run **того же workflow**;
- разные workflows одного PR не отменяют друг друга;
- разные PR не отменяют друг друга;
- push `main` группируется отдельно от PR;
- tag имеет собственный ref;
- tag-capable `CI` и `Benchmark` не используют `cancel-in-progress` для `refs/tags/*`, чтобы release validation не прерывалась.

Покрыты:

- `CI`;
- `Benchmark`;
- `Documentation language`;
- `jsonRVM compatibility inventory`;
- `jsonRVM legacy oracle`;
- `jsonRVM oracle golden verify`.

Runtime semantics не меняется.

## Проверка

После старта этого PR будет сделан ещё один metadata-only commit в той же ветке: предыдущие PR runs должны перейти в `cancelled`, а новый head получить обычный check set. Это будет фактическим conformance-тестом concurrency policy.