### PR TITLE
AVM 1.5: functional semantic execution outcomes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/avm.h
     include/avm/bootstrap_runtime.h
     include/avm/execution_observer.h
+    include/avm/execution_outcome.h
     include/avm/execution_trace.h
     include/avm/executor.h
     include/avm/link_store.h
@@ -39,6 +40,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/relations_model.h
     include/avm/relations_query.h
     include/avm/semantic_context.h
+    include/avm/semantic_execution.h
     include/avm/triune_primitives.h
     include/avm/version.h)
 
@@ -175,6 +177,10 @@ if(AVM_BUILD_CORE_TESTS)
     avm_add_core_test(avm_relations_query_test test/relations_query_test.cpp relations_query_tests)
     avm_add_core_test(avm_executor_test test/executor_test.cpp executor_tests)
     avm_add_core_test(avm_semantic_context_test test/semantic_context_test.cpp semantic_context_tests)
+    avm_add_core_test(
+        avm_semantic_execution_outcome_test
+        test/semantic_execution_outcome_test.cpp
+        semantic_execution_outcome_tests)
     avm_add_core_test(avm_triune_primitives_test test/triune_primitives_test.cpp triune_primitives_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
@@ -232,6 +238,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_relations_query_test
         avm_executor_test
         avm_semantic_context_test
+        avm_semantic_execution_outcome_test
         avm_triune_primitives_test
         avm_execution_observer_test
         avm_execution_trace_test

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -2,6 +2,7 @@
 
 #include "avm/bootstrap_runtime.h"
 #include "avm/execution_observer.h"
+#include "avm/execution_outcome.h"
 #include "avm/execution_trace.h"
 #include "avm/executor.h"
 #include "avm/link_store.h"
@@ -12,5 +13,6 @@
 #include "avm/relations_model.h"
 #include "avm/relations_query.h"
 #include "avm/semantic_context.h"
+#include "avm/semantic_execution.h"
 #include "avm/triune_primitives.h"
 #include "avm/version.h"

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -2,6 +2,7 @@
 
 #include "avm/executor.h"
 #include "avm/program_model.h"
+#include "avm/semantic_execution.h"
 
 #include <initializer_list>
 #include <optional>
@@ -350,11 +351,7 @@ private:
 			                          require_expression_subject(context, vocabulary_.unit);
 			                          const std::vector<LinkId> expressions =
 			                              decode_link_list(store_, vocabulary_.nil, context.object);
-
-			                          LinkId result = vocabulary_.nil;
-			                          for (const LinkId expression : expressions)
-				                          result = executor.execute(expression, context.entity, context.frame);
-			                          return result;
+			                          return execute_same_context_sequence(executor, expressions, vocabulary_.nil, context);
 		                          });
 
 		executor_.register_native(vocabulary_.begin_relation,

--- a/include/avm/bootstrap_runtime.h
+++ b/include/avm/bootstrap_runtime.h
@@ -345,14 +345,14 @@ private:
 			                          return context.object;
 		                          });
 
