### PR TITLE
AVM 1.5: реализовать canonical Integer и direct arithmetic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/execution_outcome.h
     include/avm/execution_trace.h
     include/avm/executor.h
+    include/avm/integer_value.h
     include/avm/link_store.h
     include/avm/persistent_link_store.h
     include/avm/program_model.h
@@ -194,6 +195,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_semantic_execution_outcome_test
         test/semantic_execution_outcome_test.cpp
         semantic_execution_outcome_tests)
+    avm_add_core_test(avm_integer_value_test test/integer_value_test.cpp integer_value_tests)
     avm_add_core_test(avm_triune_primitives_test test/triune_primitives_test.cpp triune_primitives_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
@@ -264,6 +266,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_executor_test
         avm_semantic_context_test
         avm_semantic_execution_outcome_test
+        avm_integer_value_test
         avm_triune_primitives_test
         avm_execution_observer_test
         avm_execution_trace_test

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -5,6 +5,7 @@
 #include "avm/execution_outcome.h"
 #include "avm/execution_trace.h"
 #include "avm/executor.h"
+#include "avm/integer_value.h"
 #include "avm/link_store.h"
 #include "avm/persistent_link_store.h"
 #include "avm/program_model.h"

--- a/include/avm/integer_value.h
+++ b/include/avm/integer_value.h
@@ -1,0 +1,302 @@
+#pragma once
+
+#include "avm/executor.h"
+
+#include <cstdint>
+#include <limits>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+struct IntegerVocabulary
+{
+	LinkId zero;
+	LinkId positive;
+	LinkId negative;
+	LinkId magnitude_end;
+	LinkId bit_zero;
+	LinkId bit_one;
+	LinkId add_relation;
+	LinkId subtract_relation;
+	LinkId multiply_relation;
+	LinkId divide_relation;
+
+	static IntegerVocabulary create(LinkStore &store)
+	{
+		IntegerVocabulary vocabulary{};
+		vocabulary.zero = store.create_point();
+		vocabulary.positive = store.create_point();
+		vocabulary.negative = store.create_point();
+		vocabulary.magnitude_end = store.create_point();
+		vocabulary.bit_zero = store.create_point();
+		vocabulary.bit_one = store.create_point();
+		vocabulary.add_relation = store.create_point();
+		vocabulary.subtract_relation = store.create_point();
+		vocabulary.multiply_relation = store.create_point();
+		vocabulary.divide_relation = store.create_point();
+		return vocabulary;
+	}
+};
+
+inline void validate_integer_vocabulary(const LinkStore &store, const IntegerVocabulary &vocabulary)
+{
+	const LinkId ids[] = {
+	    vocabulary.zero,
+	    vocabulary.positive,
+	    vocabulary.negative,
+	    vocabulary.magnitude_end,
+	    vocabulary.bit_zero,
+	    vocabulary.bit_one,
+	    vocabulary.add_relation,
+	    vocabulary.subtract_relation,
+	    vocabulary.multiply_relation,
+	    vocabulary.divide_relation,
+	};
+
+	std::set<LinkId> unique;
+	for (const LinkId id : ids)
+	{
+		if (!store.contains(id))
+			throw std::invalid_argument("integer vocabulary contains an unknown LinkId");
+		if (!unique.insert(id).second)
+			throw std::invalid_argument("integer vocabulary identities must be distinct");
+	}
+}
+
+inline std::uint64_t integer_unsigned_magnitude(std::int64_t value) noexcept
+{
+	if (value >= 0)
+		return static_cast<std::uint64_t>(value);
+	return static_cast<std::uint64_t>(-(value + 1)) + 1U;
+}
+
+inline std::vector<bool> integer_magnitude_bits(std::uint64_t magnitude)
+{
+	std::vector<bool> bits;
+	while (magnitude != 0)
+	{
+		bits.push_back((magnitude & 1U) != 0);
+		magnitude >>= 1U;
+	}
+	return bits;
+}
+
+inline std::optional<LinkId> find_integer(const LinkStore &store, const IntegerVocabulary &vocabulary,
+                                          std::int64_t value)
+{
+	validate_integer_vocabulary(store, vocabulary);
+	if (value == 0)
+		return vocabulary.zero;
+
+	const std::vector<bool> bits = integer_magnitude_bits(integer_unsigned_magnitude(value));
+	LinkId suffix = vocabulary.magnitude_end;
+	for (auto it = bits.rbegin(); it != bits.rend(); ++it)
+	{
+		const LinkId marker = *it ? vocabulary.bit_one : vocabulary.bit_zero;
+		const auto cell = store.find(marker, suffix);
+		if (!cell)
+			return std::nullopt;
+		suffix = *cell;
+	}
+
+	return store.find(value < 0 ? vocabulary.negative : vocabulary.positive, suffix);
+}
+
+inline LinkId realize_integer(LinkStore &store, const IntegerVocabulary &vocabulary, std::int64_t value)
+{
+	validate_integer_vocabulary(store, vocabulary);
+	if (value == 0)
+		return vocabulary.zero;
+
+	const std::vector<bool> bits = integer_magnitude_bits(integer_unsigned_magnitude(value));
+	LinkId suffix = vocabulary.magnitude_end;
+	for (auto it = bits.rbegin(); it != bits.rend(); ++it)
+	{
+		const LinkId marker = *it ? vocabulary.bit_one : vocabulary.bit_zero;
+		suffix = store.intern(marker, suffix);
+	}
+
+	return store.intern(value < 0 ? vocabulary.negative : vocabulary.positive, suffix);
+}
+
+inline std::int64_t integer_from_magnitude(std::uint64_t magnitude, bool negative)
+{
+	if (magnitude == 0)
+		throw std::runtime_error("signed integer wrapper contains zero magnitude");
+
+	const std::uint64_t positive_limit = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+	const std::uint64_t negative_limit = positive_limit + 1U;
+
+	if (!negative)
+	{
+		if (magnitude > positive_limit)
+			throw std::overflow_error("integer value exceeds int64 positive range");
+		return static_cast<std::int64_t>(magnitude);
+	}
+
+	if (magnitude > negative_limit)
+		throw std::overflow_error("integer value exceeds int64 negative range");
+	if (magnitude == negative_limit)
+		return std::numeric_limits<std::int64_t>::min();
+	return -static_cast<std::int64_t>(magnitude);
+}
+
+inline std::int64_t decode_integer(const LinkStore &store, const IntegerVocabulary &vocabulary, LinkId value)
+{
+	validate_integer_vocabulary(store, vocabulary);
+	if (!store.contains(value))
+		throw std::invalid_argument("integer LinkId is not present in LinkStore");
+	if (value == vocabulary.zero)
+		return 0;
+
+	const Link wrapper = store.get(value);
+	bool negative = false;
+	if (wrapper.begin == vocabulary.positive)
+		negative = false;
+	else if (wrapper.begin == vocabulary.negative)
+		negative = true;
+	else
+		throw std::runtime_error("LinkId is not a signed integer wrapper");
+
+	LinkId cursor = wrapper.end;
+	std::set<LinkId> visited;
+	std::uint64_t magnitude = 0;
+	unsigned bit_index = 0;
+	bool saw_bit = false;
+	bool last_bit_was_one = false;
+
+	while (cursor != vocabulary.magnitude_end)
+	{
+		if (!store.contains(cursor))
+			throw std::runtime_error("integer magnitude references an unknown LinkId");
+		if (!visited.insert(cursor).second)
+			throw std::runtime_error("cycle detected in integer magnitude");
+
+		const Link cell = store.get(cursor);
+		bool bit = false;
+		if (cell.begin == vocabulary.bit_zero)
+			bit = false;
+		else if (cell.begin == vocabulary.bit_one)
+			bit = true;
+		else
+			throw std::runtime_error("integer magnitude contains a non-bit marker");
+
+		if (bit)
+		{
+			if (bit_index >= 64)
+				throw std::overflow_error("integer magnitude exceeds int64 host domain");
+			magnitude |= std::uint64_t{1} << bit_index;
+		}
+
+		saw_bit = true;
+		last_bit_was_one = bit;
+		cursor = cell.end;
+		++bit_index;
+		if (bit_index > 64 && cursor != vocabulary.magnitude_end)
+			throw std::overflow_error("integer magnitude exceeds int64 host domain");
+	}
+
+	if (!saw_bit)
+		throw std::runtime_error("signed integer wrapper contains an empty magnitude");
+	if (!last_bit_was_one)
+		throw std::runtime_error("integer magnitude has a non-canonical leading zero");
+
+	return integer_from_magnitude(magnitude, negative);
+}
+
+inline bool is_integer(const LinkStore &store, const IntegerVocabulary &vocabulary, LinkId value) noexcept
+{
+	try
+	{
+		static_cast<void>(decode_integer(store, vocabulary, value));
+		return true;
+	}
+	catch (...)
+	{
+		return false;
+	}
+}
+
+inline std::int64_t checked_integer_add(std::int64_t left, std::int64_t right)
+{
+	const auto min = std::numeric_limits<std::int64_t>::min();
+	const auto max = std::numeric_limits<std::int64_t>::max();
+	if ((right > 0 && left > max - right) || (right < 0 && left < min - right))
+		throw std::overflow_error("integer addition overflow");
+	return left + right;
+}
+
+inline std::int64_t checked_integer_subtract(std::int64_t left, std::int64_t right)
+{
+	const auto min = std::numeric_limits<std::int64_t>::min();
+	const auto max = std::numeric_limits<std::int64_t>::max();
+	if ((right > 0 && left < min + right) || (right < 0 && left > max + right))
+		throw std::overflow_error("integer subtraction overflow");
+	return left - right;
+}
+
+inline std::int64_t integer_from_product_magnitude(std::uint64_t magnitude, bool negative)
+{
+	if (magnitude == 0)
+		return 0;
+	return integer_from_magnitude(magnitude, negative);
+}
+
+inline std::int64_t checked_integer_multiply(std::int64_t left, std::int64_t right)
+{
+	if (left == 0 || right == 0)
+		return 0;
+
+	const bool negative = (left < 0) != (right < 0);
+	const std::uint64_t left_magnitude = integer_unsigned_magnitude(left);
+	const std::uint64_t right_magnitude = integer_unsigned_magnitude(right);
+	const std::uint64_t positive_limit = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+	const std::uint64_t limit = negative ? positive_limit + 1U : positive_limit;
+
+	if (left_magnitude > limit / right_magnitude)
+		throw std::overflow_error("integer multiplication overflow");
+	return integer_from_product_magnitude(left_magnitude * right_magnitude, negative);
+}
+
+inline std::int64_t checked_integer_divide(std::int64_t left, std::int64_t right)
+{
+	if (right == 0)
+		throw std::domain_error("integer division by zero");
+	if (left == std::numeric_limits<std::int64_t>::min() && right == -1)
+		throw std::overflow_error("integer division overflow");
+	return left / right;
+}
+
+template <typename Operation>
+inline ExecutionOutcome execute_integer_binary(const ExecutionContext &context, Executor &executor,
+                                               const IntegerVocabulary &vocabulary, Operation operation)
+{
+	const std::int64_t left = decode_integer(executor.store(), vocabulary, context.subject);
+	const std::int64_t right = decode_integer(executor.store(), vocabulary, context.object);
+	const LinkId result = realize_integer(executor.store(), vocabulary, operation(left, right));
+	if (context.semantic)
+		return ExecutionOutcome{result, context.semantic.with_relation_state(result)};
+	return ExecutionOutcome{result};
+}
+
+inline void register_integer_arithmetic(Executor &executor, const IntegerVocabulary &vocabulary)
+{
+	validate_integer_vocabulary(executor.store(), vocabulary);
+	const auto make_handler = [vocabulary](auto operation)
+	{
+		return [vocabulary, operation](const ExecutionContext &context, Executor &current_executor)
+		{ return execute_integer_binary(context, current_executor, vocabulary, operation); };
+	};
+
+	executor.register_native(vocabulary.add_relation, make_handler(checked_integer_add));
+	executor.register_native(vocabulary.subtract_relation, make_handler(checked_integer_subtract));
+	executor.register_native(vocabulary.multiply_relation, make_handler(checked_integer_multiply));
+	executor.register_native(vocabulary.divide_relation, make_handler(checked_integer_divide));
+}
+
+} // namespace avm

