### PR TITLE
AVM Native JSON: project duplet-json/1 into ProjectionDescription

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,12 @@ if(AVM_BUILD_CORE_TESTS)
     avm_enable_test_assertions(avm_json_duplet_converter_test)
     add_test(NAME json_duplet_converter_tests COMMAND avm_json_duplet_converter_test)
 
+    add_executable(avm_json_duplet_projection_test "${CMAKE_CURRENT_SOURCE_DIR}/test/json_duplet_projection_test.cpp")
+    avm_add_json_adapter_includes(avm_json_duplet_projection_test)
+    avm_apply_quality(avm_json_duplet_projection_test)
+    avm_enable_test_assertions(avm_json_duplet_projection_test)
+    add_test(NAME json_duplet_projection_tests COMMAND avm_json_duplet_projection_test)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -277,7 +283,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_persistent_inspection_session_test
         avm_vertical_slice_test
         avm_json_value_codec_test
-        avm_json_duplet_converter_test)
+        avm_json_duplet_converter_test
+        avm_json_duplet_projection_test)
 endif()
 
 if(AVM_BUILD_ANUM_ADAPTER_TESTS)

--- a/adapters/json_duplet_projection.h
+++ b/adapters/json_duplet_projection.h
@@ -1,0 +1,116 @@
+#pragma once
+
+#include "avm/projection.h"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace avm::json_duplet
+{
+
+class ProjectionError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+namespace detail
+{
+
+inline std::string projection_object_path(const std::string &path, const std::string &key)
+{
+	return path + "." + key;
+}
+
+template <typename Json> LinkId decode_link_anchor(const Json &value, const std::string &path)
+{
+	if (!value.is_object() || !value.contains("$link") || value.size() != 1)
+		throw ProjectionError(path + ": unsupported duplet JSON leaf; expected exact {$link: N} anchor");
+
+	const Json &encoded_id = value.at("$link");
+	std::uint64_t id = 0;
+	if (encoded_id.is_number_unsigned())
+	{
+		id = encoded_id.template get<std::uint64_t>();
+	}
+	else if (encoded_id.is_number_integer())
+	{
+		const std::int64_t signed_id = encoded_id.template get<std::int64_t>();
+		if (signed_id <= 0)
+			throw ProjectionError(path + ".$link: LinkId must be a positive integer");
+		id = static_cast<std::uint64_t>(signed_id);
+	}
+	else
+	{
+		throw ProjectionError(path + ".$link: LinkId must be an integer");
+	}
+
+	if (id == invalid_link_id)
+		throw ProjectionError(path + ".$link: invalid LinkId 0 is not allowed");
+	return static_cast<LinkId>(id);
+}
+
+template <typename Json> class ProjectionBuilder
+{
+public:
+	ProjectionDescription build_term(const Json &term)
+	{
+		ProjectionDescription description;
+		description_ = &description;
+		description.root = project_term(term, "$ ");
+		description_ = nullptr;
+		return description;
+	}
+
+private:
+	ProjectionRef project_term(const Json &term, const std::string &path)
+	{
+		if (!term.is_object())
+			throw ProjectionError(path + ": unsupported duplet JSON leaf; expected pair or {$link: N}");
+
+		const bool has_begin = term.contains("<<");
+		const bool has_end = term.contains(">>");
+		if (has_begin || has_end)
+		{
+			if (!has_begin || !has_end)
+				throw ProjectionError(path + ": malformed duplet: fields << and >> must appear together");
+			if (term.size() != 2)
+				throw ProjectionError(path + ": malformed duplet: foreign members are not allowed");
+
+			const ProjectionRef begin = project_term(term.at("<<"), projection_object_path(path, "<<"));
+			const ProjectionRef end = project_term(term.at(">>"), projection_object_path(path, ">>"));
+			const ProjectionNodeId node_id = description_->nodes.size();
+			description_->nodes.push_back(ProjectionNode{begin, end});
+			return ProjectionRef::node(node_id);
+		}
+
+		return ProjectionRef::anchor(decode_link_anchor(term, path));
+	}
+
+	ProjectionDescription *description_ = nullptr;
+};
+
+} // namespace detail
+
+template <typename Json> ProjectionDescription project_duplet_term(const Json &term)
+{
+	detail::ProjectionBuilder<Json> builder;
+	return builder.build_term(term);
+}
+
+template <typename Json> ProjectionDescription project_duplet_document(const Json &document)
+{
+	if (!document.is_object())
+		throw ProjectionError("$: duplet-json/1 document must be an object");
+	if (!document.contains("$avm") || !document.contains("$root") || document.size() != 2)
+		throw ProjectionError("$: duplet-json/1 document must contain exactly $avm and $root");
+
+	const Json &version = document.at("$avm");
+	if (!version.is_string() || version.template get<std::string>() != "duplet-json/1")
+		throw ProjectionError("$.$avm: expected version marker duplet-json/1");
+
+	return project_duplet_term(document.at("$root"));
+}
+
+} // namespace avm::json_duplet