-		executor_.register_native(vocabulary_.sequence_relation,
-		                          [this](const ExecutionContext &context, Executor &executor)
-		                          {
-			                          require_expression_subject(context, vocabulary_.unit);
-			                          const std::vector<LinkId> expressions =
-			                              decode_link_list(store_, vocabulary_.nil, context.object);
-			                          return execute_same_context_sequence(executor, expressions, vocabulary_.nil, context);
-		                          });
+		executor_.register_native(
+		    vocabulary_.sequence_relation,
+		    [this](const ExecutionContext &context, Executor &executor)
+		    {
+			    require_expression_subject(context, vocabulary_.unit);
+			    const std::vector<LinkId> expressions = decode_link_list(store_, vocabulary_.nil, context.object);
+			    return execute_same_context_sequence(executor, expressions, vocabulary_.nil, context);
+		    });
 
 		executor_.register_native(vocabulary_.begin_relation,
 		                          [this](const ExecutionContext &context, Executor &executor)

--- a/include/avm/execution_observer.h
+++ b/include/avm/execution_observer.h
@@ -45,10 +45,19 @@ enum class ExecutionFailurePhase
 
 struct ExecutionEvent
 {
+	ExecutionEvent(ExecutionEventKind kind, ExecutionContext context, std::optional<LinkId> result,
+	               std::optional<ExecutionFailurePhase> failure_phase = std::nullopt,
+	               SemanticContextView semantic_result = {})
+	    : kind(kind), context(std::move(context)), result(result), failure_phase(failure_phase),
+	      semantic_result(std::move(semantic_result))
+	{
+	}
+
 	ExecutionEventKind kind;
 	ExecutionContext context;
 	std::optional<LinkId> result;
-	std::optional<ExecutionFailurePhase> failure_phase = std::nullopt;
+	std::optional<ExecutionFailurePhase> failure_phase;
+	SemanticContextView semantic_result;
 
 	bool operator==(const ExecutionEvent &) const = default;
 };

--- a/include/avm/execution_outcome.h
+++ b/include/avm/execution_outcome.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "avm/link_store.h"
+#include "avm/semantic_context.h"
+
+#include <utility>
+
+namespace avm
+{
+
+struct ExecutionOutcome
+{
+	ExecutionOutcome(LinkId result) noexcept : result(result) {}
+
+	ExecutionOutcome(LinkId result, SemanticContextView semantic) noexcept
+	    : result(result), semantic(std::move(semantic))
+	{
+	}
+
+	LinkId result;
+	SemanticContextView semantic;
+
+	bool operator==(const ExecutionOutcome &) const = default;
+};
+
+} // namespace avm

--- a/include/avm/executor.h
+++ b/include/avm/executor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "avm/execution_observer.h"
+#include "avm/execution_outcome.h"
 #include "avm/relations_model.h"
 
 #include <functional>
@@ -14,7 +15,7 @@ namespace avm
 {
 
 class Executor;
-using NativeRelationHandler = std::function<LinkId(const ExecutionContext &, Executor &)>;
+using NativeRelationHandler = std::function<ExecutionOutcome(const ExecutionContext &, Executor &)>;
 
 class Executor
 {
@@ -46,42 +47,70 @@ public:
 
 	bool has_native(LinkId relation) const { return native_handlers_.contains(relation); }
 
-	LinkId execute(LinkId entity, std::optional<LinkId> parent = std::nullopt,
-	               std::optional<LinkId> frame = std::nullopt)
+	ExecutionOutcome execute_outcome(LinkId entity, std::optional<LinkId> parent = std::nullopt,
+	                                 std::optional<LinkId> frame = std::nullopt)
 	{
 		return execute_impl(entity, parent, frame, SemanticContextView{});
 	}
 
-	LinkId execute_in_context(LinkId entity, const SemanticContextView &semantic)
+	LinkId execute(LinkId entity, std::optional<LinkId> parent = std::nullopt,
+	               std::optional<LinkId> frame = std::nullopt)
+	{
+		return execute_outcome(entity, parent, frame).result;
+	}
+
+	ExecutionOutcome execute_outcome_in_context(LinkId entity, const SemanticContextView &semantic)
 	{
 		return execute_impl(entity, std::nullopt, std::nullopt, semantic);
+	}
+
+	ExecutionOutcome execute_outcome_in_context(LinkId entity, const SemanticContextView &semantic,
+	                                            std::optional<LinkId> parent, std::optional<LinkId> frame)
+	{
+		return execute_impl(entity, parent, frame, semantic);
+	}
+
+	LinkId execute_in_context(LinkId entity, const SemanticContextView &semantic)
+	{
+		return execute_outcome_in_context(entity, semantic).result;
 	}
 
 	LinkId execute_in_context(LinkId entity, const SemanticContextView &semantic, std::optional<LinkId> parent,
 	                          std::optional<LinkId> frame)
 	{
-		return execute_impl(entity, parent, frame, semantic);
+		return execute_outcome_in_context(entity, semantic, parent, frame).result;
+	}
+
+	ExecutionOutcome execute_same_semantic_context_outcome(LinkId entity, const ExecutionContext &parent_context)
+	{
+		if (!parent_context.semantic)
+			throw std::logic_error("parent execution context has no semantic context");
+		return execute_outcome_in_context(entity, parent_context.semantic, parent_context.entity, parent_context.frame);
 	}
 
 	LinkId execute_same_semantic_context(LinkId entity, const ExecutionContext &parent_context)
 	{
+		return execute_same_semantic_context_outcome(entity, parent_context).result;
+	}
+
+	ExecutionOutcome execute_child_semantic_context_outcome(LinkId entity, const ExecutionContext &parent_context,
+	                                                        SemanticContextFrame child_frame)
+	{
 		if (!parent_context.semantic)
 			throw std::logic_error("parent execution context has no semantic context");
-		return execute_in_context(entity, parent_context.semantic, parent_context.entity, parent_context.frame);
+		const SemanticContextView child = parent_context.semantic.child(std::move(child_frame));
+		return execute_outcome_in_context(entity, child, parent_context.entity, parent_context.frame);
 	}
 
 	LinkId execute_child_semantic_context(LinkId entity, const ExecutionContext &parent_context,
 	                                      SemanticContextFrame child_frame)
 	{
-		if (!parent_context.semantic)
-			throw std::logic_error("parent execution context has no semantic context");
-		const SemanticContextView child = parent_context.semantic.child(std::move(child_frame));
-		return execute_in_context(entity, child, parent_context.entity, parent_context.frame);
+		return execute_child_semantic_context_outcome(entity, parent_context, std::move(child_frame)).result;
 	}
 
 private:
-	LinkId execute_impl(LinkId entity, std::optional<LinkId> parent, std::optional<LinkId> frame,
-	                    SemanticContextView semantic)
+	ExecutionOutcome execute_impl(LinkId entity, std::optional<LinkId> parent, std::optional<LinkId> frame,
+	                              SemanticContextView semantic)
 	{
 		if (!store_.contains(entity))
 			throw std::invalid_argument("execution entity is not present in LinkStore");
@@ -99,10 +128,10 @@ private:
 			throw std::runtime_error("unknown relation LinkId: " + std::to_string(context.relation));
 		}
 
-		LinkId result = invalid_link_id;
+		ExecutionOutcome outcome{invalid_link_id};
 		try
 		{
-			result = handler->second(context, *this);
+			outcome = handler->second(context, *this);
 		}
 		catch (...)
 		{
@@ -110,15 +139,18 @@ private:
 			throw;
 		}
 
-		if (!store_.contains(result))
+		if (!store_.contains(outcome.result))
 		{
 			notify(ExecutionEvent{ExecutionEventKind::Fail, context, std::nullopt,
 			                      ExecutionFailurePhase::ResultValidation});
 			throw std::runtime_error("native relation returned an unknown LinkId");
 		}
 
-		notify(ExecutionEvent{ExecutionEventKind::Return, context, result});
-		return result;
+		if (!outcome.semantic)
+			outcome.semantic = context.semantic;
+
+		notify(ExecutionEvent{ExecutionEventKind::Return, context, outcome.result, std::nullopt, outcome.semantic});
+		return outcome;
 	}
 
 	void notify(const ExecutionEvent &event) noexcept

--- a/include/avm/semantic_execution.h
+++ b/include/avm/semantic_execution.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "avm/executor.h"
+
+#include <optional>
+#include <span>
+
+namespace avm
+{
+
+inline ExecutionOutcome execute_same_context_sequence(Executor &executor, std::span<const LinkId> entities,
+                                                      LinkId empty_result, SemanticContextView semantic,
+                                                      std::optional<LinkId> parent = std::nullopt,
+                                                      std::optional<LinkId> frame = std::nullopt)
+{
+	ExecutionOutcome outcome{empty_result, semantic};
+	for (const LinkId entity : entities)
+	{
+		if (outcome.semantic)
+			outcome = executor.execute_outcome_in_context(entity, outcome.semantic, parent, frame);
+		else
+			outcome = executor.execute_outcome(entity, parent, frame);
+	}
+	return outcome;
+}
+
+inline ExecutionOutcome execute_same_context_sequence(Executor &executor, std::span<const LinkId> entities,
+                                                      LinkId empty_result, const ExecutionContext &parent_context)
+{
+	return execute_same_context_sequence(executor, entities, empty_result, parent_context.semantic,
+	                                     parent_context.entity, parent_context.frame);
+}
+
+} // namespace avm

--- a/test/semantic_execution_outcome_test.cpp
+++ b/test/semantic_execution_outcome_test.cpp
@@ -1,5 +1,5 @@
+#include "avm/bootstrap_runtime.h"
 #include "avm/execution_trace.h"
-#include "avm/program_model.h"
 #include "avm/semantic_execution.h"
 
 #include <cassert>
@@ -13,8 +13,10 @@ static_assert(std::is_nothrow_copy_constructible_v<avm::ExecutionEvent>);
 int main()
 {
 	avm::InMemoryLinkStore store;
+	avm::BootstrapRuntime runtime(store);
 	avm::BoundedExecutionTrace trace(64);
-	avm::Executor executor(store, &trace);
+	avm::Executor &executor = runtime.executor();
+	executor.set_observer(&trace);
 
 	const avm::LinkId initial_state = store.create_point();
 	const avm::LinkId value_2 = store.create_point();
@@ -34,9 +36,7 @@ int main()
 	const avm::LinkId return_only_relation = store.create_point();
 	const avm::LinkId combine_relation = store.create_point();
 	const avm::LinkId invalid_result_relation = store.create_point();
-	const avm::LinkId sequence_relation = store.create_point();
 	const avm::LinkId dispatch_subject = store.create_point();
-	const avm::LinkId nil = store.create_point();
 
 	executor.register_native(set_state_relation,
 	                         [](const avm::ExecutionContext &context, avm::Executor &)
@@ -77,14 +77,6 @@ int main()
 		                         };
 	                         });
 
-	executor.register_native(sequence_relation,
-	                         [nil](const avm::ExecutionContext &context, avm::Executor &current_executor)
-	                         {
-		                         const std::vector<avm::LinkId> children =
-		                             avm::decode_link_list(current_executor.store(), nil, context.object);
-		                         return avm::execute_same_context_sequence(current_executor, children, nil, context);
-	                         });
-
 	const avm::LinkId set_value_2 =
 	    avm::encode_relation_entity(store, avm::RelationEntity{set_state_relation, dispatch_subject, value_2});
 	const avm::LinkId return_value_3 =
@@ -92,9 +84,7 @@ int main()
 	const avm::LinkId combine_value_3 =
 	    avm::encode_relation_entity(store, avm::RelationEntity{combine_relation, dispatch_subject, value_3});
 	const std::vector<avm::LinkId> children{set_value_2, return_value_3, combine_value_3};
-	const avm::LinkId child_list = avm::encode_link_list(store, nil, children);
-	const avm::LinkId sequence_entity =
-	    avm::encode_relation_entity(store, avm::RelationEntity{sequence_relation, dispatch_subject, child_list});
+	const avm::LinkId sequence_entity = runtime.builder().sequence(children);
 
 	const avm::SemanticContextView root_before = root;
 	const std::size_t store_before_sequence = store.size();

--- a/test/semantic_execution_outcome_test.cpp
+++ b/test/semantic_execution_outcome_test.cpp
@@ -1,0 +1,162 @@
+#include "avm/execution_trace.h"
+#include "avm/program_model.h"
+#include "avm/semantic_execution.h"
+
+#include <array>
+#include <cassert>
+#include <stdexcept>
+#include <type_traits>
+#include <vector>
+
+static_assert(std::is_nothrow_copy_constructible_v<avm::ExecutionOutcome>);
+static_assert(std::is_nothrow_copy_constructible_v<avm::ExecutionEvent>);
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	avm::BoundedExecutionTrace trace(64);
+	avm::Executor executor(store, &trace);
+
+	const avm::LinkId initial_state = store.create_point();
+	const avm::LinkId value_2 = store.create_point();
+	const avm::LinkId value_3 = store.create_point();
+	const avm::LinkId value_5 = store.create_point();
+	const avm::LinkId semantic_entity = store.create_point();
+	const avm::LinkId semantic_subject = store.create_point();
+	const avm::LinkId semantic_object = store.create_point();
+	const avm::SemanticContextView root = avm::SemanticContextView::root(avm::SemanticContextFrame{
+	    semantic_entity,
+	    initial_state,
+	    semantic_subject,
+	    semantic_object,
+	});
+
+	const avm::LinkId set_state_relation = store.create_point();
+	const avm::LinkId return_only_relation = store.create_point();
+	const avm::LinkId combine_relation = store.create_point();
+	const avm::LinkId invalid_result_relation = store.create_point();
+	const avm::LinkId sequence_relation = store.create_point();
+	const avm::LinkId dispatch_subject = store.create_point();
+	const avm::LinkId nil = store.create_point();
+
+	executor.register_native(set_state_relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         if (!context.semantic)
+			                         throw std::runtime_error("set-state requires semantic context");
+		                         return avm::ExecutionOutcome{
+		                             context.object,
+		                             context.semantic.with_relation_state(context.object),
+		                         };
+	                         });
+
+	// This intentionally returns only LinkId. Implicit conversion to
+	// ExecutionOutcome proves old native handlers remain source-compatible.
+	executor.register_native(return_only_relation,
+	                         [](const avm::ExecutionContext &context, avm::Executor &) { return context.object; });
+
+	executor.register_native(combine_relation,
+	                         [value_2, value_3, value_5](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         if (!context.semantic)
+			                         throw std::runtime_error("combine requires semantic context");
+		                         if (context.semantic.role(avm::SemanticContextRole::RelationState) != value_2 ||
+		                             context.object != value_3)
+			                         throw std::runtime_error("unexpected semantic composition input");
+		                         return avm::ExecutionOutcome{
+		                             value_5,
+		                             context.semantic.with_relation_state(value_5),
+		                         };
+	                         });
+
+	executor.register_native(invalid_result_relation,
+	                         [value_3](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         return avm::ExecutionOutcome{
+		                             avm::invalid_link_id,
+		                             context.semantic.with_relation_state(value_3),
+		                         };
+	                         });
+
+	executor.register_native(sequence_relation,
+	                         [nil](const avm::ExecutionContext &context, avm::Executor &current_executor)
+	                         {
+		                         const std::vector<avm::LinkId> children =
+		                             avm::decode_link_list(current_executor.store(), nil, context.object);
+		                         return avm::execute_same_context_sequence(current_executor, children, nil, context);
+	                         });
+
+	const avm::LinkId set_value_2 = avm::encode_relation_entity(
+	    store, avm::RelationEntity{set_state_relation, dispatch_subject, value_2});
+	const avm::LinkId return_value_3 = avm::encode_relation_entity(
+	    store, avm::RelationEntity{return_only_relation, dispatch_subject, value_3});
+	const avm::LinkId combine_value_3 =
+	    avm::encode_relation_entity(store, avm::RelationEntity{combine_relation, dispatch_subject, value_3});
+	const std::array<avm::LinkId, 3> children{set_value_2, return_value_3, combine_value_3};
+	const avm::LinkId child_list = avm::encode_link_list(store, nil, children);
+	const avm::LinkId sequence_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{sequence_relation, dispatch_subject, child_list});
+
+	const avm::SemanticContextView root_before = root;
+	const std::size_t store_before_sequence = store.size();
+	const avm::ExecutionOutcome sequence_outcome = executor.execute_outcome_in_context(sequence_entity, root);
+	assert(store.size() == store_before_sequence);
+	assert(sequence_outcome.result == value_5);
+	assert(sequence_outcome.semantic.role(avm::SemanticContextRole::RelationState) == value_5);
+	assert(root == root_before);
+	assert(root.role(avm::SemanticContextRole::RelationState) == initial_state);
+
+	const auto events = trace.events();
+	assert(events.size() == 8);
+	assert(events[0].kind == avm::ExecutionEventKind::Enter);
+	assert(events[0].context.entity == sequence_entity);
+	assert(events[0].context.semantic == root);
+	assert(!events[0].semantic_result);
+
+	assert(events[2].kind == avm::ExecutionEventKind::Return);
+	assert(events[2].context.entity == set_value_2);
+	assert(events[2].context.semantic.role(avm::SemanticContextRole::RelationState) == initial_state);
+	assert(events[2].semantic_result.role(avm::SemanticContextRole::RelationState) == value_2);
+
+	assert(events[4].kind == avm::ExecutionEventKind::Return);
+	assert(events[4].context.entity == return_value_3);
+	assert(events[4].result == value_3);
+	assert(events[4].context.semantic.role(avm::SemanticContextRole::RelationState) == value_2);
+	assert(events[4].semantic_result.role(avm::SemanticContextRole::RelationState) == value_2);
+
+	assert(events[6].kind == avm::ExecutionEventKind::Return);
+	assert(events[6].context.entity == combine_value_3);
+	assert(events[6].context.semantic.role(avm::SemanticContextRole::RelationState) == value_2);
+	assert(events[6].result == value_5);
+	assert(events[6].semantic_result.role(avm::SemanticContextRole::RelationState) == value_5);
+
+	assert(events[7].kind == avm::ExecutionEventKind::Return);
+	assert(events[7].context.entity == sequence_entity);
+	assert(events[7].context.semantic == root);
+	assert(events[7].result == value_5);
+	assert(events[7].semantic_result == sequence_outcome.semantic);
+
+	trace.reset();
+	const avm::LinkId invalid_result_entity = avm::encode_relation_entity(
+	    store, avm::RelationEntity{invalid_result_relation, dispatch_subject, value_3});
+	const std::size_t store_before_failure = store.size();
+	bool rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute_outcome_in_context(invalid_result_entity, root));
+	}
+	catch (const std::runtime_error &)
+	{
+		rejected = true;
+	}
+	assert(rejected);
+	assert(store.size() == store_before_failure);
+	assert(trace.size() == 2);
+	assert(trace.events()[0].kind == avm::ExecutionEventKind::Enter);
+	assert(trace.events()[1].kind == avm::ExecutionEventKind::Fail);
+	assert(trace.events()[1].failure_phase == avm::ExecutionFailurePhase::ResultValidation);
+	assert(!trace.events()[1].semantic_result);
+	assert(root.role(avm::SemanticContextRole::RelationState) == initial_state);
+
+	return 0;
+}