--- a/test/integer_value_test.cpp
+++ b/test/integer_value_test.cpp
@@ -1,0 +1,194 @@
+#include "avm/integer_value.h"
+#include "avm/persistent_link_store.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+bool decode_rejected(const avm::LinkStore &store, const avm::IntegerVocabulary &vocabulary, avm::LinkId value)
+{
+	try
+	{
+		static_cast<void>(avm::decode_integer(store, vocabulary, value));
+		return false;
+	}
+	catch (const std::exception &)
+	{
+		return true;
+	}
+}
+
+bool operation_rejected(const std::function<void()> &operation)
+{
+	try
+	{
+		operation();
+		return false;
+	}
+	catch (const std::exception &)
+	{
+		return true;
+	}
+}
+
+avm::LinkId arithmetic_entity(avm::LinkStore &store, avm::LinkId relation, avm::LinkId left, avm::LinkId right)
+{
+	return avm::encode_relation_entity(store, avm::RelationEntity{relation, left, right});
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::IntegerVocabulary vocabulary = avm::IntegerVocabulary::create(store);
+	avm::validate_integer_vocabulary(store, vocabulary);
+
+	std::vector<std::int64_t> values;
+	values.push_back(0);
+	values.push_back(1);
+	values.push_back(-1);
+	values.push_back(2);
+	values.push_back(3);
+	values.push_back(7);
+	values.push_back(10);
+	values.push_back(42);
+	values.push_back(std::numeric_limits<std::int64_t>::max());
+	values.push_back(std::numeric_limits<std::int64_t>::min());
+
+	for (const std::int64_t value : values)
+	{
+		const std::size_t before_find = store.size();
+		const auto missing_or_existing = avm::find_integer(store, vocabulary, value);
+		assert(store.size() == before_find);
+		if (value != 0)
+			assert(!missing_or_existing.has_value());
+
+		const avm::LinkId realized = avm::realize_integer(store, vocabulary, value);
+		assert(avm::decode_integer(store, vocabulary, realized) == value);
+		assert(avm::is_integer(store, vocabulary, realized));
+		assert(avm::find_integer(store, vocabulary, value) == realized);
+
+		const std::size_t before_repeat = store.size();
+		assert(avm::realize_integer(store, vocabulary, value) == realized);
+		assert(store.size() == before_repeat);
+	}
+
+	const avm::LinkId arbitrary_point = store.create_point();
+	const std::size_t before_bad_read = store.size();
+	assert(decode_rejected(store, vocabulary, arbitrary_point));
+	assert(!avm::is_integer(store, vocabulary, arbitrary_point));
+	assert(store.size() == before_bad_read);
+
+	const avm::LinkId leading_zero = store.intern(vocabulary.bit_zero, vocabulary.magnitude_end);
+	const avm::LinkId malformed_integer = store.intern(vocabulary.positive, leading_zero);
+	const std::size_t before_malformed_read = store.size();
+	assert(decode_rejected(store, vocabulary, malformed_integer));
+	assert(store.size() == before_malformed_read);
+
+	avm::Executor executor(store);
+	avm::register_integer_arithmetic(executor, vocabulary);
+
+	const avm::LinkId zero = avm::realize_integer(store, vocabulary, 0);
+	const avm::LinkId one = avm::realize_integer(store, vocabulary, 1);
+	const avm::LinkId two = avm::realize_integer(store, vocabulary, 2);
+	const avm::LinkId three = avm::realize_integer(store, vocabulary, 3);
+	const avm::LinkId four = avm::realize_integer(store, vocabulary, 4);
+	const avm::LinkId six = avm::realize_integer(store, vocabulary, 6);
+	const avm::LinkId seven = avm::realize_integer(store, vocabulary, 7);
+	const avm::LinkId eight = avm::realize_integer(store, vocabulary, 8);
+	const avm::LinkId nine = avm::realize_integer(store, vocabulary, 9);
+
+	const avm::LinkId add_7_3 = arithmetic_entity(store, vocabulary.add_relation, seven, three);
+	const avm::LinkId ten = executor.execute(add_7_3);
+	assert(avm::decode_integer(store, vocabulary, ten) == 10);
+
+	const avm::LinkId subtract_9_4 = arithmetic_entity(store, vocabulary.subtract_relation, nine, four);
+	assert(avm::decode_integer(store, vocabulary, executor.execute(subtract_9_4)) == 5);
+
+	const avm::LinkId subtract_0_7 = arithmetic_entity(store, vocabulary.subtract_relation, zero, seven);
+	assert(avm::decode_integer(store, vocabulary, executor.execute(subtract_0_7)) == -7);
+
+	const avm::LinkId multiply_6_7 = arithmetic_entity(store, vocabulary.multiply_relation, six, seven);
+	assert(avm::decode_integer(store, vocabulary, executor.execute(multiply_6_7)) == 42);
+
+	const avm::LinkId divide_8_2 = arithmetic_entity(store, vocabulary.divide_relation, eight, two);
+	assert(avm::decode_integer(store, vocabulary, executor.execute(divide_8_2)) == 4);
+
+	const avm::LinkId minus_seven = avm::realize_integer(store, vocabulary, -7);
+	const avm::LinkId divide_negative = arithmetic_entity(store, vocabulary.divide_relation, minus_seven, two);
+	assert(avm::decode_integer(store, vocabulary, executor.execute(divide_negative)) == -3);
+
+	const avm::SemanticContextView root = avm::SemanticContextView::root(avm::SemanticContextFrame{
+	    store.create_point(),
+	    zero,
+	    store.create_point(),
+	    store.create_point(),
+	});
+	const avm::ExecutionOutcome semantic_add = executor.execute_outcome_in_context(add_7_3, root);
+	assert(semantic_add.result == ten);
+	assert(semantic_add.semantic.role(avm::SemanticContextRole::RelationState) == ten);
+	assert(root.role(avm::SemanticContextRole::RelationState) == zero);
+
+	const avm::LinkId int_max = avm::realize_integer(store, vocabulary, std::numeric_limits<std::int64_t>::max());
+	const avm::LinkId int_min = avm::realize_integer(store, vocabulary, std::numeric_limits<std::int64_t>::min());
+
+	const avm::LinkId overflow_add = arithmetic_entity(store, vocabulary.add_relation, int_max, one);
+	const std::size_t before_overflow_add = store.size();
+	assert(operation_rejected([&] { static_cast<void>(executor.execute(overflow_add)); }));
+	assert(store.size() == before_overflow_add);
+
+	const avm::LinkId overflow_subtract = arithmetic_entity(store, vocabulary.subtract_relation, int_min, one);
+	const std::size_t before_overflow_subtract = store.size();
+	assert(operation_rejected([&] { static_cast<void>(executor.execute(overflow_subtract)); }));
+	assert(store.size() == before_overflow_subtract);
+
+	const avm::LinkId overflow_multiply = arithmetic_entity(store, vocabulary.multiply_relation, int_max, two);
+	const std::size_t before_overflow_multiply = store.size();
+	assert(operation_rejected([&] { static_cast<void>(executor.execute(overflow_multiply)); }));
+	assert(store.size() == before_overflow_multiply);
+
+	const avm::LinkId divide_by_zero = arithmetic_entity(store, vocabulary.divide_relation, one, zero);
+	const std::size_t before_divide_zero = store.size();
+	assert(operation_rejected([&] { static_cast<void>(executor.execute(divide_by_zero)); }));
+	assert(store.size() == before_divide_zero);
+
+	const avm::LinkId minus_one = avm::realize_integer(store, vocabulary, -1);
+	const avm::LinkId overflow_divide = arithmetic_entity(store, vocabulary.divide_relation, int_min, minus_one);
+	const std::size_t before_overflow_divide = store.size();
+	assert(operation_rejected([&] { static_cast<void>(executor.execute(overflow_divide)); }));
+	assert(store.size() == before_overflow_divide);
+
+	const std::filesystem::path persistent_path =
+	    std::filesystem::temp_directory_path() / "avm_integer_value_test.links";
+	std::filesystem::remove(persistent_path);
+
+	std::optional<avm::IntegerVocabulary> persistent_vocabulary;
+	avm::LinkId persistent_42 = avm::invalid_link_id;
+	{
+		avm::PersistentLinkStore persistent_store(persistent_path);
+		persistent_vocabulary = avm::IntegerVocabulary::create(persistent_store);
+		persistent_42 = avm::realize_integer(persistent_store, *persistent_vocabulary, 42);
+		assert(avm::decode_integer(persistent_store, *persistent_vocabulary, persistent_42) == 42);
+	}
+	{
+		avm::PersistentLinkStore reopened(persistent_path);
+		assert(avm::decode_integer(reopened, *persistent_vocabulary, persistent_42) == 42);
+		assert(avm::find_integer(reopened, *persistent_vocabulary, 42) == persistent_42);
+		const std::size_t before_repeat = reopened.size();
+		assert(avm::realize_integer(reopened, *persistent_vocabulary, 42) == persistent_42);
+		assert(reopened.size() == before_repeat);
+	}
+	std::filesystem::remove(persistent_path);
+
+	return 0;
+}


