### PR TITLE
AVM Native JSON: добавить явный resolver символов и canonical Integer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,6 +258,12 @@ if(AVM_BUILD_CORE_TESTS)
     avm_enable_test_assertions(avm_json_duplet_projection_test)
     add_test(NAME json_duplet_projection_tests COMMAND avm_json_duplet_projection_test)
 
+    add_executable(avm_json_duplet_values_test "${CMAKE_CURRENT_SOURCE_DIR}/test/json_duplet_values_test.cpp")
+    avm_add_json_adapter_includes(avm_json_duplet_values_test)
+    avm_apply_quality(avm_json_duplet_values_test)
+    avm_enable_test_assertions(avm_json_duplet_values_test)
+    add_test(NAME json_duplet_values_tests COMMAND avm_json_duplet_values_test)
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -287,7 +293,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_vertical_slice_test
         avm_json_value_codec_test
         avm_json_duplet_converter_test
-        avm_json_duplet_projection_test)
+        avm_json_duplet_projection_test
+        avm_json_duplet_values_test)
 endif()
 
 if(AVM_BUILD_ANUM_ADAPTER_TESTS)

--- a/adapters/json_duplet_projection.h
+++ b/adapters/json_duplet_projection.h
@@ -51,9 +51,20 @@ template <typename Json> LinkId decode_link_anchor(const Json &value, const std:
 	return static_cast<LinkId>(id);
 }
 
-template <typename Json> class ProjectionBuilder
+struct LinkAnchorResolver
+{
+	template <typename Json>
+	ProjectionRef operator()(const Json &value, ProjectionDescription &, const std::string &path) const
+	{
+		return ProjectionRef::anchor(decode_link_anchor(value, path));
+	}
+};
+
+template <typename Json, typename LeafResolver> class ProjectionBuilder
 {
 public:
+	explicit ProjectionBuilder(const LeafResolver &leaf_resolver) : leaf_resolver_(leaf_resolver) {}
+
 	ProjectionDescription build_term(const Json &term)
 	{
 		description_ = ProjectionDescription{};
@@ -64,40 +75,49 @@ public:
 private:
 	ProjectionRef project_term(const Json &term, const std::string &path)
 	{
-		if (!term.is_object())
-			throw ProjectionError(path + ": unsupported duplet JSON leaf; expected pair or {$link: N}");
-
-		const bool has_begin = term.contains("<<");
-		const bool has_end = term.contains(">>");
-		if (has_begin || has_end)
+		if (term.is_object())
 		{
-			if (!has_begin || !has_end)
-				throw ProjectionError(path + ": malformed duplet: fields << and >> must appear together");
-			if (term.size() != 2)
-				throw ProjectionError(path + ": malformed duplet: foreign members are not allowed");
+			const bool has_begin = term.contains("<<");
+			const bool has_end = term.contains(">>");
+			if (has_begin || has_end)
+			{
+				if (!has_begin || !has_end)
+					throw ProjectionError(path + ": malformed duplet: fields << and >> must appear together");
+				if (term.size() != 2)
+					throw ProjectionError(path + ": malformed duplet: foreign members are not allowed");
 
-			const ProjectionRef begin = project_term(term.at("<<"), projection_object_path(path, "<<"));
-			const ProjectionRef end = project_term(term.at(">>"), projection_object_path(path, ">>"));
-			const ProjectionNodeId node_id = description_.nodes.size();
-			description_.nodes.push_back(ProjectionNode{begin, end});
-			return ProjectionRef::node(node_id);
+				const ProjectionRef begin = project_term(term.at("<<"), projection_object_path(path, "<<"));
+				const ProjectionRef end = project_term(term.at(">>"), projection_object_path(path, ">>"));
+				const ProjectionNodeId node_id = description_.nodes.size();
+				description_.nodes.push_back(ProjectionNode{begin, end});
+				return ProjectionRef::node(node_id);
+			}
 		}
 
-		return ProjectionRef::anchor(decode_link_anchor(term, path));
+		return leaf_resolver_(term, description_, path);
 	}
 
+	const LeafResolver &leaf_resolver_;
 	ProjectionDescription description_{};
 };
 
 } // namespace detail
 
