### PR TITLE
AVM 1.5: исправить live jsonRVM oracle на Linux

### DIFF
--- a/.github/workflows/jsonrvm-oracle-golden-verify.yml
+++ b/.github/workflows/jsonrvm-oracle-golden-verify.yml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - 'compat/jsonrvm-legacy-fixtures/**'
       - 'compat/jsonrvm-oracle-golden.json'
+      - 'tools/run_jsonrvm_legacy_oracle.py'
       - '.github/workflows/jsonrvm-oracle-golden-verify.yml'
   workflow_dispatch:
 

--- a/tools/run_jsonrvm_legacy_oracle.py
+++ b/tools/run_jsonrvm_legacy_oracle.py
@@ -31,7 +31,15 @@ def run_fixture(executable: pathlib.Path, fixture: pathlib.Path) -> subprocess.C
     entry_point = fixture.stem
     with tempfile.TemporaryDirectory(prefix=f"avm-jsonrvm-oracle-{entry_point}-") as directory:
         work = pathlib.Path(directory)
-        shutil.copyfile(fixture, work / f"{entry_point}.json")
+
+        # Pinned jsonRVM console creates file_database_t(".\\") and then
+        # concatenates that string with '<entry>.json'. On Windows this is the
+        # normal spelling of a relative path; on POSIX the backslash is a
+        # literal filename character. Preserve the legacy spelling instead of
+        # patching the old runtime for the audit job.
+        legacy_fixture = work / f".\\{entry_point}.json"
+        shutil.copyfile(fixture, legacy_fixture)
+
         return subprocess.run(
             [str(executable), entry_point],
             cwd=work,


### PR DESCRIPTION
Closes #148.

## Причина failure

Pinned `jsonRVM` успешно собирался на hosted Ubuntu, но первый fixture падал как missing entity:

```text
entity 'arithmetic-add' does not exist!
```

Legacy console создаёт `file_database_t(".\\")`. На Windows это обычный relative-path prefix, а на POSIX backslash является literal символом имени. Python oracle копировал fixture как `arithmetic-add.json`, тогда как неизменённый legacy runtime искал literal `'.\\arithmetic-add.json'`.

## Исправление

Audit runner теперь в isolated temp cwd копирует fixture под exact legacy path spelling:

```python
legacy_fixture = work / f".\\{entry_point}.json"
```

Pinned jsonRVM source не патчится.

## Усиление CI

`jsonRVM oracle golden verify` теперь запускается также при изменениях:

- `compat/jsonrvm-legacy-fixtures/**`;
- `tools/run_jsonrvm_legacy_oracle.py`.

До этого изменение самого runner могло не перепроверить frozen oracle.

## Veto

- frozen expected outputs не изменяются;
- pinned commit остаётся `843b3326141e090ccd1a106ba0a4a21ce72805b7`;
- legacy interpreter не входит в AVM core/runtime;
- исправляется только filesystem spelling старого console adapter в audit harness.