### PR TITLE
AVM Native JSON: зафиксировать duplet-json/1 и добавить strict converter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ install(FILES
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/avm)
 
 option(AVM_BUILD_CLI "Build the AVM JSON CLI" ON)
+option(AVM_BUILD_JSON_TOOLS "Build AVM JSON conversion tools" ON)
 option(AVM_BUILD_CORE_TESTS "Build AVM core tests" ON)
 option(AVM_BUILD_JSON_COMPAT_TESTS "Build JSON projection/session tests" ON)
 option(AVM_BUILD_ANUM_ADAPTER_TESTS "Build canonical Anum denotation adapter tests" ON)
@@ -105,6 +106,11 @@ endfunction()
 function(avm_add_json_includes target)
     target_link_libraries(${target} PRIVATE avm_core)
     target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/3p")
+endfunction()
+
+function(avm_add_json_adapter_includes target)
+    avm_add_json_includes(${target})
+    target_include_directories(${target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/adapters")
 endfunction()
 
 if(AVM_BUILD_CLI)
@@ -160,6 +166,14 @@ if(AVM_BUILD_CLI)
     avm_add_trace_cli_test(cli_trace_failure failure "${TEST_DIR}/trace_failure.json")
     avm_add_trace_cli_test(cli_trace_nonexpression nonexpression "${TEST_DIR}/true.json")
     avm_add_trace_cli_test(cli_trace_badlimit badlimit "${TEST_DIR}/trace_boolean.json")
+endif()
+
+if(AVM_BUILD_JSON_TOOLS)
+    add_executable(avm_json_convert "${CMAKE_CURRENT_SOURCE_DIR}/src/json_convert.cpp")
+    set_target_properties(avm_json_convert PROPERTIES OUTPUT_NAME "avm-json-convert")
+    avm_add_json_adapter_includes(avm_json_convert)
+    avm_apply_quality(avm_json_convert)
+    install(TARGETS avm_json_convert RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if(AVM_BUILD_CORE_TESTS)
@@ -231,6 +245,12 @@ if(AVM_BUILD_CORE_TESTS)
     avm_enable_test_assertions(avm_json_value_codec_test)
     add_test(NAME json_value_codec_tests COMMAND avm_json_value_codec_test)
 
+    add_executable(avm_json_duplet_converter_test "${CMAKE_CURRENT_SOURCE_DIR}/test/json_duplet_converter_test.cpp")
+    avm_add_json_adapter_includes(avm_json_duplet_converter_test)
+    avm_apply_quality(avm_json_duplet_converter_test)
+    avm_enable_test_assertions(avm_json_duplet_converter_test)
+    add_test(NAME json_duplet_converter_tests COMMAND avm_json_duplet_converter_test)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -257,7 +277,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_inspection_session_test
         avm_persistent_inspection_session_test
         avm_vertical_slice_test
-        avm_json_value_codec_test)
+        avm_json_value_codec_test
+        avm_json_duplet_converter_test)
 endif()
 
 if(AVM_BUILD_ANUM_ADAPTER_TESTS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,6 @@ if(AVM_BUILD_JSON_TOOLS)
     set_target_properties(avm_json_convert PROPERTIES OUTPUT_NAME "avm-json-convert")
     avm_add_json_adapter_includes(avm_json_convert)
     avm_apply_quality(avm_json_convert)
-    install(TARGETS avm_json_convert RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 if(AVM_BUILD_CORE_TESTS)

--- a/adapters/json_duplet_converter.h
+++ b/adapters/json_duplet_converter.h
@@ -50,8 +50,11 @@ template <typename Json> Json triplet_to_duplet(const Json &value, const std::st
 		if (relation_members != 3)
 			throw ConversionError(path + ": incomplete legacy relation form: expected $rel, $sub and $obj");
 		if (value.size() != 3)
-			throw ConversionError(
-			    path + ": mixed legacy relation form: foreign members are not losslessly convertible");
+		{
+			const std::string message =
+			    path + ": mixed legacy relation form: foreign members are not losslessly convertible";
+			throw ConversionError(message);
+		}
 
 		Json arguments = Json::object();
 		arguments["<<"] = triplet_to_duplet(value.at("$sub"), object_path(path, "$sub"));

--- a/adapters/json_duplet_converter.h
+++ b/adapters/json_duplet_converter.h
@@ -121,12 +121,12 @@ inline Json duplet_to_triplet(const Json &value, const std::string &path)
 
 inline Json convert_explicit_triplets_to_duplets(const Json &value)
 {
-	return detail::triplet_to_duplet(value, "$ ");
+	return detail::triplet_to_duplet(value, "$");
 }
 
 inline Json convert_relation_duplets_to_explicit_triplets(const Json &value)
 {
-	return detail::duplet_to_triplet(value, "$ ");
+	return detail::duplet_to_triplet(value, "$");
 }
 
 } // namespace avm::json_duplet

--- a/adapters/json_duplet_converter.h
+++ b/adapters/json_duplet_converter.h
@@ -26,8 +26,7 @@ inline std::string array_path(const std::string &path, std::size_t index)
 	return path + "[" + std::to_string(index) + "]";
 }
 
-template <typename Json>
-Json triplet_to_duplet(const Json &value, const std::string &path)
+template <typename Json> Json triplet_to_duplet(const Json &value, const std::string &path)
 {
 	if (value.is_array())
 	{
@@ -43,15 +42,16 @@ Json triplet_to_duplet(const Json &value, const std::string &path)
 	const bool has_relation = value.contains("$rel");
 	const bool has_subject = value.contains("$sub");
 	const bool has_object = value.contains("$obj");
-	const unsigned relation_members = static_cast<unsigned>(has_relation) + static_cast<unsigned>(has_subject) +
-	                                  static_cast<unsigned>(has_object);
+	const unsigned relation_members =
+	    static_cast<unsigned>(has_relation) + static_cast<unsigned>(has_subject) + static_cast<unsigned>(has_object);
 
 	if (relation_members != 0)
 	{
 		if (relation_members != 3)
 			throw ConversionError(path + ": incomplete legacy relation form: expected $rel, $sub and $obj");
 		if (value.size() != 3)
-			throw ConversionError(path + ": mixed legacy relation form: foreign members are not losslessly convertible");
+			throw ConversionError(
+			    path + ": mixed legacy relation form: foreign members are not losslessly convertible");
 
 		Json arguments = Json::object();
 		arguments["<<"] = triplet_to_duplet(value.at("$sub"), object_path(path, "$sub"));
@@ -69,8 +69,7 @@ Json triplet_to_duplet(const Json &value, const std::string &path)
 	return result;
 }
 
-template <typename Json>
-Json duplet_to_triplet(const Json &value, const std::string &path)
+template <typename Json> Json duplet_to_triplet(const Json &value, const std::string &path)
 {
 	if (value.is_array())
 	{
@@ -117,14 +116,12 @@ Json duplet_to_triplet(const Json &value, const std::string &path)
 
 } // namespace detail
 
-template <typename Json>
-Json convert_explicit_triplets_to_duplets(const Json &value)
+template <typename Json> Json convert_explicit_triplets_to_duplets(const Json &value)
 {
 	return detail::triplet_to_duplet(value, "$");
 }
 
-template <typename Json>
-Json convert_relation_duplets_to_explicit_triplets(const Json &value)
+template <typename Json> Json convert_relation_duplets_to_explicit_triplets(const Json &value)
 {
 	return detail::duplet_to_triplet(value, "$");
 }

--- a/adapters/json_duplet_converter.h
+++ b/adapters/json_duplet_converter.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "nlohmann/json.hpp"
+
+#include <cstddef>
+#include <stdexcept>
+#include <string>
+
+namespace avm::json_duplet
+{
+
+using Json = nlohmann::ordered_json;
+
+class ConversionError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+namespace detail
+{
+
+inline std::string object_path(const std::string &path, const std::string &key)
+{
+	return path + "." + key;
+}
+
+inline std::string array_path(const std::string &path, std::size_t index)
+{
+	return path + "[" + std::to_string(index) + "]";
+}
+
+inline Json triplet_to_duplet(const Json &value, const std::string &path)
+{
+	if (value.is_array())
+	{
+		Json result = Json::array();
+		for (std::size_t index = 0; index < value.size(); ++index)
+			result.push_back(triplet_to_duplet(value[index], array_path(path, index)));
+		return result;
+	}
+
+	if (!value.is_object())
+		return value;
+
+	const bool has_relation = value.contains("$rel");
+	const bool has_subject = value.contains("$sub");
+	const bool has_object = value.contains("$obj");
+	const unsigned relation_members = static_cast<unsigned>(has_relation) + static_cast<unsigned>(has_subject) +
+	                                  static_cast<unsigned>(has_object);
+
+	if (relation_members != 0)
+	{
+		if (relation_members != 3)
+			throw ConversionError(path + ": incomplete legacy relation form: expected $rel, $sub and $obj");
+		if (value.size() != 3)
+			throw ConversionError(path + ": mixed legacy relation form: foreign members are not losslessly convertible");
+
+		Json arguments = Json::object();
+		arguments["<<"] = triplet_to_duplet(value.at("$sub"), object_path(path, "$sub"));
+		arguments[">>"] = triplet_to_duplet(value.at("$obj"), object_path(path, "$obj"));
+
+		Json result = Json::object();
+		result["<<"] = triplet_to_duplet(value.at("$rel"), object_path(path, "$rel"));
+		result[">>"] = std::move(arguments);
+		return result;
+	}
+
+	Json result = Json::object();
+	for (auto member = value.begin(); member != value.end(); ++member)
+		result[member.key()] = triplet_to_duplet(member.value(), object_path(path, member.key()));
+	return result;
+}
+
+inline Json duplet_to_triplet(const Json &value, const std::string &path)
+{
+	if (value.is_array())
+	{
+		Json result = Json::array();
+		for (std::size_t index = 0; index < value.size(); ++index)
+			result.push_back(duplet_to_triplet(value[index], array_path(path, index)));
+		return result;
+	}
+
+	if (!value.is_object())
+		return value;
+
+	const bool has_begin = value.contains("<<");
+	const bool has_end = value.contains(">>");
+	if (has_begin || has_end)
+	{
+		if (!has_begin || !has_end)
+			throw ConversionError(path + ": malformed duplet: fields << and >> must appear together");
+		if (value.size() != 2)
+			throw ConversionError(path + ": malformed duplet: foreign members are not allowed");
+
+		const Json &arguments = value.at(">>");
+		if (!arguments.is_object())
+			throw ConversionError(path + ": standalone duplet has no explicit-triplet representation");
+
+		const bool arguments_have_begin = arguments.contains("<<");
+		const bool arguments_have_end = arguments.contains(">>");
+		if (!arguments_have_begin || !arguments_have_end || arguments.size() != 2)
+			throw ConversionError(object_path(path, ">>") +
+			                      ": relation arguments must be an exact duplet with << and >>");
+
+		Json result = Json::object();
+		result["$rel"] = duplet_to_triplet(value.at("<<"), object_path(path, "<<"));
+		result["$sub"] = duplet_to_triplet(arguments.at("<<"), object_path(object_path(path, ">>"), "<<"));
+		result["$obj"] = duplet_to_triplet(arguments.at(">>"), object_path(object_path(path, ">>"), ">>"));
+		return result;
+	}
+
+	Json result = Json::object();
+	for (auto member = value.begin(); member != value.end(); ++member)
+		result[member.key()] = duplet_to_triplet(member.value(), object_path(path, member.key()));
+	return result;
+}
+
+} // namespace detail
+
+inline Json convert_explicit_triplets_to_duplets(const Json &value)
+{
+	return detail::triplet_to_duplet(value, "$ ");
+}
+
+inline Json convert_relation_duplets_to_explicit_triplets(const Json &value)
+{
+	return detail::duplet_to_triplet(value, "$ ");
+}
+
+} // namespace avm::json_duplet

--- a/adapters/json_duplet_converter.h
+++ b/adapters/json_duplet_converter.h
@@ -1,15 +1,11 @@
 #pragma once
 
-#include "nlohmann/json.hpp"
-
 #include <cstddef>
 #include <stdexcept>
 #include <string>
 
 namespace avm::json_duplet
 {
-
-using Json = nlohmann::ordered_json;
 
 class ConversionError : public std::runtime_error
 {
@@ -30,7 +26,8 @@ inline std::string array_path(const std::string &path, std::size_t index)
 	return path + "[" + std::to_string(index) + "]";
 }
 
-inline Json triplet_to_duplet(const Json &value, const std::string &path)
+template <typename Json>
+Json triplet_to_duplet(const Json &value, const std::string &path)
 {
 	if (value.is_array())
 	{
@@ -72,7 +69,8 @@ inline Json triplet_to_duplet(const Json &value, const std::string &path)
 	return result;
 }
 
-inline Json duplet_to_triplet(const Json &value, const std::string &path)
+template <typename Json>
+Json duplet_to_triplet(const Json &value, const std::string &path)
 {
 	if (value.is_array())
 	{
@@ -119,12 +117,14 @@ inline Json duplet_to_triplet(const Json &value, const std::string &path)
 
 } // namespace detail
 
-inline Json convert_explicit_triplets_to_duplets(const Json &value)
+template <typename Json>
+Json convert_explicit_triplets_to_duplets(const Json &value)
 {
 	return detail::triplet_to_duplet(value, "$");
 }
 
-inline Json convert_relation_duplets_to_explicit_triplets(const Json &value)
+template <typename Json>
+Json convert_relation_duplets_to_explicit_triplets(const Json &value)
 {
 	return detail::duplet_to_triplet(value, "$");
 }

--- a/convert_json.bat
+++ b/convert_json.bat
@@ -1,0 +1,47 @@
+@echo off
+setlocal
+
+cd /d "%~dp0"
+
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: cmake.exe was not found in PATH.
+    exit /b 1
+)
+
+set "BUILD_DIR=build"
+set "CONVERTER_EXE="
+
+for /r "%BUILD_DIR%" %%F in (avm-json-convert.exe) do (
+    set "CONVERTER_EXE=%%F"
+)
+
+if not defined CONVERTER_EXE (
+    echo.
+    echo === Build avm-json-convert ===
+    cmake -S . -B "%BUILD_DIR%"
+    if errorlevel 1 goto :fail
+
+    cmake --build "%BUILD_DIR%" --config Release --target avm_json_convert
+    if errorlevel 1 goto :fail
+
+    for /r "%BUILD_DIR%" %%F in (avm-json-convert.exe) do (
+        set "CONVERTER_EXE=%%F"
+    )
+)
+
+if not defined CONVERTER_EXE (
+    echo ERROR: avm-json-convert.exe was not found under %BUILD_DIR%.
+    exit /b 1
+)
+
+echo.
+echo === AVM JSON converter ===
+echo %CONVERTER_EXE%
+"%CONVERTER_EXE%" %*
+exit /b %errorlevel%
+
+:fail
+echo.
+echo ERROR: avm-json-convert build failed.
+exit /b 1

--- a/docs/duplet-json-format.md
+++ b/docs/duplet-json-format.md
@@ -1,0 +1,603 @@
+# Нативный дуплетный JSON-формат AVM
+
+Родительская задача: #169. ADR-задача: #170. Связанные задачи: #130, #171–#175.
+
+## Статус
+
+Этот документ определяет нативный JSON frontend AVM версии `duplet-json/1`.
+
+Формат принадлежит AVM. Он **не заменяет** и не изменяет JSON-язык `jsonRVM`. Исторический `jsonRVM` сохраняет формы `$rel/$sub/$obj` и используется как compatibility/oracle source.
+
+Главный принцип новой нотации:
+
+```text
+JSON-пара описывает ровно Link(begin, end)
+```
+
+а триединая сущность Модели Отношений является только частным структурным паттерном пары.
+
+## Канонический порядок ролей
+
+Модель Отношений использует:
+
+```text
+(rel, sub, obj)
+```
+
+Каноническое представление через вложенные дуплеты:
+
+```text
+(rel, sub, obj) = (rel, (sub, obj))
+```
+
+Следовательно AVM RelationEntity структурно равна:
+
+```text
+Link(relation, Link(subject, object))
+```
+
+В старом `jsonRVM#10` исторически была записана перестановка `(rel,(obj,sub))`. Она **не является** compatibility-вариантом AVM и не поддерживается native frontend-ом.
+
+## Базовая JSON-форма дуплета
+
+Единственная структурная primitive-форма:
+
+```json
+{
+  "<<": <begin>,
+  ">>": <end>
+}
+```
+
+где:
+
+```text
+<< = begin
+>> = end
+```
+
+Объект пары должен содержать **ровно** два поля `<<` и `>>`.
+
+Недопустимы:
+
+```json
+{"<<": 1}
+```
+
+```json
+{">>": 2}
+```
+
+```json
+{"<<": 1, ">>": 2, "extra": 3}
+```
+
+Parser обязан отвергнуть такие формы до любой materialization.
+
+## Триединая сущность
+
+Явный relation pattern:
+
+```json
+{
+  "<<": <relation>,
+  ">>": {
+    "<<": <subject>,
+    ">>": <object>
+  }
+}
+```
+
+Это **не отдельная JSON-конструкция** и не специальный opcode parser-а. Это обычная пара, у которой `end` также является парой.
+
+Именно Executor позднее интерпретирует полученный canonical `LinkId` как RelationEntity по существующему контракту:
+
+```text
+decode_relation_entity(entity)
+ -> relation
+ -> subject
+ -> object
+```
+
+Native JSON adapter не исполняет этот паттерн и не знает controller semantics.
+
+## Почему используются `<<` и `>>`
+
+Короткий вариант через JSON array:
+
+```json
+[begin, end]
+```
+
+не выбран как нормативный по трём причинам:
+
+1. `jsonRVM` исторически использует arrays как исполняемые последовательности;
+2. визуально array не показывает направление связи;
+3. `<<` и `>>` позволяют глазами читать рекурсивную асеть как begin/end links.
+
+При этом символы не имеют execution meaning. Они являются только transport spelling полей `begin` и `end`.
+
+## Документ и bare term
+
+### Versioned file/document
+
+Файл AVM Native JSON версии 1 имеет envelope:
+
+```json
+{
+  "$avm": "duplet-json/1",
+  "$root": <term>
+}
+```
+
+Envelope относится только к transport layer.
+
+`$avm` и `$root` **не материализуются** как связи и не входят в semantic identity программы.
+
+Version marker обязателен для file/CLI format, чтобы будущая версия могла менять surface protocol без эвристического определения формата.
+
+### Bare term API
+
+Library adapter может принимать непосредственно `<term>`, если вызывающий код уже явно выбрал parser версии `duplet-json/1`.
+
+Bare term не должен использоваться для автоматического определения формата файла.
+
+## Term и leaf
+
+Концептуальная grammar:
+
+```text
+Document := {
+  "$avm": "duplet-json/1",
+  "$root": Term
+}
+
+Term := Pair | Leaf
+
+Pair := {
+  "<<": Term,
+  ">>": Term
+}
+
+Leaf := protocol-level token,
+        который разрешается внешним leaf resolver
+```
+
+JSON parser отвечает только за синтаксис Pair/Document.
+
+Он не имеет права самостоятельно решать, какой `LinkId` соответствует произвольному JSON scalar/object.
+
+## Минимальный стандартный leaf: существующий LinkId
+
+Первый raw resolver должен поддержать явную ссылку на существующую AVM identity:
+
+```json
+{"$link": 42}
+```
+
+Нормативная семантика:
+
+```text
+{"$link": N}
+ -> ProjectionRef::Anchor(N)
+```
+
+Ограничения:
+
+- `N` — положительный целый JSON number в диапазоне `LinkId`;
+- `0` запрещён как `invalid_link_id`;
+- parser/resolver не создаёт отсутствующий LinkId;
+- `find_projection` при отсутствующем anchor возвращает miss;
+- `realize_projection` при отсутствующем anchor завершает операцию ошибкой **до** materialization prefix.
+
+Пример RelationEntity над существующими anchors:
+
+```json
+{
+  "$avm": "duplet-json/1",
+  "$root": {
+    "<<": {"$link": 10},
+    ">>": {
+      "<<": {"$link": 20},
+      ">>": {"$link": 30}
+    }
+  }
+}
+```
+
+После projection/realization структура обязана быть:
+
+```text
+args   = Link(20, 30)
+entity = Link(10, args)
+```
+
+то есть `(rel,(sub,obj))`.
+
+## Расширяемые leaf resolvers
+
+Будущие задачи могут добавить protocol-level leaves:
+
+```text
+symbolic anchor
+canonical Integer
+Boolean / nil
+Text
+context/reference expression
+```
+
+Но эти формы должны реализовываться отдельным resolver/projection contract.
+
+Запрещено вводить правило:
+
+```text
+"unknown string" -> store.create_point()
+```
+
+или:
+
+```text
+JSON scalar -> hidden host-side value keyed by LinkId
+```
+
+Такой подход создаёт вторую невидимую semantic universe и нарушает persistence/find semantics.
+
+## Рекомендуемые будущие spelling-и
+
+Следующие spelling-и зарезервированы как рабочее пространство resolver-а, но **не становятся нормативными до #173**:
+
+```json
+{"$symbol": "integer_add"}
+{"$integer": 7}
+{"$text": "hello"}
+```
+
+Raw v1 parser должен передавать неизвестный непарный object leaf resolver-у, а стандартный resolver обязан детерминированно отвергать неизвестный leaf kind.
+
+Это позволяет расширять protocol layer без изменения `ProjectionDescription` и LinkStore.
+
+## Parser и `ProjectionDescription`
+
+Нативный путь:
+
+```text
+Duplet JSON
+ -> parse JSON
+ -> validate Document/Pair syntax
+ -> resolve Leaf -> ProjectionRef
+ -> post-order build ProjectionNode list
+ -> ProjectionDescription
+```
+
+Для пары:
+
+```json
+{"<<": B, ">>": E}
+```
+
+adapter сначала проецирует `B` и `E`, затем добавляет:
+
+```text
+ProjectionNode{begin_ref, end_ref}
+```
+
+и возвращает `ProjectionRef::Node(new_index)`.
+
+Post-order нужен, потому что `ProjectionDescription` разрешает Node ссылаться только на более ранние nodes.
+
+## `find` и `realize` остаются разными операциями
+
+Parser/projector не принимает решение materialize.
+
+После него caller явно выбирает:
+
+```text
+find_projection(store, description)
+```
+
+или:
+
+```text
+realize_projection(store, description)
+```
+
+### Find
+
+- не вызывает `intern`;
+- не вызывает `create_point`;
+- miss не меняет `LinkStore::size()`;
+- одинаково работает для in-memory и persistent stores.
+
+### Realize
+
+- сначала валидирует description и anchors;
+- затем явно вызывает canonical `intern(begin,end)`;
+- повторный вызов идемпотентен;
+- одинаковые пары могут получить одну structural identity только здесь, а не потому что parser видел одинаковые JSON subtrees.
+
+## JSON tree не является графом identity
+
+JSON AST — дерево occurrence-ов. LinkStore — граф canonical links.
+
+Два одинаковых фрагмента:
+
+```json
+{"<<": {"$link": 1}, ">>": {"$link": 2}}
+```
+
+в двух местах JSON являются двумя syntax occurrences.
+
+При `realize_projection` они могут схлопнуться в один canonical `LinkId`, потому что `intern(1,2)` каноничен.
+
+Запрещено использовать:
+
+- адрес JSON DOM node;
+- pointer на parser object;
+- индекс occurrence без explicit document semantics
+
+как semantic identity AVM.
+
+## Named definitions и shared references
+
+`duplet-json/1` raw tree не вводит `$defs`, forward references или graph labels автоматически.
+
+Они могут появиться отдельным document-level расширением после определения identity ownership.
+
+Причина: named definition может означать разные вещи:
+
+1. имя существующего anchor;
+2. создание новой независимой point identity;
+3. alias на уже описанный duplet;
+4. external symbol resolver entry.
+
+Смешивать эти варианты одной строкой опасно для persistence и `find != realize`.
+
+## Обычные JSON values не являются structural Pair
+
+Любой JSON object, который не содержит pair-marker `<<`/`>>`, является Leaf token для resolver-а.
+
+Если object содержит хотя бы один pair-marker, parser применяет strict pair validation:
+
+- есть оба `<<` и `>>`;
+- нет других members.
+
+Это не даёт malformed pair случайно уйти в generic leaf resolver.
+
+JSON arrays и scalars также являются leaf tokens на raw adapter boundary, пока конкретный resolver не определит их projection.
+
+## Дубликаты JSON keys
+
+Стандартный DOM parser может потерять информацию о duplicate object members до semantic validation.
+
+CLI/file frontend должен использовать parse mode/callback, который обнаруживает duplicate members, либо отдельную pre-validation стратегию.
+
+Документ с duplicate `<<`, `>>`, `$avm` или `$root` должен быть отвергнут как неоднозначный.
+
+До реализации такого контроля #172 не считается завершённым.
+
+## Structural converter и native parser — разные компоненты
+
+Strict converter #171 переводит surface syntax:
+
+```text
+explicit triplet JSON
+ -> duplet JSON
+```
+
+и **не обязан** уметь разрешить листья в LinkId.
+
+Например:
+
+```json
+{"$rel":"+","$sub":1,"$obj":2}
+```
+
+структурно преобразуется в:
+
+```json
+{
+  "<<": "+",
+  ">>": {
+    "<<": 1,
+    ">>": 2
+  }
+}
+```
+
+Это корректный результат structural migration, но он станет executable native AVM program только когда resolver определит canonical meaning листьев `"+"`, `1`, `2`.
+
+Converter не должен ради удобства создавать identities или встраивать hidden symbol table.
+
+## Structural converter v1
+
+Поддерживаемый source relation-form:
+
+```json
+{
+  "$rel": R,
+  "$sub": S,
+  "$obj": O
+}
+```
+
+Преобразование:
+
+```text
+convert(R,S,O)
+ -> Pair(convert(R), Pair(convert(S), convert(O)))
+```
+
+То есть:
+
+```json
+{
+  "<<": R,
+  ">>": {
+    "<<": S,
+    ">>": O
+  }
+}
+```
+
+Порядок `S`/`O` является conformance-veto.
+
+## Неполные legacy relation forms
+
+Старый jsonRVM допускает context-dependent формы, в которых `$sub` или `$obj` отсутствует.
+
+Например runtime может подставлять текущее semantic relation-state.
+
+Strict structural converter **не исполняет context semantics**, поэтому v1 обязан отвергать:
+
+```json
+{"$rel":"+","$obj":1}
+```
+
+а не угадывать недостающий subject.
+
+Полная миграция таких программ относится к #174 после context/reference contracts.
+
+## Смешанные legacy relation forms
+
+Объект вида:
+
+```json
+{
+  "$rel": R,
+  "$sub": S,
+  "$obj": O,
+  "extra": X
+}
+```
+
+strict converter отвергает как неоднозначный.
+
+Причина: неизвестно, является `extra` частью data projection, metadata или ошибкой source format. Механический converter не имеет права терять member или придумывать representation.
+
+## Inverse converter
+
+Для conformance нужен обратный путь поддерживаемого relation-shaped subset:
+
+```text
+Pair(R, Pair(S,O))
+ -> {"$rel":R,"$sub":S,"$obj":O}
+```
+
+Он предназначен прежде всего для проверки:
+
+```text
+triplet -> duplet -> triplet
+```
+
+и **не является** общим способом представить произвольную пару в старом jsonRVM.
+
+Произвольный `Link(A,B)`, где `B` не relation-arguments pair, не имеет однозначного explicit-triplet representation и должен быть отвергнут inverse converter-ом.
+
+## Формат converter output
+
+Converter должен:
+
+- использовать UTF-8 JSON;
+- выдавать deterministic pretty-print с отступом 2 пробела;
+- создавать pair keys в порядке `<<`, затем `>>`;
+- создавать inverse triplet keys в порядке `$rel`, `$sub`, `$obj`;
+- завершать файл переводом строки;
+- не нормализовывать значения чисел/строк сверх поведения JSON parser/serializer;
+- не менять ordinary object members кроме рекурсивного преобразования их values.
+
+Converter output не получает `$avm` envelope автоматически: mechanical conversion может применяться к fragment-у внутри произвольного legacy document.
+
+Отдельный `--envelope` может быть добавлен позднее после появления полноценного native leaf resolver.
+
+## Граница с `JsonCompatibilitySession`
+
+Существующий `JsonCompatibilitySession` остаётся compatibility frontend-ом и не переписывается под `<<`/`>>`.
+
+Разделение:
+
+```text
+legacy JSON
+ -> JsonCompatibilitySession / semantic migration tooling
+
+native AVM duplet JSON
+ -> DupletJson frontend
+ -> ProjectionDescription
+```
+
+Нельзя добавлять branch вида:
+
+```text
+if object has "$rel" ... else if object has "<<" ...
+```
+
+в один общий interpreter. Это снова смешало бы два protocol языка и сделало JSON частью runtime semantics.
+
+## Ошибки
+
+Ошибки native parser/converter должны содержать JSON path к проблемной форме, например:
+
+```text
+$.items[2].program: incomplete legacy relation form: expected $rel/$sub/$obj
+```
+
+или:
+
+```text
+$.$root.>>: malformed duplet: fields << and >> must appear together
+```
+
+Диагностика является host tooling text, а не частью semantic Link structure.
+
+## Conformance
+
+Минимальный набор:
+
+1. один explicit triplet;
+2. sentinel `relation=R, subject=S, object=O`, доказывающий `(R,(S,O))`;
+3. relation в relation slot;
+4. relation в subject slot;
+5. relation в object slot;
+6. triplet внутри array;
+7. triplet внутри ordinary object;
+8. incomplete `$sub`;
+9. incomplete `$obj`;
+10. mixed legacy members;
+11. malformed pair без `<<`;
+12. malformed pair без `>>`;
+13. mixed pair members;
+14. forward/inverse round-trip supported subset;
+15. raw native anchors -> `ProjectionDescription` -> canonical RelationEntity;
+16. find miss не пишет;
+17. repeated realize возвращает тот же canonical root.
+
+## Влияние на jsonRVM
+
+Никакого.
+
+`jsonRVM#10` закрывается как перенесённый в AVM. Existing jsonRVM source files, parser, tests и runtime остаются в старой нотации.
+
+Это позволяет использовать jsonRVM как стабильный semantic oracle во время разработки AVM, вместо одновременного изменения и источника, и целевой реализации.
+
+## Нормативные запреты
+
+Запрещено:
+
+- поддерживать `(rel,(obj,sub))` в native AVM;
+- считать `<<`/`>>` execution opcodes;
+- выполнять `realize` внутри parser-а;
+- создавать point из неизвестного JSON leaf;
+- хранить JSON DOM как canonical program representation;
+- смешивать native duplet parser и legacy compatibility interpreter;
+- считать occurrence identity JSON semantic identity;
+- превращать structural converter в jsonRVM evaluator;
+- silently convert incomplete context-dependent triplets.
+
+## Следующие gates
+
+После этого ADR:
+
+1. #171 — strict structural converter;
+2. #172 — native duplet parser/projector;
+3. #173 — canonical leaf/value/symbol resolver;
+4. #174 — полный semantic migrator jsonRVM;
+5. #175 — CLI/examples/Showcase.

--- a/docs/duplet-json-format.md
+++ b/docs/duplet-json-format.md
@@ -6,15 +6,15 @@
 
 Этот документ определяет нативный JSON frontend AVM версии `duplet-json/1`.
 
-Формат принадлежит AVM. Он **не заменяет** и не изменяет JSON-язык `jsonRVM`. Исторический `jsonRVM` сохраняет формы `$rel/$sub/$obj` и используется как compatibility/oracle source.
+Формат принадлежит AVM. Он **не заменяет** и не изменяет JSON-язык `jsonRVM`: исторический `jsonRVM` сохраняет `$rel/$sub/$obj` и остаётся compatibility/oracle source.
 
-Главный принцип новой нотации:
+Главный принцип:
 
 ```text
 JSON-пара описывает ровно Link(begin, end)
 ```
 
-а триединая сущность Модели Отношений является только частным структурным паттерном пары.
+Триединая сущность Модели Отношений является только частным структурным паттерном пары.
 
 ## Канонический порядок ролей
 
@@ -30,15 +30,15 @@ JSON-пара описывает ровно Link(begin, end)
 (rel, sub, obj) = (rel, (sub, obj))
 ```
 
-Следовательно AVM RelationEntity структурно равна:
+Следовательно:
 
 ```text
-Link(relation, Link(subject, object))
+RelationEntity = Link(relation, Link(subject, object))
 ```
 
-В старом `jsonRVM#10` исторически была записана перестановка `(rel,(obj,sub))`. Она **не является** compatibility-вариантом AVM и не поддерживается native frontend-ом.
+В старом `jsonRVM#10` исторически была записана перестановка `(rel,(obj,sub))`. Она не является compatibility-вариантом AVM и в native frontend не поддерживается.
 
-## Базовая JSON-форма дуплета
+## Базовая форма дуплета
 
 Единственная структурная primitive-форма:
 
@@ -56,7 +56,7 @@ Link(relation, Link(subject, object))
 >> = end
 ```
 
-Объект пары должен содержать **ровно** два поля `<<` и `>>`.
+Объект пары должен содержать ровно два поля `<<` и `>>`.
 
 Недопустимы:
 
@@ -76,7 +76,7 @@ Parser обязан отвергнуть такие формы до любой m
 
 ## Триединая сущность
 
-Явный relation pattern:
+RelationEntity записывается обычной вложенностью пар:
 
 ```json
 {
@@ -88,40 +88,23 @@ Parser обязан отвергнуть такие формы до любой m
 }
 ```
 
-Это **не отдельная JSON-конструкция** и не специальный opcode parser-а. Это обычная пара, у которой `end` также является парой.
-
-Именно Executor позднее интерпретирует полученный canonical `LinkId` как RelationEntity по существующему контракту:
-
-```text
-decode_relation_entity(entity)
- -> relation
- -> subject
- -> object
-```
-
-Native JSON adapter не исполняет этот паттерн и не знает controller semantics.
+Это не отдельная JSON-конструкция и не opcode parser-а. Только Executor позднее интерпретирует полученный canonical `LinkId` как исполняемую RelationEntity.
 
 ## Почему используются `<<` и `>>`
 
-Короткий вариант через JSON array:
+Запись `[begin,end]` короче, но не выбрана нормативной, потому что:
 
-```json
-[begin, end]
-```
+1. `jsonRVM` исторически использует JSON arrays как исполняемые последовательности;
+2. array визуально не показывает направление связи;
+3. `<<` и `>>` позволяют глазами читать begin/end рекурсивной асети.
 
-не выбран как нормативный по трём причинам:
+Эти ключи не имеют execution semantics.
 
-1. `jsonRVM` исторически использует arrays как исполняемые последовательности;
-2. визуально array не показывает направление связи;
-3. `<<` и `>>` позволяют глазами читать рекурсивную асеть как begin/end links.
+## Документ и отдельный терм
 
-При этом символы не имеют execution meaning. Они являются только transport spelling полей `begin` и `end`.
+### Версионированный файл
 
-## Документ и bare term
-
-### Versioned file/document
-
-Файл AVM Native JSON версии 1 имеет envelope:
+Файл Native JSON версии 1 имеет envelope:
 
 ```json
 {
@@ -130,19 +113,17 @@ Native JSON adapter не исполняет этот паттерн и не зн
 }
 ```
 
-Envelope относится только к transport layer.
+`$avm` и `$root` относятся только к transport layer и не материализуются как связи.
 
-`$avm` и `$root` **не материализуются** как связи и не входят в semantic identity программы.
+Version marker обязателен для file/CLI format.
 
-Version marker обязателен для file/CLI format, чтобы будущая версия могла менять surface protocol без эвристического определения формата.
+### API отдельного терма
 
-### Bare term API
+Library adapter может принимать непосредственно `<term>`, если вызывающий код уже явно выбрал parser `duplet-json/1`.
 
-Library adapter может принимать непосредственно `<term>`, если вызывающий код уже явно выбрал parser версии `duplet-json/1`.
+Bare term не используется для эвристического определения формата файла.
 
-Bare term не должен использоваться для автоматического определения формата файла.
-
-## Term и leaf
+## Терм и лист
 
 Концептуальная grammar:
 
@@ -160,22 +141,20 @@ Pair := {
 }
 
 Leaf := protocol-level token,
-        который разрешается внешним leaf resolver
+        разрешаемый внешним leaf resolver
 ```
 
-JSON parser отвечает только за синтаксис Pair/Document.
+Parser отвечает за структуру пары, но не имеет права сам решать, какой `LinkId` соответствует произвольному JSON scalar/object.
 
-Он не имеет права самостоятельно решать, какой `LinkId` соответствует произвольному JSON scalar/object.
+## Минимальный лист: существующий LinkId
 
-## Минимальный стандартный leaf: существующий LinkId
-
-Первый raw resolver должен поддержать явную ссылку на существующую AVM identity:
+Первый raw resolver поддерживает явную ссылку на уже существующую AVM identity:
 
 ```json
 {"$link": 42}
 ```
 
-Нормативная семантика:
+Семантика:
 
 ```text
 {"$link": N}
@@ -188,9 +167,9 @@ JSON parser отвечает только за синтаксис Pair/Document.
 - `0` запрещён как `invalid_link_id`;
 - parser/resolver не создаёт отсутствующий LinkId;
 - `find_projection` при отсутствующем anchor возвращает miss;
-- `realize_projection` при отсутствующем anchor завершает операцию ошибкой **до** materialization prefix.
+- `realize_projection` при отсутствующем anchor завершается ошибкой до materialization prefix.
 
-Пример RelationEntity над существующими anchors:
+Пример:
 
 ```json
 {
@@ -205,7 +184,7 @@ JSON parser отвечает только за синтаксис Pair/Document.
 }
 ```
 
-После projection/realization структура обязана быть:
+После realization:
 
 ```text
 args   = Link(20, 30)
@@ -214,9 +193,9 @@ entity = Link(10, args)
 
 то есть `(rel,(sub,obj))`.
 
-## Расширяемые leaf resolvers
+## Расширяемые resolvers листьев
 
-Будущие задачи могут добавить protocol-level leaves:
+Будущие задачи могут добавить:
 
 ```text
 symbolic anchor
@@ -226,9 +205,7 @@ Text
 context/reference expression
 ```
 
-Но эти формы должны реализовываться отдельным resolver/projection contract.
-
-Запрещено вводить правило:
+Но запрещено вводить правила:
 
 ```text
 "unknown string" -> store.create_point()
@@ -240,56 +217,28 @@ context/reference expression
 JSON scalar -> hidden host-side value keyed by LinkId
 ```
 
-Такой подход создаёт вторую невидимую semantic universe и нарушает persistence/find semantics.
+Рабочие spelling-и `$symbol`, `$integer`, `$text` не становятся нормативными до #173.
 
-## Рекомендуемые будущие spelling-и
-
-Следующие spelling-и зарезервированы как рабочее пространство resolver-а, но **не становятся нормативными до #173**:
-
-```json
-{"$symbol": "integer_add"}
-{"$integer": 7}
-{"$text": "hello"}
-```
-
-Raw v1 parser должен передавать неизвестный непарный object leaf resolver-у, а стандартный resolver обязан детерминированно отвергать неизвестный leaf kind.
-
-Это позволяет расширять protocol layer без изменения `ProjectionDescription` и LinkStore.
-
-## Parser и `ProjectionDescription`
+## Проекция в `ProjectionDescription`
 
 Нативный путь:
 
 ```text
 Duplet JSON
  -> parse JSON
- -> validate Document/Pair syntax
+ -> validate Document/Pair
  -> resolve Leaf -> ProjectionRef
  -> post-order build ProjectionNode list
  -> ProjectionDescription
 ```
 
-Для пары:
-
-```json
-{"<<": B, ">>": E}
-```
-
-adapter сначала проецирует `B` и `E`, затем добавляет:
-
-```text
-ProjectionNode{begin_ref, end_ref}
-```
-
-и возвращает `ProjectionRef::Node(new_index)`.
+Для пары `{"<<":B,">>":E}` adapter сначала проецирует `B` и `E`, затем добавляет `ProjectionNode{begin_ref,end_ref}`.
 
 Post-order нужен, потому что `ProjectionDescription` разрешает Node ссылаться только на более ранние nodes.
 
-## `find` и `realize` остаются разными операциями
+## Разделение поиска и материализации
 
-Parser/projector не принимает решение materialize.
-
-После него caller явно выбирает:
+Parser/projector не принимает решение materialize. Caller явно выбирает:
 
 ```text
 find_projection(store, description)
@@ -301,90 +250,58 @@ find_projection(store, description)
 realize_projection(store, description)
 ```
 
-### Find
+### Поиск
 
 - не вызывает `intern`;
 - не вызывает `create_point`;
-- miss не меняет `LinkStore::size()`;
-- одинаково работает для in-memory и persistent stores.
+- miss не меняет `LinkStore::size()`.
 
-### Realize
+### Материализация
 
 - сначала валидирует description и anchors;
 - затем явно вызывает canonical `intern(begin,end)`;
-- повторный вызов идемпотентен;
-- одинаковые пары могут получить одну structural identity только здесь, а не потому что parser видел одинаковые JSON subtrees.
+- повторный вызов идемпотентен.
 
-## JSON tree не является графом identity
+Одинаковые пары получают одну structural identity только благодаря canonical `intern`, а не потому что parser увидел одинаковые JSON subtrees.
 
-JSON AST — дерево occurrence-ов. LinkStore — граф canonical links.
+## JSON-дерево не является графом identity
 
-Два одинаковых фрагмента:
+JSON AST содержит occurrences. LinkStore содержит canonical graph identities.
 
-```json
-{"<<": {"$link": 1}, ">>": {"$link": 2}}
-```
+Два одинаковых JSON-фрагмента являются двумя syntax occurrences, но после explicit realization могут схлопнуться в один `LinkId`.
 
-в двух местах JSON являются двумя syntax occurrences.
+Нельзя использовать адрес DOM node, pointer parser-а или occurrence index как semantic identity AVM.
 
-При `realize_projection` они могут схлопнуться в один canonical `LinkId`, потому что `intern(1,2)` каноничен.
+## Именованные определения и общие ссылки
 
-Запрещено использовать:
+Raw `duplet-json/1` не вводит `$defs`, forward references или graph labels автоматически.
 
-- адрес JSON DOM node;
-- pointer на parser object;
-- индекс occurrence без explicit document semantics
+Такая возможность требует отдельного identity contract, потому что имя может означать:
 
-как semantic identity AVM.
-
-## Named definitions и shared references
-
-`duplet-json/1` raw tree не вводит `$defs`, forward references или graph labels автоматически.
-
-Они могут появиться отдельным document-level расширением после определения identity ownership.
-
-Причина: named definition может означать разные вещи:
-
-1. имя существующего anchor;
-2. создание новой независимой point identity;
+1. существующий anchor;
+2. создание независимой point identity;
 3. alias на уже описанный duplet;
 4. external symbol resolver entry.
 
-Смешивать эти варианты одной строкой опасно для persistence и `find != realize`.
+До решения #173 эти случаи не смешиваются.
 
-## Обычные JSON values не являются structural Pair
+## Обычные JSON-значения
 
-Любой JSON object, который не содержит pair-marker `<<`/`>>`, является Leaf token для resolver-а.
+Object без `<<`/`>>` является Leaf token для resolver-а.
 
-Если object содержит хотя бы один pair-marker, parser применяет strict pair validation:
+Если object содержит хотя бы один pair-marker, применяется strict pair validation: должны присутствовать оба marker-а и не должно быть чужих members.
 
-- есть оба `<<` и `>>`;
-- нет других members.
+Arrays и scalars также являются leaf tokens до определения конкретного resolver-а.
 
-Это не даёт malformed pair случайно уйти в generic leaf resolver.
+## Дубликаты ключей JSON
 
-JSON arrays и scalars также являются leaf tokens на raw adapter boundary, пока конкретный resolver не определит их projection.
+DOM parser может потерять duplicate members до semantic validation.
 
-## Дубликаты JSON keys
+CLI/file frontend #172 должен обнаруживать duplicate `<<`, `>>`, `$avm`, `$root` и отвергать неоднозначный документ.
 
-Стандартный DOM parser может потерять информацию о duplicate object members до semantic validation.
+## Structural converter и native parser разделены
 
-CLI/file frontend должен использовать parse mode/callback, который обнаруживает duplicate members, либо отдельную pre-validation стратегию.
-
-Документ с duplicate `<<`, `>>`, `$avm` или `$root` должен быть отвергнут как неоднозначный.
-
-До реализации такого контроля #172 не считается завершённым.
-
-## Structural converter и native parser — разные компоненты
-
-Strict converter #171 переводит surface syntax:
-
-```text
-explicit triplet JSON
- -> duplet JSON
-```
-
-и **не обязан** уметь разрешить листья в LinkId.
+Strict converter #171 преобразует syntax и не обязан разрешать листья в LinkId.
 
 Например:
 
@@ -392,7 +309,7 @@ explicit triplet JSON
 {"$rel":"+","$sub":1,"$obj":2}
 ```
 
-структурно преобразуется в:
+преобразуется в:
 
 ```json
 {
@@ -404,11 +321,9 @@ explicit triplet JSON
 }
 ```
 
-Это корректный результат structural migration, но он станет executable native AVM program только когда resolver определит canonical meaning листьев `"+"`, `1`, `2`.
+Это корректная structural migration. Исполняемой AVM-программой результат станет только после resolver-а, который определит canonical meaning `"+"`, `1`, `2`.
 
-Converter не должен ради удобства создавать identities или встраивать hidden symbol table.
-
-## Structural converter v1
+## Структурный конвертер версии 1
 
 Поддерживаемый source relation-form:
 
@@ -439,79 +354,48 @@ convert(R,S,O)
 }
 ```
 
-Порядок `S`/`O` является conformance-veto.
+Порядок `S/O` является veto-gate.
 
-## Неполные legacy relation forms
+## Неполные legacy-формы
 
-Старый jsonRVM допускает context-dependent формы, в которых `$sub` или `$obj` отсутствует.
+Старый jsonRVM допускает context-dependent relation forms, в которых `$sub` или `$obj` отсутствует.
 
-Например runtime может подставлять текущее semantic relation-state.
+Strict converter не исполняет context semantics и поэтому обязан отвергать их, а не угадывать недостающий operand.
 
-Strict structural converter **не исполняет context semantics**, поэтому v1 обязан отвергать:
+Полная миграция относится к #174.
 
-```json
-{"$rel":"+","$obj":1}
-```
+## Смешанные legacy-формы
 
-а не угадывать недостающий subject.
+Объект с `$rel/$sub/$obj` и дополнительными members strict converter отвергает как неоднозначный, потому что механический converter не имеет права терять или переинтерпретировать поля.
 
-Полная миграция таких программ относится к #174 после context/reference contracts.
+## Обратный конвертер
 
-## Смешанные legacy relation forms
-
-Объект вида:
-
-```json
-{
-  "$rel": R,
-  "$sub": S,
-  "$obj": O,
-  "extra": X
-}
-```
-
-strict converter отвергает как неоднозначный.
-
-Причина: неизвестно, является `extra` частью data projection, metadata или ошибкой source format. Механический converter не имеет права терять member или придумывать representation.
-
-## Inverse converter
-
-Для conformance нужен обратный путь поддерживаемого relation-shaped subset:
+Для round-trip conformance поддерживается:
 
 ```text
 Pair(R, Pair(S,O))
  -> {"$rel":R,"$sub":S,"$obj":O}
 ```
 
-Он предназначен прежде всего для проверки:
+Он предназначен для relation-shaped subset и не является общим представлением произвольного `Link(A,B)` в jsonRVM.
 
-```text
-triplet -> duplet -> triplet
-```
+Standalone duplet, который нельзя однозначно выразить explicit triplet-ом, отвергается.
 
-и **не является** общим способом представить произвольную пару в старом jsonRVM.
+## Формат вывода конвертера
 
-Произвольный `Link(A,B)`, где `B` не relation-arguments pair, не имеет однозначного explicit-triplet representation и должен быть отвергнут inverse converter-ом.
+Converter:
 
-## Формат converter output
-
-Converter должен:
-
-- использовать UTF-8 JSON;
-- выдавать deterministic pretty-print с отступом 2 пробела;
-- создавать pair keys в порядке `<<`, затем `>>`;
-- создавать inverse triplet keys в порядке `$rel`, `$sub`, `$obj`;
-- завершать файл переводом строки;
-- не нормализовывать значения чисел/строк сверх поведения JSON parser/serializer;
-- не менять ordinary object members кроме рекурсивного преобразования их values.
-
-Converter output не получает `$avm` envelope автоматически: mechanical conversion может применяться к fragment-у внутри произвольного legacy document.
-
-Отдельный `--envelope` может быть добавлен позднее после появления полноценного native leaf resolver.
+- использует UTF-8 JSON;
+- печатает отступ 2 пробела;
+- создаёт keys `<<`, затем `>>`;
+- inverse создаёт `$rel`, `$sub`, `$obj`;
+- завершает output переводом строки;
+- сохраняет ordinary leaves;
+- не добавляет `$avm` envelope автоматически.
 
 ## Граница с `JsonCompatibilitySession`
 
-Существующий `JsonCompatibilitySession` остаётся compatibility frontend-ом и не переписывается под `<<`/`>>`.
+Существующий `JsonCompatibilitySession` остаётся старым compatibility frontend-ом.
 
 Разделение:
 
@@ -524,65 +408,48 @@ native AVM duplet JSON
  -> ProjectionDescription
 ```
 
-Нельзя добавлять branch вида:
+Не допускается общий interpreter с ветками `$rel` и `<<`.
+
+## Диагностика
+
+Ошибки должны содержать JSON path, например:
 
 ```text
-if object has "$rel" ... else if object has "<<" ...
+$.items[2].program: incomplete legacy relation form: expected $rel, $sub and $obj
 ```
 
-в один общий interpreter. Это снова смешало бы два protocol языка и сделало JSON частью runtime semantics.
+Диагностика является tooling text и не входит в semantic Link structure.
 
-## Ошибки
+## Проверки соответствия
 
-Ошибки native parser/converter должны содержать JSON path к проблемной форме, например:
+Минимальный corpus:
 
-```text
-$.items[2].program: incomplete legacy relation form: expected $rel/$sub/$obj
-```
-
-или:
-
-```text
-$.$root.>>: malformed duplet: fields << and >> must appear together
-```
-
-Диагностика является host tooling text, а не частью semantic Link structure.
-
-## Conformance
-
-Минимальный набор:
-
-1. один explicit triplet;
-2. sentinel `relation=R, subject=S, object=O`, доказывающий `(R,(S,O))`;
-3. relation в relation slot;
-4. relation в subject slot;
-5. relation в object slot;
-6. triplet внутри array;
-7. triplet внутри ordinary object;
-8. incomplete `$sub`;
-9. incomplete `$obj`;
-10. mixed legacy members;
-11. malformed pair без `<<`;
-12. malformed pair без `>>`;
-13. mixed pair members;
-14. forward/inverse round-trip supported subset;
-15. raw native anchors -> `ProjectionDescription` -> canonical RelationEntity;
-16. find miss не пишет;
-17. repeated realize возвращает тот же canonical root.
+1. explicit triplet;
+2. sentinel `R/S/O`, доказывающий `(R,(S,O))`;
+3. relation в relation/subject/object slots;
+4. triplet внутри array;
+5. triplet внутри ordinary object;
+6. incomplete `$sub`;
+7. incomplete `$obj`;
+8. mixed legacy members;
+9. malformed pair без одного marker-а;
+10. mixed pair members;
+11. forward/inverse round-trip;
+12. raw anchors -> `ProjectionDescription` -> canonical RelationEntity;
+13. find miss не пишет;
+14. repeated realize возвращает тот же root.
 
 ## Влияние на jsonRVM
 
 Никакого.
 
-`jsonRVM#10` закрывается как перенесённый в AVM. Existing jsonRVM source files, parser, tests и runtime остаются в старой нотации.
-
-Это позволяет использовать jsonRVM как стабильный semantic oracle во время разработки AVM, вместо одновременного изменения и источника, и целевой реализации.
+`jsonRVM#10` закрывается как перенесённый. Existing parser/runtime/tests jsonRVM остаются в старой нотации и продолжают служить стабильным semantic oracle.
 
 ## Нормативные запреты
 
 Запрещено:
 
-- поддерживать `(rel,(obj,sub))` в native AVM;
+- поддерживать `(rel,(obj,sub))` в AVM native syntax;
 - считать `<<`/`>>` execution opcodes;
 - выполнять `realize` внутри parser-а;
 - создавать point из неизвестного JSON leaf;
@@ -592,9 +459,7 @@ $.$root.>>: malformed duplet: fields << and >> must appear together
 - превращать structural converter в jsonRVM evaluator;
 - silently convert incomplete context-dependent triplets.
 
-## Следующие gates
-
-После этого ADR:
+## Следующие этапы
 
 1. #171 — strict structural converter;
 2. #172 — native duplet parser/projector;

--- a/src/json_convert.cpp
+++ b/src/json_convert.cpp
@@ -1,0 +1,167 @@
+#include "json_duplet_converter.h"
+
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+
+struct Options
+{
+	std::string from;
+	std::string to;
+	std::string input = "-";
+	std::string output = "-";
+	bool check_only = false;
+};
+
+[[noreturn]] void usage_error(const std::string &message)
+{
+	throw std::invalid_argument(message +
+	                            "\nusage: avm-json-convert --from=jsonrvm-triplet --to=avm-duplet [input|-] "
+	                            "[-o output|-] [--check]");
+}
+
+std::string option_value(const std::string &argument, const std::string &name)
+{
+	const std::string prefix = name + "=";
+	if (argument.rfind(prefix, 0) != 0)
+		return {};
+	return argument.substr(prefix.size());
+}
+
+Options parse_options(int argc, char **argv)
+{
+	Options options;
+	bool input_seen = false;
+
+	for (int index = 1; index < argc; ++index)
+	{
+		const std::string argument = argv[index];
+		if (argument == "--check")
+		{
+			options.check_only = true;
+			continue;
+		}
+
+		if (const std::string value = option_value(argument, "--from"); !value.empty())
+		{
+			options.from = value;
+			continue;
+		}
+		if (argument == "--from")
+		{
+			if (++index >= argc)
+				usage_error("--from requires a value");
+			options.from = argv[index];
+			continue;
+		}
+
+		if (const std::string value = option_value(argument, "--to"); !value.empty())
+		{
+			options.to = value;
+			continue;
+		}
+		if (argument == "--to")
+		{
+			if (++index >= argc)
+				usage_error("--to requires a value");
+			options.to = argv[index];
+			continue;
+		}
+
+		if (argument == "-o" || argument == "--output")
+		{
+			if (++index >= argc)
+				usage_error(argument + " requires a value");
+			options.output = argv[index];
+			continue;
+		}
+		if (const std::string value = option_value(argument, "--output"); !value.empty())
+		{
+			options.output = value;
+			continue;
+		}
+
+		if (!argument.empty() && argument[0] == '-' && argument != "-")
+			usage_error("unknown option: " + argument);
+		if (input_seen)
+			usage_error("only one input path is allowed");
+		options.input = argument;
+		input_seen = true;
+	}
+
+	if (options.from.empty())
+		usage_error("--from is required");
+	if (options.to.empty())
+		usage_error("--to is required");
+
+	const bool forward = options.from == "jsonrvm-triplet" && options.to == "avm-duplet";
+	const bool reverse = options.from == "avm-duplet" && options.to == "jsonrvm-explicit-triplet";
+	if (!forward && !reverse)
+		usage_error("unsupported conversion direction");
+
+	return options;
+}
+
+avm::json_duplet::Json read_json(const std::string &path)
+{
+	if (path == "-")
+	{
+		avm::json_duplet::Json value;
+		std::cin >> value;
+		return value;
+	}
+
+	std::ifstream input(path);
+	if (!input)
+		throw std::runtime_error("cannot open input file: " + path);
+
+	avm::json_duplet::Json value;
+	input >> value;
+	return value;
+}
+
+void write_json(const std::string &path, const avm::json_duplet::Json &value)
+{
+	if (path == "-")
+	{
+		std::cout << value.dump(2) << '\n';
+		return;
+	}
+
+	std::ofstream output(path, std::ios::trunc);
+	if (!output)
+		throw std::runtime_error("cannot open output file: " + path);
+	output << value.dump(2) << '\n';
+	if (!output)
+		throw std::runtime_error("failed to write output file: " + path);
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+	try
+	{
+		const Options options = parse_options(argc, argv);
+		const avm::json_duplet::Json input = read_json(options.input);
+
+		avm::json_duplet::Json output;
+		if (options.from == "jsonrvm-triplet")
+			output = avm::json_duplet::convert_explicit_triplets_to_duplets(input);
+		else
+			output = avm::json_duplet::convert_relation_duplets_to_explicit_triplets(input);
+
+		if (!options.check_only)
+			write_json(options.output, output);
+		return 0;
+	}
+	catch (const std::exception &error)
+	{
+		std::cerr << "avm-json-convert: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/src/json_convert.cpp
+++ b/src/json_convert.cpp
@@ -22,9 +22,9 @@ struct Options
 
 [[noreturn]] void usage_error(const std::string &message)
 {
-	throw std::invalid_argument(message +
-	                            "\nusage: avm-json-convert --from=jsonrvm-triplet --to=avm-duplet [input|-] "
-	                            "[-o output|-] [--check]");
+	throw std::invalid_argument(
+	    message + "\nusage: avm-json-convert --from=jsonrvm-triplet --to=avm-duplet [input|-] "
+	              "[-o output|-] [--check]");
 }
 
 std::string option_value(const std::string &argument, const std::string &name)

--- a/src/json_convert.cpp
+++ b/src/json_convert.cpp
@@ -1,4 +1,5 @@
 #include "json_duplet_converter.h"
+#include "nlohmann/json.hpp"
 
 #include <fstream>
 #include <iostream>
@@ -7,6 +8,8 @@
 
 namespace
 {
+
+using Json = nlohmann::ordered_json;
 
 struct Options
 {
@@ -106,11 +109,11 @@ Options parse_options(int argc, char **argv)
 	return options;
 }
 
-avm::json_duplet::Json read_json(const std::string &path)
+Json read_json(const std::string &path)
 {
 	if (path == "-")
 	{
-		avm::json_duplet::Json value;
+		Json value;
 		std::cin >> value;
 		return value;
 	}
@@ -119,12 +122,12 @@ avm::json_duplet::Json read_json(const std::string &path)
 	if (!input)
 		throw std::runtime_error("cannot open input file: " + path);
 
-	avm::json_duplet::Json value;
+	Json value;
 	input >> value;
 	return value;
 }
 
-void write_json(const std::string &path, const avm::json_duplet::Json &value)
+void write_json(const std::string &path, const Json &value)
 {
 	if (path == "-")
 	{
@@ -147,9 +150,9 @@ int main(int argc, char **argv)
 	try
 	{
 		const Options options = parse_options(argc, argv);
-		const avm::json_duplet::Json input = read_json(options.input);
+		const Json input = read_json(options.input);
 
-		avm::json_duplet::Json output;
+		Json output;
 		if (options.from == "jsonrvm-triplet")
 			output = avm::json_duplet::convert_explicit_triplets_to_duplets(input);
 		else

--- a/src/json_convert.cpp
+++ b/src/json_convert.cpp
@@ -11,6 +11,9 @@ namespace
 
 using Json = nlohmann::ordered_json;
 
+constexpr const char *converter_usage =
+    "\nusage: avm-json-convert --from=jsonrvm-triplet --to=avm-duplet [input|-] [-o output|-] [--check]";
+
 struct Options
 {
 	std::string from;
@@ -22,9 +25,7 @@ struct Options
 
 [[noreturn]] void usage_error(const std::string &message)
 {
-	throw std::invalid_argument(
-	    message + "\nusage: avm-json-convert --from=jsonrvm-triplet --to=avm-duplet [input|-] "
-	              "[-o output|-] [--check]");
+	throw std::invalid_argument(message + converter_usage);
 }
 
 std::string option_value(const std::string &argument, const std::string &name)

--- a/test/json_duplet_converter_test.cpp
+++ b/test/json_duplet_converter_test.cpp
@@ -53,8 +53,10 @@ int main()
 	assert(converted.at(">>").at("<<") == "S");
 	assert(converted.at(">>").at(">>") == "O");
 
-	const Json nested =
-	    relation(relation("RR", "RS", "RO"), relation("SR", "SS", "SO"), relation("OR", "OS", "OO"));
+	const Json nested_relation = relation("RR", "RS", "RO");
+	const Json nested_subject = relation("SR", "SS", "SO");
+	const Json nested_object = relation("OR", "OS", "OO");
+	const Json nested = relation(nested_relation, nested_subject, nested_object);
 	const Json nested_converted = avm::json_duplet::convert_explicit_triplets_to_duplets(nested);
 	assert(nested_converted.at("<<") == duplet("RR", duplet("RS", "RO")));
 	assert(nested_converted.at(">>").at("<<") == duplet("SR", duplet("SS", "SO")));

--- a/test/json_duplet_converter_test.cpp
+++ b/test/json_duplet_converter_test.cpp
@@ -1,4 +1,5 @@
 #include "json_duplet_converter.h"
+#include "nlohmann/json.hpp"
 
 #include <cassert>
 #include <string>
@@ -6,7 +7,7 @@
 namespace
 {
 
-using Json = avm::json_duplet::Json;
+using Json = nlohmann::ordered_json;
 
 bool conversion_rejected(const Json &value, bool forward)
 {

--- a/test/json_duplet_converter_test.cpp
+++ b/test/json_duplet_converter_test.cpp
@@ -1,0 +1,111 @@
+#include "json_duplet_converter.h"
+
+#include <cassert>
+#include <string>
+
+namespace
+{
+
+using Json = avm::json_duplet::Json;
+
+bool conversion_rejected(const Json &value, bool forward)
+{
+	try
+	{
+		if (forward)
+			static_cast<void>(avm::json_duplet::convert_explicit_triplets_to_duplets(value));
+		else
+			static_cast<void>(avm::json_duplet::convert_relation_duplets_to_explicit_triplets(value));
+		return false;
+	}
+	catch (const avm::json_duplet::ConversionError &)
+	{
+		return true;
+	}
+}
+
+Json relation(Json relation_value, Json subject_value, Json object_value)
+{
+	Json result = Json::object();
+	result["$rel"] = std::move(relation_value);
+	result["$sub"] = std::move(subject_value);
+	result["$obj"] = std::move(object_value);
+	return result;
+}
+
+Json duplet(Json begin, Json end)
+{
+	Json result = Json::object();
+	result["<<"] = std::move(begin);
+	result[">>"] = std::move(end);
+	return result;
+}
+
+} // namespace
+
+int main()
+{
+	const Json explicit_relation = relation("R", "S", "O");
+	const Json expected_relation = duplet("R", duplet("S", "O"));
+	const Json converted = avm::json_duplet::convert_explicit_triplets_to_duplets(explicit_relation);
+	assert(converted == expected_relation);
+	assert(converted.at(">>").at("<<") == "S");
+	assert(converted.at(">>").at(">>") == "O");
+
+	const Json nested = relation(relation("RR", "RS", "RO"), relation("SR", "SS", "SO"),
+	                             relation("OR", "OS", "OO"));
+	const Json nested_converted = avm::json_duplet::convert_explicit_triplets_to_duplets(nested);
+	assert(nested_converted.at("<<") == duplet("RR", duplet("RS", "RO")));
+	assert(nested_converted.at(">>").at("<<") == duplet("SR", duplet("SS", "SO")));
+	assert(nested_converted.at(">>").at(">>") == duplet("OR", duplet("OS", "OO")));
+
+	Json container = Json::object();
+	container["name"] = "demo";
+	container["items"] = Json::array({explicit_relation, 7, relation("X", "Y", "Z")});
+	const Json container_converted = avm::json_duplet::convert_explicit_triplets_to_duplets(container);
+	assert(container_converted.at("name") == "demo");
+	assert(container_converted.at("items")[0] == expected_relation);
+	assert(container_converted.at("items")[1] == 7);
+	assert(container_converted.at("items")[2] == duplet("X", duplet("Y", "Z")));
+
+	Json missing_subject = Json::object();
+	missing_subject["$rel"] = "+";
+	missing_subject["$obj"] = 1;
+	assert(conversion_rejected(missing_subject, true));
+
+	Json missing_object = Json::object();
+	missing_object["$rel"] = "+";
+	missing_object["$sub"] = 1;
+	assert(conversion_rejected(missing_object, true));
+
+	Json mixed_relation = explicit_relation;
+	mixed_relation["extra"] = true;
+	assert(conversion_rejected(mixed_relation, true));
+
+	const Json restored = avm::json_duplet::convert_relation_duplets_to_explicit_triplets(converted);
+	assert(restored == explicit_relation);
+
+	const Json nested_restored = avm::json_duplet::convert_relation_duplets_to_explicit_triplets(nested_converted);
+	assert(nested_restored == nested);
+
+	Json malformed_begin = Json::object();
+	malformed_begin["<<"] = "A";
+	assert(conversion_rejected(malformed_begin, false));
+
+	Json malformed_end = Json::object();
+	malformed_end[">>"] = "B";
+	assert(conversion_rejected(malformed_end, false));
+
+	Json mixed_duplet = duplet("A", duplet("B", "C"));
+	mixed_duplet["extra"] = 1;
+	assert(conversion_rejected(mixed_duplet, false));
+
+	const Json standalone_duplet = duplet("A", "B");
+	assert(conversion_rejected(standalone_duplet, false));
+
+	const Json scalar = 42;
+	assert(avm::json_duplet::convert_explicit_triplets_to_duplets(scalar) == scalar);
+	assert(avm::json_duplet::convert_relation_duplets_to_explicit_triplets(scalar) == scalar);
+
+	return 0;
+}

--- a/test/json_duplet_converter_test.cpp
+++ b/test/json_duplet_converter_test.cpp
@@ -53,8 +53,8 @@ int main()
 	assert(converted.at(">>").at("<<") == "S");
 	assert(converted.at(">>").at(">>") == "O");
 
-	const Json nested = relation(relation("RR", "RS", "RO"), relation("SR", "SS", "SO"),
-	                             relation("OR", "OS", "OO"));
+	const Json nested =
+	    relation(relation("RR", "RS", "RO"), relation("SR", "SS", "SO"), relation("OR", "OS", "OO"));
 	const Json nested_converted = avm::json_duplet::convert_explicit_triplets_to_duplets(nested);
 	assert(nested_converted.at("<<") == duplet("RR", duplet("RS", "RO")));
 	assert(nested_converted.at(">>").at("<<") == duplet("SR", duplet("SS", "SO")));


### PR DESCRIPTION
Closes #170. Closes #171. Part of #169/#130.

## Что делает PR

### ADR Native JSON

- фиксирует `duplet-json/1` как native AVM JSON protocol;
- единственная structural primitive: `{"<<": begin, ">>": end}`;
- RelationEntity нормативно `Link(relation, Link(subject, object))`;
- явно запрещает историческую swapped форму `(rel,(obj,sub))` из jsonRVM#10;
- versioned envelope `$avm=duplet-json/1` + `$root`;
- raw leaf boundary и минимальный existing-anchor spelling `{"$link": N}`;
- parser/find/realize разделены;
- JSON occurrence identity не является Link identity;
- jsonRVM сохраняет старый `$rel/$sub/$obj` protocol без изменений.

### Structural converter

Добавлен отдельный adapter `adapters/json_duplet_converter.h` без LinkStore/Executor dependencies.

Forward supported subset:

```text
{"$rel":R,"$sub":S,"$obj":O}
 -> {"<<":R,">>":{"<<":S,">>":O}}
```

Inverse поддерживается для relation-shaped subset как round-trip oracle.

Strict converter:

- рекурсивно обходит arrays/ordinary objects;
- сохраняет leaves;
- отвергает incomplete `$rel/$sub/$obj`;
- отвергает mixed relation metadata + foreign members;
- отвергает malformed/incomplete duplets;
- не исполняет jsonRVM semantics и не знает LinkStore.

### CLI / Windows

- новый target `avm_json_convert`, output `avm-json-convert[.exe]`;
- обычный `build.bat` собирает его по default CMake options;
- `convert_json.bat` из корня при необходимости дособирает target и запускает converter;
- CLI поддерживает stdin/stdout, file paths, `--check`.

Примеры:

```text
convert_json.bat --from=jsonrvm-triplet --to=avm-duplet old.json -o new.json
convert_json.bat --from=avm-duplet --to=jsonrvm-explicit-triplet new.json -o restored.json
convert_json.bat --from=jsonrvm-triplet --to=avm-duplet old.json --check
```

## Conformance

`json_duplet_converter_test` проверяет:

- order sentinel `R/S/O -> R/(S,O)`;
- nested relations во всех трёх slots;
- arrays/ordinary objects;
- incomplete/mixed legacy forms;
- malformed duplets;
- standalone pair rejection в inverse mode;
- forward/inverse round-trip.

## Veto

PR не меняет jsonRVM и не расширяет `JsonCompatibilitySession`. Native duplet JSON остаётся отдельным frontend protocol.