--- a/adapters/json_duplet_projection.h
+++ b/adapters/json_duplet_projection.h
@@ -56,11 +56,9 @@ template <typename Json> class ProjectionBuilder
 public:
 	ProjectionDescription build_term(const Json &term)
 	{
-		ProjectionDescription description;
-		description_ = &description;
-		description.root = project_term(term, "$ ");
-		description_ = nullptr;
-		return description;
+		description_ = ProjectionDescription{};
+		description_.root = project_term(term, "$");
+		return description_;
 	}
 
 private:
@@ -80,15 +78,15 @@ private:
 
 			const ProjectionRef begin = project_term(term.at("<<"), projection_object_path(path, "<<"));
 			const ProjectionRef end = project_term(term.at(">>"), projection_object_path(path, ">>"));
-			const ProjectionNodeId node_id = description_->nodes.size();
-			description_->nodes.push_back(ProjectionNode{begin, end});
+			const ProjectionNodeId node_id = description_.nodes.size();
+			description_.nodes.push_back(ProjectionNode{begin, end});
 			return ProjectionRef::node(node_id);
 		}
 
 		return ProjectionRef::anchor(decode_link_anchor(term, path));
 	}
 
-	ProjectionDescription *description_ = nullptr;
+	ProjectionDescription description_{};
 };
 
 } // namespace detail