-template <typename Json> ProjectionDescription project_duplet_term(const Json &term)
+template <typename Json, typename LeafResolver>
+ProjectionDescription project_duplet_term(const Json &term, const LeafResolver &leaf_resolver)
 {
-	detail::ProjectionBuilder<Json> builder;
+	detail::ProjectionBuilder<Json, LeafResolver> builder(leaf_resolver);
 	return builder.build_term(term);
 }
 
-template <typename Json> ProjectionDescription project_duplet_document(const Json &document)
+template <typename Json> ProjectionDescription project_duplet_term(const Json &term)
+{
+	const detail::LinkAnchorResolver resolver;
+	return project_duplet_term(term, resolver);
+}
+
+template <typename Json, typename LeafResolver>
+ProjectionDescription project_duplet_document(const Json &document, const LeafResolver &leaf_resolver)
 {
 	if (!document.is_object())
 		throw ProjectionError("$: duplet-json/1 document must be an object");
@@ -108,7 +128,13 @@ template <typename Json> ProjectionDescription project_duplet_document(const Jso
 	if (!version.is_string() || version.template get<std::string>() != "duplet-json/1")
 		throw ProjectionError("$.$avm: expected version marker duplet-json/1");
 
-	return project_duplet_term(document.at("$root"));
+	return project_duplet_term(document.at("$root"), leaf_resolver);
+}
+
+template <typename Json> ProjectionDescription project_duplet_document(const Json &document)
+{
+	const detail::LinkAnchorResolver resolver;
+	return project_duplet_document(document, resolver);
 }
 
 } // namespace avm::json_duplet

--- a/adapters/json_duplet_text.h
+++ b/adapters/json_duplet_text.h
@@ -58,9 +58,21 @@ template <typename Json> Json parse_unique_json(std::string_view text)
 
 } // namespace detail
 
+template <typename Json, typename LeafResolver>
+ProjectionDescription project_duplet_term_text(std::string_view text, const LeafResolver &leaf_resolver)
+{
+	return project_duplet_term(detail::parse_unique_json<Json>(text), leaf_resolver);
+}
+
 template <typename Json> ProjectionDescription project_duplet_term_text(std::string_view text)
 {
 	return project_duplet_term(detail::parse_unique_json<Json>(text));
+}
+
+template <typename Json, typename LeafResolver>
+ProjectionDescription project_duplet_document_text(std::string_view text, const LeafResolver &leaf_resolver)
+{
+	return project_duplet_document(detail::parse_unique_json<Json>(text), leaf_resolver);
 }
 
 template <typename Json> ProjectionDescription project_duplet_document_text(std::string_view text)

