### PR TITLE
AVM 1.5: связать where doctest с collection semantics

### DIFF
--- a/compat/jsonrvm-semantics.json
+++ b/compat/jsonrvm-semantics.json
@@ -330,6 +330,13 @@
       "notes": "Separates pure named lookup from add_entity/materializing behavior."
     },
     {
+      "id": "CASE-WHERE-FILTER",
+      "source": "modules/console/test/where_test.json",
+      "covers": ["VALUE-COLLECTION-001"],
+      "status": "selected",
+      "notes": "Existing legacy doctest freezes the observable where/filter result and provides semantic evidence for collection behavior."
+    },
+    {
       "id": "CASE-BOOLEAN-BRANCH",
       "source": "modules/console/include/base.rm.h",
       "covers": ["CTRL-IF-001", "VALUE-COMPARE-001"],


### PR DESCRIPTION
Исправляет реальный compatibility-contract gap, обнаруженный строгим validator-ом после #138.

## Симптом

`jsonRVM compatibility inventory` завершался ошибкой:

```text
fixture_status=frozen без semantic evidence: VALUE-COLLECTION-001
```

При этом evidence уже существует в `compat/jsonrvm-golden.json`: исторический legacy doctest `CASE-WHERE-FILTER` фиксирует `where_test.json` и ожидаемый результат `/0 == "4"`.

## Причина

`compat/jsonrvm-semantics.json` не содержал `CASE-WHERE-FILTER` в `corpus_candidates`, поэтому validator не мог связать существующий doctest golden с semantic ID `VALUE-COLLECTION-001`.

## Исправление

Добавлен versioned mapping:

```json
{
  "id": "CASE-WHERE-FILTER",
  "source": "modules/console/test/where_test.json",
  "covers": ["VALUE-COLLECTION-001"],
  "status": "selected"
}
```

## Важно

- `fixture_status=frozen` не понижается;
- новый expected result не придумывается;
- старый interpreter не добавляется в production/tests;
- provenance остаётся pinned к `jsonRVM@843b3326141e090ccd1a106ba0a4a21ce72805b7`;
- меняется только недостающая связь уже существующего legacy evidence с semantic inventory.