--- a/test/json_duplet_projection_test.cpp
+++ b/test/json_duplet_projection_test.cpp
@@ -1,0 +1,199 @@
+#include "json_duplet_projection.h"
+
+#include "avm/persistent_link_store.h"
+#include "avm/relations_model.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <filesystem>
+#include <stdexcept>
+
+namespace
+{
+
+using Json = nlohmann::ordered_json;
+
+Json anchor(avm::LinkId id)
+{
+	Json value = Json::object();
+	value["$link"] = id;
+	return value;
+}
+
+Json duplet(Json begin, Json end)
+{
+	Json value = Json::object();
+	value["<<"] = std::move(begin);
+	value[">>"] = std::move(end);
+	return value;
+}
+
+Json relation_term(avm::LinkId relation, avm::LinkId subject, avm::LinkId object)
+{
+	return duplet(anchor(relation), duplet(anchor(subject), anchor(object)));
+}
+
+Json document(Json root)
+{
+	Json value = Json::object();
+	value["$avm"] = "duplet-json/1";
+	value["$root"] = std::move(root);
+	return value;
+}
+
+bool projection_rejected(const Json &value, bool as_document = false)
+{
+	try
+	{
+		if (as_document)
+			static_cast<void>(avm::json_duplet::project_duplet_document(value));
+		else
+			static_cast<void>(avm::json_duplet::project_duplet_term(value));
+		return false;
+	}
+	catch (const avm::json_duplet::ProjectionError &)
+	{
+		return true;
+	}
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+
+	const Json term = relation_term(relation, subject, object);
+	const avm::ProjectionDescription description = avm::json_duplet::project_duplet_term(term);
+	assert(description.nodes.size() == 2);
+	assert(description.nodes[0] ==
+	       avm::ProjectionNode{avm::ProjectionRef::anchor(subject), avm::ProjectionRef::anchor(object)});
+	assert(description.nodes[1] ==
+	       avm::ProjectionNode{avm::ProjectionRef::anchor(relation), avm::ProjectionRef::node(0)});
+	assert(description.root == avm::ProjectionRef::node(1));
+
+	const std::size_t before_find = store.size();
+	assert(!avm::find_projection(store, description).has_value());
+	assert(store.size() == before_find);
+
+	const avm::ProjectionResult realized = avm::realize_projection(store, description);
+	assert(realized.nodes.size() == 2);
+	assert(realized.root == realized.nodes[1]);
+	const avm::RelationEntity decoded = avm::decode_relation_entity(store, realized.root);
+	assert(decoded == avm::RelationEntity{relation, subject, object});
+
+	const std::size_t before_repeat = store.size();
+	const avm::ProjectionResult repeated = avm::realize_projection(store, description);
+	assert(repeated.root == realized.root);
+	assert(repeated.nodes == realized.nodes);
+	assert(store.size() == before_repeat);
+
+	const auto found = avm::find_projection(store, description);
+	assert(found.has_value());
+	assert(found->root == realized.root);
+
+	const avm::ProjectionDescription documented = avm::json_duplet::project_duplet_document(document(term));
+	assert(documented.nodes == description.nodes);
+	assert(documented.root == description.root);
+
+	const avm::ProjectionDescription anchor_only = avm::json_duplet::project_duplet_term(anchor(subject));
+	assert(anchor_only.nodes.empty());
+	assert(anchor_only.root == avm::ProjectionRef::anchor(subject));
+	assert(avm::find_projection(store, anchor_only)->root == subject);
+
+	const avm::LinkId missing_id = store.size() + 1000;
+	const Json missing_term = duplet(anchor(relation), anchor(missing_id));
+	const avm::ProjectionDescription missing_description = avm::json_duplet::project_duplet_term(missing_term);
+	const std::size_t before_missing_find = store.size();
+	assert(!avm::find_projection(store, missing_description).has_value());
+	assert(store.size() == before_missing_find);
+
+	bool missing_realize_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, missing_description));
+	}
+	catch (const std::invalid_argument &)
+	{
+		missing_realize_rejected = true;
+	}
+	assert(missing_realize_rejected);
+	assert(store.size() == before_missing_find);
+
+	Json incomplete_pair = Json::object();
+	incomplete_pair["<<"] = anchor(relation);
+	assert(projection_rejected(incomplete_pair));
+
+	Json mixed_pair = duplet(anchor(relation), anchor(subject));
+	mixed_pair["extra"] = true;
+	assert(projection_rejected(mixed_pair));
+
+	Json zero_anchor = Json::object();
+	zero_anchor["$link"] = 0;
+	assert(projection_rejected(zero_anchor));
+
+	Json negative_anchor = Json::object();
+	negative_anchor["$link"] = -1;
+	assert(projection_rejected(negative_anchor));
+
+	Json text_anchor = Json::object();
+	text_anchor["$link"] = "1";
+	assert(projection_rejected(text_anchor));
+
+	Json mixed_anchor = anchor(relation);
+	mixed_anchor["extra"] = true;
+	assert(projection_rejected(mixed_anchor));
+
+	Json unknown_leaf = Json::object();
+	unknown_leaf["$symbol"] = "R";
+	assert(projection_rejected(unknown_leaf));
+	assert(projection_rejected(Json::array({anchor(relation)})));
+	assert(projection_rejected(Json(7)));
+	assert(projection_rejected(Json("R")));
+
+	Json bad_document = document(term);
+	bad_document["$avm"] = "duplet-json/2";
+	assert(projection_rejected(bad_document, true));
+
+	Json extra_document = document(term);
+	extra_document["extra"] = true;
+	assert(projection_rejected(extra_document, true));
+
+	const std::filesystem::path persistent_path =
+	    std::filesystem::temp_directory_path() / "avm_duplet_json_projection_test.links";
+	std::filesystem::remove(persistent_path);
+
+	avm::LinkId persistent_relation = avm::invalid_link_id;
+	avm::LinkId persistent_subject = avm::invalid_link_id;
+	avm::LinkId persistent_object = avm::invalid_link_id;
+	avm::LinkId persistent_root = avm::invalid_link_id;
+	Json persistent_document;
+	{
+		avm::PersistentLinkStore persistent_store(persistent_path);
+		persistent_relation = persistent_store.create_point();
+		persistent_subject = persistent_store.create_point();
+		persistent_object = persistent_store.create_point();
+		persistent_document = document(relation_term(persistent_relation, persistent_subject, persistent_object));
+		const avm::ProjectionDescription persistent_description =
+		    avm::json_duplet::project_duplet_document(persistent_document);
+		persistent_root = avm::realize_projection(persistent_store, persistent_description).root;
+	}
+	{
+		avm::PersistentLinkStore reopened(persistent_path);
+		const avm::ProjectionDescription persistent_description =
+		    avm::json_duplet::project_duplet_document(persistent_document);
+		const auto persistent_found = avm::find_projection(reopened, persistent_description);
+		assert(persistent_found.has_value());
+		assert(persistent_found->root == persistent_root);
+		assert(avm::decode_relation_entity(reopened, persistent_root) ==
+		       avm::RelationEntity{persistent_relation, persistent_subject, persistent_object});
+	}
+	std::filesystem::remove(persistent_path);
+
+	return 0;
+}