--- a/test/semantic_execution_outcome_test.cpp
+++ b/test/semantic_execution_outcome_test.cpp
@@ -2,7 +2,6 @@
 #include "avm/program_model.h"
 #include "avm/semantic_execution.h"
 
-#include <array>
 #include <cassert>
 #include <stdexcept>
 #include <type_traits>
@@ -92,7 +91,7 @@ int main()
 	    avm::encode_relation_entity(store, avm::RelationEntity{return_only_relation, dispatch_subject, value_3});
 	const avm::LinkId combine_value_3 =
 	    avm::encode_relation_entity(store, avm::RelationEntity{combine_relation, dispatch_subject, value_3});
-	const std::array<avm::LinkId, 3> children{set_value_2, return_value_3, combine_value_3};
+	const std::vector<avm::LinkId> children{set_value_2, return_value_3, combine_value_3};
 	const avm::LinkId child_list = avm::encode_link_list(store, nil, children);
 	const avm::LinkId sequence_entity =
 	    avm::encode_relation_entity(store, avm::RelationEntity{sequence_relation, dispatch_subject, child_list});

--- a/test/semantic_execution_outcome_test.cpp
+++ b/test/semantic_execution_outcome_test.cpp
@@ -86,10 +86,10 @@ int main()
 		                         return avm::execute_same_context_sequence(current_executor, children, nil, context);
 	                         });
 