### PR DESCRIPTION
Closes #165. Part of #128. Unblocks #156 -> #157 -> #154.

## Что реализовано

- `IntegerVocabulary` с independent link identities для zero/sign/bits/end и `+ - * /` relations;
- canonical LSB-first binary magnitude из ADR #166;
- `find_integer` без materialization;
- explicit `realize_integer`;
- observational `decode_integer` / `is_integer`;
- корректная unsigned-magnitude обработка `INT64_MIN`;
- direct meaningful arithmetic entities `(rel, Integer(a), Integer(b))`;
- checked add/subtract/multiply/divide;
- deterministic overflow и division-by-zero;
- explicit semantic transition `$rel := result` только для arithmetic handler при наличии `SemanticContextView`;
- без semantic context обычный `Executor::execute` возвращает canonical result LinkId;
- public install/export через `avm::core`.

## Conformance

Новый test покрывает:

- canonical values `0, ±1, 2, 3, 7, 10, 42, INT64_MAX, INT64_MIN`;
- find не пишет в store;
- repeated realize idempotent;
- malformed leading-zero shape rejected observationally;
- `7+3=10`, `9-4=5`, `0-7=-7`, `6*7=42`, `8/2=4`, `-7/2=-3`;
- semantic arithmetic outcome меняет только immutable output `$rel`, input context остаётся прежним;
- overflow add/sub/mul, div0, `INT64_MIN/-1` fail до result materialization;
- persistent close/reopen сохраняет meaning и canonical identity.

## Veto

Нет JSON/Anum/UI dependencies, hidden host value map, string operator registry или второго executor.