--- a/test/json_duplet_projection_test.cpp
+++ b/test/json_duplet_projection_test.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <stdexcept>
+#include <utility>
 
 namespace
 {
@@ -71,10 +72,16 @@ int main()
 	const Json term = relation_term(relation, subject, object);
 	const avm::ProjectionDescription description = avm::json_duplet::project_duplet_term(term);
 	assert(description.nodes.size() == 2);
-	assert(description.nodes[0] ==
-	       avm::ProjectionNode{avm::ProjectionRef::anchor(subject), avm::ProjectionRef::anchor(object)});
-	assert(description.nodes[1] ==
-	       avm::ProjectionNode{avm::ProjectionRef::anchor(relation), avm::ProjectionRef::node(0)});
+	const avm::ProjectionNode expected_arguments{
+	    avm::ProjectionRef::anchor(subject),
+	    avm::ProjectionRef::anchor(object),
+	};
+	const avm::ProjectionNode expected_entity{
+	    avm::ProjectionRef::anchor(relation),
+	    avm::ProjectionRef::node(0),
+	};
+	assert(description.nodes[0] == expected_arguments);
+	assert(description.nodes[1] == expected_entity);
 	assert(description.root == avm::ProjectionRef::node(1));
 
 	const std::size_t before_find = store.size();
@@ -85,7 +92,8 @@ int main()
 	assert(realized.nodes.size() == 2);
 	assert(realized.root == realized.nodes[1]);
 	const avm::RelationEntity decoded = avm::decode_relation_entity(store, realized.root);
-	assert(decoded == avm::RelationEntity{relation, subject, object});
+	const avm::RelationEntity expected_relation{relation, subject, object};
+	assert(decoded == expected_relation);
 
 	const std::size_t before_repeat = store.size();
 	const avm::ProjectionResult repeated = avm::realize_projection(store, description);
@@ -190,8 +198,9 @@ int main()
 		const auto persistent_found = avm::find_projection(reopened, persistent_description);
 		assert(persistent_found.has_value());
 		assert(persistent_found->root == persistent_root);
-		assert(avm::decode_relation_entity(reopened, persistent_root) ==
-		       avm::RelationEntity{persistent_relation, persistent_subject, persistent_object});
+		const avm::RelationEntity persistent_decoded = avm::decode_relation_entity(reopened, persistent_root);
+		const avm::RelationEntity persistent_expected{persistent_relation, persistent_subject, persistent_object};
+		assert(persistent_decoded == persistent_expected);
 	}
 	std::filesystem::remove(persistent_path);
 


### PR DESCRIPTION
Part of #172 / #169 / #130.

## Что реализовано

Добавлен `adapters/json_duplet_projection.h` — DOM-generic native AVM JSON projector.

Поддерживаемый raw v1 subset:

```json
{"<<": <term>, ">>": <term>}
```

и единственный стандартный leaf первой версии:

```json
{"$link": 42}
```

Versioned document:

```json
{"$avm":"duplet-json/1","$root":<term>}
```

## Архитектурная граница

Projector:

- не принимает `LinkStore`;
- не знает `Executor`;
- не вызывает `find/intern/create_point`;
- строит только `ProjectionDescription` post-order;
- exact pair требует ровно `<<` + `>>`;
- unknown/scalar/array leaves пока детерминированно отвергаются;
- `$symbol` / `$integer` / text/value semantics остаются #173.

После projector caller отдельно выбирает:

```text
find_projection
или
realize_projection
```

## Conformance

Новый `json_duplet_projection_test` проверяет:

- distinct R/S/O -> exact `ProjectionNode(S,O)` затем `ProjectionNode(R,node0)`;
- `find` miss не меняет store;
- `realize` создаёт canonical `Link(R, Link(S,O))`;
- `decode_relation_entity` возвращает исходные relation/subject/object;
- repeat realize idempotent;
- versioned document и bare term equivalent;
- anchor-only root;
- missing anchor: find miss, realize fail до mutation;
- malformed pair, invalid/mixed/unknown leaves, bad envelope;
- persistent close/reopen сохраняет canonical root.

## Не входит в этот PR

Raw-text duplicate-key detection (`<<`, `>>`, `$avm`, `$root`) требует file/CLI parser boundary и остаётся частью завершения #172/#175. Поэтому PR пока не закрывает #172 целиком.