-	const avm::LinkId set_value_2 = avm::encode_relation_entity(
-	    store, avm::RelationEntity{set_state_relation, dispatch_subject, value_2});
-	const avm::LinkId return_value_3 = avm::encode_relation_entity(
-	    store, avm::RelationEntity{return_only_relation, dispatch_subject, value_3});
+	const avm::LinkId set_value_2 =
+	    avm::encode_relation_entity(store, avm::RelationEntity{set_state_relation, dispatch_subject, value_2});
+	const avm::LinkId return_value_3 =
+	    avm::encode_relation_entity(store, avm::RelationEntity{return_only_relation, dispatch_subject, value_3});
 	const avm::LinkId combine_value_3 =
 	    avm::encode_relation_entity(store, avm::RelationEntity{combine_relation, dispatch_subject, value_3});
 	const std::array<avm::LinkId, 3> children{set_value_2, return_value_3, combine_value_3};
@@ -137,8 +137,8 @@ int main()
 	assert(events[7].semantic_result == sequence_outcome.semantic);
 
 	trace.reset();
-	const avm::LinkId invalid_result_entity = avm::encode_relation_entity(
-	    store, avm::RelationEntity{invalid_result_relation, dispatch_subject, value_3});
+	const avm::LinkId invalid_result_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{invalid_result_relation, dispatch_subject, value_3});
 	const std::size_t store_before_failure = store.size();
 	bool rejected = false;
 	try


