### PR TITLE
AVM Showcase: capture real Linux UI screenshots

### DIFF
--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -87,11 +87,11 @@ jobs:
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-initial.png"
             test -s "$output_dir/avm-showcase-initial.png"
 
-            # ImGui first-use window starts near (60,60); these clicks target the
-            # PairTarget pair_find and pair_realize buttons in the left panel.
-            xdotool mousemove --window "$window" 150 315 click 1
+            # Coordinates are relative to the GLFW window and are calibrated
+            # against the deterministic first-use ImGui layout captured above.
+            xdotool mousemove --window "$window" 150 285 click 1
             sleep 0.3
-            xdotool mousemove --window "$window" 150 342 click 1
+            xdotool mousemove --window "$window" 150 309 click 1
             sleep 1
 
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-triune.png"

--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -82,20 +82,24 @@ jobs:
             done
             test -n "$window"
             xdotool windowmove "$window" 0 0
+            xdotool windowfocus "$window" || true
             sleep 1
 
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-initial.png"
             test -s "$output_dir/avm-showcase-initial.png"
 
-            # Coordinates are relative to the GLFW window and are calibrated
-            # against the deterministic first-use ImGui layout captured above.
-            xdotool mousemove --window "$window" 150 285 click 1
-            sleep 0.3
-            xdotool mousemove --window "$window" 150 309 click 1
-            sleep 1
+            # The GLFW window is fixed at (0,0), so the calibrated screenshot
+            # coordinates are also deterministic root coordinates.
+            xdotool mousemove 150 285 click 1
+            sleep 0.6
+            import -display "$DISPLAY" -window root "$output_dir/avm-showcase-after-find.png"
 
-            import -display "$DISPLAY" -window root "$output_dir/avm-showcase-triune.png"
-            test -s "$output_dir/avm-showcase-triune.png"
+            xdotool mousemove 150 309 click 1
+            sleep 0.8
+            import -display "$DISPLAY" -window root "$output_dir/avm-showcase-after-realize.png"
+
+            test -s "$output_dir/avm-showcase-after-find.png"
+            test -s "$output_dir/avm-showcase-after-realize.png"
           ' _ "$binary" "$PWD/build-showcase/showcase-artifacts"
           file build-showcase/showcase-artifacts/*.png
       - name: Upload showcase screenshots

--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - agent/semantic-context-view
     paths:
       - 'CMakeLists.txt'
       - 'examples/showcase/**'
@@ -44,7 +43,7 @@ jobs:
       - name: Install window-system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y xorg-dev libgl1-mesa-dev
+          sudo apt-get install -y xorg-dev libgl1-mesa-dev xvfb xdotool imagemagick
       - name: Configure
         run: >-
           cmake -S . -B build-showcase
@@ -57,6 +56,54 @@ jobs:
           -DAVM_WARNINGS_AS_ERRORS=ON
       - name: Build
         run: cmake --build build-showcase --target avm_showcase --parallel
+      - name: Run showcase and capture real UI
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p build-showcase/showcase-artifacts
+          binary=$(find build-showcase -type f -name avm_showcase -perm -111 -print -quit)
+          test -n "$binary"
+          xvfb-run -a --server-args="-screen 0 1600x1000x24" bash -c '
+            set -euo pipefail
+            export LIBGL_ALWAYS_SOFTWARE=1
+            binary="$1"
+            output_dir="$2"
+            "$binary" &
+            pid=$!
+            trap "kill $pid 2>/dev/null || true" EXIT
+
+            window=""
+            for _ in $(seq 1 100); do
+              window=$(xdotool search --name "AVM Showcase" 2>/dev/null | head -n 1 || true)
+              if [ -n "$window" ]; then
+                break
+              fi
+              sleep 0.1
+            done
+            test -n "$window"
+            xdotool windowmove "$window" 0 0
+            sleep 1
+
+            import -display "$DISPLAY" -window root "$output_dir/avm-showcase-initial.png"
+            test -s "$output_dir/avm-showcase-initial.png"
+
+            # ImGui first-use window starts near (60,60); these clicks target the
+            # PairTarget pair_find and pair_realize buttons in the left panel.
+            xdotool mousemove --window "$window" 150 315 click 1
+            sleep 0.3
+            xdotool mousemove --window "$window" 150 342 click 1
+            sleep 1
+
+            import -display "$DISPLAY" -window root "$output_dir/avm-showcase-triune.png"
+            test -s "$output_dir/avm-showcase-triune.png"
+          ' _ "$binary" "$PWD/build-showcase/showcase-artifacts"
+          file build-showcase/showcase-artifacts/*.png
+      - name: Upload showcase screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: avm-showcase-screenshots
+          path: build-showcase/showcase-artifacts/*.png
+          if-no-files-found: error
 
   windows:
     name: Showcase / Windows

--- a/.github/workflows/showcase.yml
+++ b/.github/workflows/showcase.yml
@@ -88,13 +88,17 @@ jobs:
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-initial.png"
             test -s "$output_dir/avm-showcase-initial.png"
 
-            # The GLFW window is fixed at (0,0), so the calibrated screenshot
-            # coordinates are also deterministic root coordinates.
-            xdotool mousemove 150 285 click 1
+            # y=315 was confirmed to hit pair_realize in the first smoke run.
+            # pair_find is the immediately preceding ImGui row.
+            xdotool mousemove --window "$window" 150 292
+            xdotool getmouselocation
+            xdotool click 1
             sleep 0.6
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-after-find.png"
 
-            xdotool mousemove 150 309 click 1
+            xdotool mousemove --window "$window" 150 315
+            xdotool getmouselocation
+            xdotool click 1
             sleep 0.8
             import -display "$DISPLAY" -window root "$output_dir/avm-showcase-after-realize.png"
 


### PR DESCRIPTION
Part of #160 / #158 / #154.

Добавляет визуальный smoke-test уже слитого `avm_showcase` без отдельной demo semantics.

Linux focused workflow после реальной сборки:

- запускает тот же `avm_showcase` под Xvfb + Mesa software OpenGL;
- сохраняет initial PNG;
- через `xdotool` физически нажимает `pair_find` и `pair_realize` в ImGui playground;
- сохраняет второй PNG после исполнения;
- публикует оба изображения artifact-ом `avm-showcase-screenshots`.

Это проверяет реальный путь `UI event -> canonical Executor -> observer trace -> render`. Default AVM build/package не меняются; Windows продолжает compile-check GUI target.

После получения первого стабильного screenshot отдельно добавим удобный deterministic CLI walkthrough для #158.