--- a/adapters/json_duplet_values.h
+++ b/adapters/json_duplet_values.h
@@ -8,6 +8,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <vector>
 
 namespace avm::json_duplet
 {

--- a/adapters/json_duplet_values.h
+++ b/adapters/json_duplet_values.h
@@ -40,7 +40,10 @@ inline ProjectionRef append_integer_projection(ProjectionDescription &descriptio
 class NativeLeafResolver
 {
 public:
-	NativeLeafResolver(IntegerVocabulary integers, const SymbolAnchors &symbols) : integers_(integers), symbols_(symbols) {}
+	NativeLeafResolver(IntegerVocabulary integers, const SymbolAnchors &symbols)
+	    : integers_(integers), symbols_(symbols)
+	{
+	}
 
 	template <typename Json>
 	ProjectionRef operator()(const Json &value, ProjectionDescription &description, const std::string &path) const

--- a/adapters/json_duplet_values.h
+++ b/adapters/json_duplet_values.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include "json_duplet_projection.h"
+
+#include "avm/integer_value.h"
+
+#include <cstdint>
+#include <limits>
+#include <map>
+#include <string>
+
+namespace avm::json_duplet
+{
+
+using SymbolAnchors = std::map<std::string, LinkId>;
+
+inline ProjectionRef append_integer_projection(ProjectionDescription &description, const IntegerVocabulary &vocabulary,
+                                               std::int64_t value)
+{
+	if (value == 0)
+		return ProjectionRef::anchor(vocabulary.zero);
+
+	const std::vector<bool> bits = integer_magnitude_bits(integer_unsigned_magnitude(value));
+	ProjectionRef suffix = ProjectionRef::anchor(vocabulary.magnitude_end);
+	for (auto bit = bits.rbegin(); bit != bits.rend(); ++bit)
+	{
+		const LinkId marker = *bit ? vocabulary.bit_one : vocabulary.bit_zero;
+		const ProjectionNodeId node_id = description.nodes.size();
+		description.nodes.push_back(ProjectionNode{ProjectionRef::anchor(marker), suffix});
+		suffix = ProjectionRef::node(node_id);
+	}
+
+	const LinkId sign = value < 0 ? vocabulary.negative : vocabulary.positive;
+	const ProjectionNodeId wrapper_id = description.nodes.size();
+	description.nodes.push_back(ProjectionNode{ProjectionRef::anchor(sign), suffix});
+	return ProjectionRef::node(wrapper_id);
+}
+
+class NativeLeafResolver
+{
+public:
+	NativeLeafResolver(IntegerVocabulary integers, const SymbolAnchors &symbols) : integers_(integers), symbols_(symbols) {}
+
+	template <typename Json>
+	ProjectionRef operator()(const Json &value, ProjectionDescription &description, const std::string &path) const
+	{
+		if (!value.is_object() || value.size() != 1)
+			throw ProjectionError(path + ": unsupported native AVM leaf; expected exactly one leaf marker");
+
+		if (value.contains("$link"))
+			return ProjectionRef::anchor(detail::decode_link_anchor(value, path));
+		if (value.contains("$symbol"))
+			return resolve_symbol(value, path);
+		if (value.contains("$integer"))
+			return resolve_integer(value, description, path);
+
+		throw ProjectionError(path + ": unsupported native AVM leaf marker");
+	}
+
+private:
+	template <typename Json> ProjectionRef resolve_symbol(const Json &value, const std::string &path) const
+	{
+		const Json &encoded_symbol = value.at("$symbol");
+		if (!encoded_symbol.is_string())
+			throw ProjectionError(path + ".$symbol: symbol name must be a string");
+
+		const std::string name = encoded_symbol.template get<std::string>();
+		const auto symbol = symbols_.find(name);
+		if (symbol == symbols_.end())
+			throw ProjectionError(path + ".$symbol: unknown symbol: " + name);
+		if (symbol->second == invalid_link_id)
+			throw ProjectionError(path + ".$symbol: symbol resolves to invalid LinkId 0");
+		return ProjectionRef::anchor(symbol->second);
+	}
+
+	template <typename Json>
+	ProjectionRef resolve_integer(const Json &value, ProjectionDescription &description, const std::string &path) const
+	{
+		const Json &encoded_integer = value.at("$integer");
+		std::int64_t integer = 0;
+		if (encoded_integer.is_number_unsigned())
+		{
+			const std::uint64_t unsigned_value = encoded_integer.template get<std::uint64_t>();
+			const std::uint64_t max = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+			if (unsigned_value > max)
+				throw ProjectionError(path + ".$integer: value exceeds int64 host projection domain");
+			integer = static_cast<std::int64_t>(unsigned_value);
+		}
+		else if (encoded_integer.is_number_integer())
+		{
+			integer = encoded_integer.template get<std::int64_t>();
+		}
+		else
+		{
+			throw ProjectionError(path + ".$integer: value must be an integer JSON number");
+		}
+
+		return append_integer_projection(description, integers_, integer);
+	}
+
+	IntegerVocabulary integers_;
+	const SymbolAnchors &symbols_;
+};
+
+} // namespace avm::json_duplet

--- a/docs/duplet-json-leaf-resolution.md
+++ b/docs/duplet-json-leaf-resolution.md
@@ -1,0 +1,204 @@
+# Разрешение листьев в нативном Duplet JSON AVM
+
+Родительские задачи: #169, #173. Связанные задачи: #128, #130.
+
+## Назначение
+
+`duplet-json/1` описывает структуру связей через пары `<<` / `>>`, но сама JSON-сериализация не определяет semantic identity листьев.
+
+Нормативная граница:
+
+```text
+JSON token
+ -> явный leaf resolver
+ -> ProjectionRef / ProjectionNode
+ -> find_projection | realize_projection
+ -> canonical LinkId
+```
+
+Parser пары не создаёт `LinkId`, не вызывает `create_point()` и не содержит скрытой таблицы `string -> identity`.
+
+## Грамматика листьев v1
+
+Первый нативный resolver поддерживает три явные формы:
+
+```text
+Leaf := LinkAnchor | SymbolAnchor | IntegerValue
+
+LinkAnchor := {"$link": positive_integer}
+SymbolAnchor := {"$symbol": string}
+IntegerValue := {"$integer": int64_json_integer}
+```
+
+Каждый объект-лист содержит **ровно один** marker. Raw JSON scalar сам по себе листом AVM не является.
+
+Следовательно, это недопустимо:
+
+```json
+"integer_add"
+```
+
+```json
+7
+```
+
+а это допустимо:
+
+```json
+{"$symbol":"integer_add"}
+```
+
+```json
+{"$integer":7}
+```
+
+## `$link`: существующая identity
+
+```json
+{"$link":42}
+```
+
+проецируется как:
+
+```text
+ProjectionRef::Anchor(42)
+```
+
+Resolver не проверяет наличие `42` в конкретном store и не создаёт её. Это остаётся обязанностью последующей операции:
+
+- `find_projection` возвращает miss без изменения store;
+- `realize_projection` отклоняет отсутствующий anchor до materialization.
+
+`0` запрещён как `invalid_link_id`.
+
+## `$symbol`: имя, принадлежащее вызывающему коду
+
+```json
+{"$symbol":"integer_add"}
+```
+
+разрешается только через явно переданный `SymbolAnchors`:
+
+```text
+"integer_add" -> IntegerVocabulary::add_relation
+"true"        -> BootstrapVocabulary::true_value
+"false"       -> BootstrapVocabulary::false_value
+"nil"         -> BootstrapVocabulary::nil
+```
+
+Таблица символов:
+
+- принадлежит caller/frontend configuration;
+- не хранится скрыто внутри `LinkStore`;
+- не создаёт identity для неизвестного имени;
+- может использовать разные spelling-и для одной и той же semantic identity;
+- не является частью core execution semantics.
+
+Неизвестный `$symbol` — deterministic projection error.
+
+Таким образом, строка является **именем ссылки на уже определённую identity**, а не источником новой identity.
+
+## `$integer`: canonical Integer projection
+
+```json
+{"$integer":7}
+```
+
+не превращается в JSON-tagged link и не хранится в host-side variant.
+
+Resolver строит обычный `ProjectionDescription`, эквивалентный canonical Integer denotation из `IntegerVocabulary`:
+
+```text
+$integer
+ -> sign / bit cells / magnitude_end
+ -> ProjectionDescription
+ -> find_projection | realize_projection
+ -> тот же LinkId, что find_integer / realize_integer
+```
+
+Это означает:
+
+- projection не меняет store;
+- `find_projection` не материализует число;
+- `realize_projection` использует обычный canonical `intern`;
+- повторная realization идемпотентна;
+- persistent reopen сохраняет identity и значение;
+- direct C++ API и Native JSON сходятся в одну структуру.
+
+Текущий canonical Integer contract ограничен `int64`, поэтому `$integer` принимает только целые JSON numbers в диапазоне `INT64_MIN..INT64_MAX`.
+
+## Boolean и nil
+
+`true`, `false` и `nil` уже имеют canonical identities в `BootstrapVocabulary`. Поэтому v1 не вводит отдельные JSON-tagged value classes для них.
+
+Их рекомендуется именовать через caller-owned symbols:
+
+```json
+{"$symbol":"true"}
+{"$symbol":"false"}
+{"$symbol":"nil"}
+```
+
+Это сохраняет единственную identity каждого значения и не создаёт второй Boolean universe внутри JSON frontend.
+
+## Пример: `7 + 3`
+
+```json
+{
+  "<<": {"$symbol":"integer_add"},
+  ">>": {
+    "<<": {"$integer":7},
+    ">>": {"$integer":3}
+  }
+}
+```
+
+После projection и explicit realization получается:
+
+```text
+Link(
+  IntegerVocabulary::add_relation,
+  Link(Integer(7), Integer(3))
+)
+```
+
+То есть ровно та же `RelationEntity`, которую создаёт direct link-native API:
+
+```text
+(relation, subject, object)
+ = (integer_add, Integer(7), Integer(3))
+```
+
+`Executor` не знает, что entity когда-либо была записана в JSON.
+
+## Text не входит в этот gate
+
+Форма вроде:
+
+```json
+{"$text":"hello"}
+```
+
+**не вводится**, пока #128 не зафиксирует canonical Text/byte-string denotation.
+
+Причина принципиальная: UTF-8/JSON serialization не должна автоматически становиться semantic identity. Сначала нужен frontend-neutral link encoding текста с отдельными `find/realize/decode` контрактами, затем `$text` сможет быть лишь projection adapter-ом к этой структуре.
+
+До этого любой `$text` должен отклоняться как неизвестный leaf marker.
+
+## Context/reference expressions
+
+Контекстные ссылки (`$ent/$rel/$sub/$obj`, path/reference semantics jsonRVM) также не являются простыми value leaves. Их перенос относится к #125/#126 и semantic migrator #174.
+
+Native JSON resolver не должен угадывать их по строкам.
+
+## Инварианты
+
+Для любого поддержанного листа обязательны:
+
+1. parse/project не меняет `LinkStore`;
+2. чтение и `find` не вызывают `intern`;
+3. materialization происходит только через явный `realize_projection`;
+4. одинаковое canonical значение сходится к одной structural identity;
+5. неизвестное имя не создаёт point;
+6. `Executor`, `LinkStore` и canonical value core не зависят от JSON syntax;
+7. persistent reopen сохраняет structural meaning.

--- a/docs/duplet-json-leaf-resolution.md
+++ b/docs/duplet-json-leaf-resolution.md
@@ -98,7 +98,7 @@ Resolver не проверяет наличие `42` в конкретном sto
 
 Таким образом, строка является **именем ссылки на уже определённую identity**, а не источником новой identity.
 
-## `$integer`: canonical Integer projection
+## `$integer`: каноническая проекция Integer
 
 ```json
 {"$integer":7}
@@ -185,7 +185,7 @@ Link(
 
 До этого любой `$text` должен отклоняться как неизвестный leaf marker.
 
-## Context/reference expressions
+## Контекстные ссылки и выражения
 
 Контекстные ссылки (`$ent/$rel/$sub/$obj`, path/reference semantics jsonRVM) также не являются простыми value leaves. Их перенос относится к #125/#126 и semantic migrator #174.
 

--- a/test/json_duplet_values_test.cpp
+++ b/test/json_duplet_values_test.cpp
@@ -1,0 +1,199 @@
+#include "json_duplet_text.h"
+#include "json_duplet_values.h"
+
+#include "avm/executor.h"
+#include "avm/integer_value.h"
+#include "avm/persistent_link_store.h"
+#include "avm/program_model.h"
+#include "avm/relations_model.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <filesystem>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+
+using Json = nlohmann::ordered_json;
+
+Json tagged(const char *name, Json value)
+{
+	Json result = Json::object();
+	result[name] = std::move(value);
+	return result;
+}
+
+Json pair(Json begin, Json end)
+{
+	Json result = Json::object();
+	result["<<"] = std::move(begin);
+	result[">>"] = std::move(end);
+	return result;
+}
+
+Json add_expression(std::int64_t left, std::int64_t right)
+{
+	return pair(tagged("$symbol", "integer_add"), pair(tagged("$integer", left), tagged("$integer", right)));
+}
+
+bool projection_rejected(const Json &value, const avm::json_duplet::NativeLeafResolver &resolver)
+{
+	try
+	{
+		static_cast<void>(avm::json_duplet::project_duplet_term(value, resolver));
+		return false;
+	}
+	catch (const avm::json_duplet::ProjectionError &)
+	{
+		return true;
+	}
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::BootstrapVocabulary bootstrap = avm::BootstrapVocabulary::create(store);
+	const avm::IntegerVocabulary integers = avm::IntegerVocabulary::create(store);
+	const avm::json_duplet::SymbolAnchors symbols{
+	    {"integer_add", integers.add_relation},
+	    {"nil", bootstrap.nil},
+	    {"false", bootstrap.false_value},
+	    {"true", bootstrap.true_value},
+	    {"unit", bootstrap.unit},
+	};
+	const avm::json_duplet::NativeLeafResolver resolver(integers, symbols);
+
+	const Json expression = add_expression(7, 3);
+	const std::size_t before_projection = store.size();
+	const avm::ProjectionDescription description = avm::json_duplet::project_duplet_term(expression, resolver);
+	assert(store.size() == before_projection);
+	assert(!avm::find_projection(store, description).has_value());
+	assert(store.size() == before_projection);
+
+	const avm::ProjectionResult realized = avm::realize_projection(store, description);
+	const auto seven = avm::find_integer(store, integers, 7);
+	const auto three = avm::find_integer(store, integers, 3);
+	assert(seven.has_value());
+	assert(three.has_value());
+	const avm::RelationEntity decoded = avm::decode_relation_entity(store, realized.root);
+	const avm::RelationEntity expected{integers.add_relation, *seven, *three};
+	assert(decoded == expected);
+
+	const std::size_t before_direct_encode = store.size();
+	assert(avm::encode_relation_entity(store, expected) == realized.root);
+	assert(store.size() == before_direct_encode);
+
+	avm::Executor executor(store);
+	avm::register_integer_arithmetic(executor, integers);
+	const avm::LinkId ten = executor.execute(realized.root);
+	assert(avm::decode_integer(store, integers, ten) == 10);
+
+	const std::string raw_expression =
+	    R"({"<<":{"$symbol":"integer_add"},">>":{"<<":{"$integer":7},">>":{"$integer":3}}})";
+	const std::size_t before_text_projection = store.size();
+	const avm::ProjectionDescription text_description =
+	    avm::json_duplet::project_duplet_term_text<Json>(raw_expression, resolver);
+	assert(text_description.nodes == description.nodes);
+	assert(text_description.root == description.root);
+	assert(store.size() == before_text_projection);
+	const auto text_found = avm::find_projection(store, text_description);
+	assert(text_found.has_value());
+	assert(text_found->root == realized.root);
+
+	const Json true_leaf = tagged("$symbol", "true");
+	const avm::ProjectionDescription true_description = avm::json_duplet::project_duplet_term(true_leaf, resolver);
+	assert(true_description.nodes.empty());
+	assert(true_description.root == avm::ProjectionRef::anchor(bootstrap.true_value));
+	assert(avm::find_projection(store, true_description)->root == bootstrap.true_value);
+
+	const Json false_leaf = tagged("$symbol", "false");
+	const avm::ProjectionDescription false_description = avm::json_duplet::project_duplet_term(false_leaf, resolver);
+	assert(false_description.root == avm::ProjectionRef::anchor(bootstrap.false_value));
+
+	const Json nil_leaf = tagged("$symbol", "nil");
+	const avm::ProjectionDescription nil_description = avm::json_duplet::project_duplet_term(nil_leaf, resolver);
+	assert(nil_description.root == avm::ProjectionRef::anchor(bootstrap.nil));
+
+	const Json zero_leaf = tagged("$integer", 0);
+	const avm::ProjectionDescription zero_description = avm::json_duplet::project_duplet_term(zero_leaf, resolver);
+	assert(zero_description.nodes.empty());
+	assert(zero_description.root == avm::ProjectionRef::anchor(integers.zero));
+	assert(avm::find_projection(store, zero_description)->root == integers.zero);
+
+	const Json negative_leaf = tagged("$integer", -7);
+	const avm::ProjectionDescription negative_description = avm::json_duplet::project_duplet_term(negative_leaf, resolver);
+	const avm::LinkId negative_root = avm::realize_projection(store, negative_description).root;
+	assert(avm::decode_integer(store, integers, negative_root) == -7);
+	assert(negative_root == avm::realize_integer(store, integers, -7));
+
+	assert(projection_rejected(tagged("$symbol", "missing"), resolver));
+	assert(projection_rejected(tagged("$symbol", 7), resolver));
+	assert(projection_rejected(Json("integer_add"), resolver));
+	assert(projection_rejected(Json(7), resolver));
+	assert(projection_rejected(tagged("$integer", 1.5), resolver));
+
+	Json mixed_leaf = tagged("$integer", 7);
+	mixed_leaf["extra"] = true;
+	assert(projection_rejected(mixed_leaf, resolver));
+
+	const std::uint64_t too_large = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1U;
+	assert(projection_rejected(tagged("$integer", too_large), resolver));
+
+	const avm::LinkId missing_link = store.size() + 1000;
+	const avm::ProjectionDescription missing_description =
+	    avm::json_duplet::project_duplet_term(tagged("$link", missing_link), resolver);
+	const std::size_t before_missing = store.size();
+	assert(!avm::find_projection(store, missing_description).has_value());
+	assert(store.size() == before_missing);
+	bool missing_realize_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, missing_description));
+	}
+	catch (const std::invalid_argument &)
+	{
+		missing_realize_rejected = true;
+	}
+	assert(missing_realize_rejected);
+	assert(store.size() == before_missing);
+
+	const std::filesystem::path persistent_path =
+	    std::filesystem::temp_directory_path() / "avm_json_duplet_values_test.links";
+	std::filesystem::remove(persistent_path);
+
+	avm::IntegerVocabulary persistent_integers{};
+	avm::LinkId persistent_value = avm::invalid_link_id;
+	{
+		avm::PersistentLinkStore persistent_store(persistent_path);
+		persistent_integers = avm::IntegerVocabulary::create(persistent_store);
+		const avm::json_duplet::SymbolAnchors persistent_symbols;
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_symbols);
+		const avm::ProjectionDescription persistent_description =
+		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
+		persistent_value = avm::realize_projection(persistent_store, persistent_description).root;
+		assert(avm::decode_integer(persistent_store, persistent_integers, persistent_value) == 42);
+	}
+	{
+		avm::PersistentLinkStore reopened(persistent_path);
+		const avm::json_duplet::SymbolAnchors persistent_symbols;
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_symbols);
+		const avm::ProjectionDescription persistent_description =
+		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
+		const std::size_t before_reopen_find = reopened.size();
+		const auto persistent_found = avm::find_projection(reopened, persistent_description);
+		assert(persistent_found.has_value());
+		assert(persistent_found->root == persistent_value);
+		assert(reopened.size() == before_reopen_find);
+		assert(avm::decode_integer(reopened, persistent_integers, persistent_value) == 42);
+	}
+	std::filesystem::remove(persistent_path);
+
+	return 0;
+}

--- a/test/json_duplet_values_test.cpp
+++ b/test/json_duplet_values_test.cpp
@@ -61,13 +61,12 @@ int main()
 	avm::InMemoryLinkStore store;
 	const avm::BootstrapVocabulary bootstrap = avm::BootstrapVocabulary::create(store);
 	const avm::IntegerVocabulary integers = avm::IntegerVocabulary::create(store);
-	const avm::json_duplet::SymbolAnchors symbols{
-	    {"integer_add", integers.add_relation},
-	    {"nil", bootstrap.nil},
-	    {"false", bootstrap.false_value},
-	    {"true", bootstrap.true_value},
-	    {"unit", bootstrap.unit},
-	};
+	avm::json_duplet::SymbolAnchors symbols;
+	symbols.emplace("integer_add", integers.add_relation);
+	symbols.emplace("nil", bootstrap.nil);
+	symbols.emplace("false", bootstrap.false_value);
+	symbols.emplace("true", bootstrap.true_value);
+	symbols.emplace("unit", bootstrap.unit);
 	const avm::json_duplet::NativeLeafResolver resolver(integers, symbols);
 
 	const Json expression = add_expression(7, 3);
@@ -128,7 +127,8 @@ int main()
 	assert(avm::find_projection(store, zero_description)->root == integers.zero);
 
 	const Json negative_leaf = tagged("$integer", -7);
-	const avm::ProjectionDescription negative_description = avm::json_duplet::project_duplet_term(negative_leaf, resolver);
+	const avm::ProjectionDescription negative_description =
+	    avm::json_duplet::project_duplet_term(negative_leaf, resolver);
 	const avm::LinkId negative_root = avm::realize_projection(store, negative_description).root;
 	assert(avm::decode_integer(store, integers, negative_root) == -7);
 	assert(negative_root == avm::realize_integer(store, integers, -7));


### PR DESCRIPTION
Part of #173 / #169 / #128 / #130.

## Что реализовано

Native `duplet-json/1` получает явный leaf-resolution layer без скрытого создания identity.

Поддержаны формы:

```json
{"$link":42}
{"$symbol":"integer_add"}
{"$integer":7}
```

`$symbol` разрешается только через caller-owned `SymbolAnchors`; неизвестное имя не создаёт `point`. `$integer` строит `ProjectionDescription`, эквивалентный canonical `IntegerVocabulary`, без materialization на этапе parser/projector.

## End-to-end conformance

Тест строит:

```json
{
  "<<":{"$symbol":"integer_add"},
  ">>":{
    "<<":{"$integer":7},
    ">>":{"$integer":3}
  }
}
```

и проверяет:

- projection и find не меняют store;
- realize создаёт canonical `Link(integer_add, Link(Integer(7), Integer(3)))`;
- direct `encode_relation_entity` возвращает тот же root;
- обычный `Executor` + canonical Integer arithmetic возвращает canonical `10`;
- strict raw-text parser поддерживает тот же explicit resolver;
- `true/false/nil` используются как существующие Bootstrap identities через `$symbol`;
- zero/negative/int64-boundary diagnostics;
- unknown symbol и raw scalar reject;
- missing `$link`: find miss, realize fail без mutation;
- persistent reopen сохраняет canonical Integer identity.

## Архитектурные границы

- parser не знает `LinkStore`/`Executor`;
- symbol table не прячется в store;
- нет `string -> create_point()`;
- нет JSON-tagged runtime values;
- `find` и `realize` остаются раздельными;
- core Integer не зависит от JSON.

## Документация

Добавлен русский нормативный документ `docs/duplet-json-leaf-resolution.md`.

## Text

`$text` намеренно не вводится в этом PR: #128 требует сначала frontend-neutral canonical Text/byte-string denotation. До этого `$text` должен оставаться unsupported marker, а не получать ad-hoc JSON-specific identity.