### PR DESCRIPTION
Closes #153. Part of #125 / #122.

## Что добавлено

- `ExecutionOutcome{result, semantic}` как единый functional handler result;
- implicit `ExecutionOutcome(LinkId)`, поэтому существующие native lambdas, возвращающие только `LinkId`, остаются source-compatible;
- единая registry map по-прежнему используется тем же `Executor`;
- `execute_outcome(...)` / `execute_outcome_in_context(...)`;
- существующие `execute(...)` / `execute_in_context(...)` остаются projection на `.result`;
- outcome-aware same-context/child-context nested helpers;
- `ExecutionEvent.semantic_result` отдельно от input `context.semantic`;
- output semantic state публикуется только на успешном `Return`;
- `execute_same_context_sequence(...)` функционально thread-ит output state между children.

## Семантический инвариант

`LinkId`-only handler **не** означает `$rel := result`.

Если handler не возвращает explicit semantic state, Executor наследует input semantic context без изменений.

## Link-native conformance

Новый test строит relation entity последовательности с link-list children:

1. child1 явно ставит `$rel = V2`;
2. child2 возвращает `V3` как обычный `LinkId`, но `$rel` остаётся `V2`;
3. child3 видит `$rel = V2` + operand `V3`, возвращает `V5` и явно ставит `$rel = V5`.

Это structural analogue frozen legacy composition `1+1; $rel+3 -> 5` без JSON references.

Также проверяется:

- input root immutable;
- observer различает input и output state;
- invalid result + proposed semantic transition завершается `Fail/ResultValidation` без публикации `semantic_result`;
- context/state reads не materialize links;
- `ExecutionEvent` и `ExecutionOutcome` остаются nothrow-copyable для bounded trace.

Не добавляются parser `$...`, mutable context, global current state, второй executor или JSON semantic storage.