### PR TITLE
AVM Native JSON: проецировать `$text` в canonical Text

### DIFF
--- a/adapters/json_duplet_values.h
+++ b/adapters/json_duplet_values.h
@@ -3,6 +3,7 @@
 #include "json_duplet_projection.h"
 
 #include "avm/integer_value.h"
+#include "avm/text_value.h"
 
 #include <cstdint>
 #include <limits>
@@ -37,11 +38,47 @@ inline ProjectionRef append_integer_projection(ProjectionDescription &descriptio
 	return ProjectionRef::node(wrapper_id);
 }
 
+inline ProjectionRef append_byte_projection(ProjectionDescription &description, const TextVocabulary &vocabulary,
+                                            std::uint8_t value)
+{
+	ProjectionRef suffix = ProjectionRef::anchor(vocabulary.byte_end);
+	for (int bit = 7; bit >= 0; --bit)
+	{
+		const bool one = (value & static_cast<std::uint8_t>(1U << bit)) != 0;
+		const LinkId marker = one ? vocabulary.bit_one : vocabulary.bit_zero;
+		const ProjectionNodeId node_id = description.nodes.size();
+		description.nodes.push_back(ProjectionNode{ProjectionRef::anchor(marker), suffix});
+		suffix = ProjectionRef::node(node_id);
+	}
+
+	const ProjectionNodeId wrapper_id = description.nodes.size();
+	description.nodes.push_back(ProjectionNode{ProjectionRef::anchor(vocabulary.byte_marker), suffix});
+	return ProjectionRef::node(wrapper_id);
+}
+
+inline ProjectionRef append_text_projection(ProjectionDescription &description, const TextVocabulary &vocabulary,
+                                            const std::string &bytes)
+{
+	ProjectionRef tail = ProjectionRef::anchor(vocabulary.text_end);
+	for (auto byte = bytes.rbegin(); byte != bytes.rend(); ++byte)
+	{
+		const auto value = static_cast<std::uint8_t>(static_cast<unsigned char>(*byte));
+		const ProjectionRef byte_ref = append_byte_projection(description, vocabulary, value);
+		const ProjectionNodeId cell_id = description.nodes.size();
+		description.nodes.push_back(ProjectionNode{byte_ref, tail});
+		tail = ProjectionRef::node(cell_id);
+	}
+
+	const ProjectionNodeId wrapper_id = description.nodes.size();
+	description.nodes.push_back(ProjectionNode{ProjectionRef::anchor(vocabulary.text_marker), tail});
+	return ProjectionRef::node(wrapper_id);
+}
+
 class NativeLeafResolver
 {
 public:
-	NativeLeafResolver(IntegerVocabulary integers, const SymbolAnchors &symbols)
-	    : integers_(integers), symbols_(symbols)
+	NativeLeafResolver(IntegerVocabulary integers, TextVocabulary text, const SymbolAnchors &symbols)
+	    : integers_(integers), text_(text), symbols_(symbols)
 	{
 	}
 
@@ -57,6 +94,8 @@ public:
 			return resolve_symbol(value, path);
 		if (value.contains("$integer"))
 			return resolve_integer(value, description, path);
+		if (value.contains("$text"))
+			return resolve_text(value, description, path);
 
 		throw ProjectionError(path + ": unsupported native AVM leaf marker");
 	}
@@ -102,7 +141,19 @@ private:
 		return append_integer_projection(description, integers_, integer);
 	}
 
+	template <typename Json>
+	ProjectionRef resolve_text(const Json &value, ProjectionDescription &description, const std::string &path) const
+	{
+		const Json &encoded_text = value.at("$text");
+		if (!encoded_text.is_string())
+			throw ProjectionError(path + ".$text: text value must be a JSON string");
+
+		const std::string bytes = encoded_text.template get<std::string>();
+		return append_text_projection(description, text_, bytes);
+	}
+
 	IntegerVocabulary integers_;
+	TextVocabulary text_;
 	const SymbolAnchors &symbols_;
 };
 

--- a/adapters/json_duplet_values.h
+++ b/adapters/json_duplet_values.h
@@ -9,6 +9,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace avm::json_duplet
@@ -77,8 +78,8 @@ inline ProjectionRef append_text_projection(ProjectionDescription &description, 
 class NativeLeafResolver
 {
 public:
-	NativeLeafResolver(IntegerVocabulary integers, TextVocabulary text, const SymbolAnchors &symbols)
-	    : integers_(integers), text_(text), symbols_(symbols)
+	NativeLeafResolver(IntegerVocabulary integers, TextVocabulary text, SymbolAnchors symbols)
+	    : integers_(integers), text_(text), symbols_(std::move(symbols))
 	{
 	}
 
@@ -154,7 +155,7 @@ private:
 
 	IntegerVocabulary integers_;
 	TextVocabulary text_;
-	const SymbolAnchors &symbols_;
+	SymbolAnchors symbols_;
 };
 
 } // namespace avm::json_duplet

--- a/docs/duplet-json-leaf-resolution.md
+++ b/docs/duplet-json-leaf-resolution.md
@@ -20,14 +20,15 @@ Parser пары не создаёт `LinkId`, не вызывает `create_poin
 
 ## Грамматика листьев v1
 
-Первый нативный resolver поддерживает три явные формы:
+Первый нативный resolver поддерживает четыре явные формы:
 
 ```text
-Leaf := LinkAnchor | SymbolAnchor | IntegerValue
+Leaf := LinkAnchor | SymbolAnchor | IntegerValue | TextValue
 
 LinkAnchor := {"$link": positive_integer}
 SymbolAnchor := {"$symbol": string}
 IntegerValue := {"$integer": int64_json_integer}
+TextValue := {"$text": string}
 ```
 
 Каждый объект-лист содержит **ровно один** marker. Raw JSON scalar сам по себе листом AVM не является.
@@ -42,6 +43,10 @@ IntegerValue := {"$integer": int64_json_integer}
 7
 ```
 
+```json
+"hello"
+```
+
 а это допустимо:
 
 ```json
@@ -50,6 +55,10 @@ IntegerValue := {"$integer": int64_json_integer}
 
 ```json
 {"$integer":7}
+```
+
+```json
+{"$text":"hello"}
 ```
 
 ## `$link`: существующая identity
@@ -127,6 +136,56 @@ $integer
 
 Текущий canonical Integer contract ограничен `int64`, поэтому `$integer` принимает только целые JSON numbers в диапазоне `INT64_MIN..INT64_MAX`.
 
+## `$text`: проекция JSON-строки в канонический Text
+
+```json
+{"$text":"hello"}
+```
+
+не создаёт JSON-specific строковый тип. После того как JSON parser разобрал escapes, resolver берёт **точную последовательность байтов** полученной строки и строит `ProjectionDescription`, эквивалентный canonical byte-string Text из `TextVocabulary`.
+
+Нормативный путь:
+
+```text
+JSON string
+ -> bytes строки после JSON parsing
+ -> canonical Byte/Text projection
+ -> find_projection | realize_projection
+ -> тот же LinkId, что find_text | realize_text
+```
+
+AVM не выполняет Unicode normalization на этом пути.
+
+Поэтому:
+
+```json
+{"$text":"\u00e9"}
+```
+
+и literal UTF-8 `é` после JSON parsing дают одинаковые байты `C3 A9` и сходятся к одной identity.
+
+Но:
+
+```json
+{"$text":"e\u0301"}
+```
+
+даёт `65 CC 81` и остаётся другой byte identity.
+
+Это не ошибка: Unicode normalization является явной политикой frontend-а, а canonical Text AVM определён побайтово.
+
+Встроенный NUL также является обычным байтом. DOM-строка `A 00 B` проецируется как Text из трёх байтов и не обрезается C-string semantics.
+
+Пустая JSON-строка:
+
+```json
+{"$text":""}
+```
+
+проецируется в canonical empty Text `Link(text_marker, text_end)`.
+
+Как и `$integer`, `$text` ничего не materialize на этапе parse/project.
+
 ## Boolean и nil
 
 `true`, `false` и `nil` уже имеют canonical identities в `BootstrapVocabulary`. Поэтому v1 не вводит отдельные JSON-tagged value classes для них.
@@ -171,25 +230,13 @@ Link(
 
 `Executor` не знает, что entity когда-либо была записана в JSON.
 
-## Text не входит в этот gate
-
-Форма вроде:
-
-```json
-{"$text":"hello"}
-```
-
-**не вводится**, пока #128 не зафиксирует canonical Text/byte-string denotation.
-
-Причина принципиальная: UTF-8/JSON serialization не должна автоматически становиться semantic identity. Сначала нужен frontend-neutral link encoding текста с отдельными `find/realize/decode` контрактами, затем `$text` сможет быть лишь projection adapter-ом к этой структуре.
-
-До этого любой `$text` должен отклоняться как неизвестный leaf marker.
-
 ## Контекстные ссылки и выражения
 
-Контекстные ссылки (`$ent/$rel/$sub/$obj`, path/reference semantics jsonRVM) также не являются простыми value leaves. Их перенос относится к #125/#126 и semantic migrator #174.
+Контекстные ссылки (`$ent/$rel/$sub/$obj`, path/reference semantics jsonRVM) не являются простыми value leaves.
 
-Native JSON resolver не должен угадывать их по строкам.
+Их перенос относится к #125/#126 и semantic migrator #174. Native JSON resolver не должен угадывать их по строкам и не должен превращать старые jsonRVM reference expressions в `$symbol`.
+
+Это отдельный класс syntax/semantics поверх execution context, а не расширение таблицы значений.
 
 ## Инварианты
 
@@ -200,5 +247,8 @@ Native JSON resolver не должен угадывать их по строка
 3. materialization происходит только через явный `realize_projection`;
 4. одинаковое canonical значение сходится к одной structural identity;
 5. неизвестное имя не создаёт point;
-6. `Executor`, `LinkStore` и canonical value core не зависят от JSON syntax;
-7. persistent reopen сохраняет structural meaning.
+6. `$integer` сходится с canonical Integer core;
+7. `$text` сходится с canonical byte-string Text core;
+8. Boolean/nil используют существующие singleton identities;
+9. `Executor`, `LinkStore` и canonical value core не зависят от JSON syntax;
+10. persistent reopen сохраняет structural meaning.

--- a/test/json_duplet_values_test.cpp
+++ b/test/json_duplet_values_test.cpp
@@ -6,6 +6,7 @@
 #include "avm/persistent_link_store.h"
 #include "avm/program_model.h"
 #include "avm/relations_model.h"
+#include "avm/text_value.h"
 
 #include "nlohmann/json.hpp"
 
@@ -15,6 +16,7 @@
 #include <limits>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -41,6 +43,15 @@ Json add_expression(std::int64_t left, std::int64_t right)
 	return pair(tagged("$symbol", "integer_add"), pair(tagged("$integer", left), tagged("$integer", right)));
 }
 
+std::vector<std::uint8_t> bytes_of(const std::string &value)
+{
+	std::vector<std::uint8_t> bytes;
+	bytes.reserve(value.size());
+	for (const unsigned char byte : value)
+		bytes.push_back(static_cast<std::uint8_t>(byte));
+	return bytes;
+}
+
 bool projection_rejected(const Json &value, const avm::json_duplet::NativeLeafResolver &resolver)
 {
 	try
@@ -61,13 +72,14 @@ int main()
 	avm::InMemoryLinkStore store;
 	const avm::BootstrapVocabulary bootstrap = avm::BootstrapVocabulary::create(store);
 	const avm::IntegerVocabulary integers = avm::IntegerVocabulary::create(store);
+	const avm::TextVocabulary text = avm::TextVocabulary::create(store);
 	avm::json_duplet::SymbolAnchors symbols;
 	symbols.emplace("integer_add", integers.add_relation);
 	symbols.emplace("nil", bootstrap.nil);
 	symbols.emplace("false", bootstrap.false_value);
 	symbols.emplace("true", bootstrap.true_value);
 	symbols.emplace("unit", bootstrap.unit);
-	const avm::json_duplet::NativeLeafResolver resolver(integers, symbols);
+	const avm::json_duplet::NativeLeafResolver resolver(integers, text, symbols);
 
 	const Json expression = add_expression(7, 3);
 	const std::size_t before_projection = store.size();
@@ -97,14 +109,14 @@ int main()
 	const std::string raw_expression =
 	    R"({"<<":{"$symbol":"integer_add"},">>":{"<<":{"$integer":7},">>":{"$integer":3}}})";
 	const std::size_t before_text_projection = store.size();
-	const avm::ProjectionDescription text_description =
+	const avm::ProjectionDescription raw_description =
 	    avm::json_duplet::project_duplet_term_text<Json>(raw_expression, resolver);
-	assert(text_description.nodes == description.nodes);
-	assert(text_description.root == description.root);
+	assert(raw_description.nodes == description.nodes);
+	assert(raw_description.root == description.root);
 	assert(store.size() == before_text_projection);
-	const auto text_found = avm::find_projection(store, text_description);
-	assert(text_found.has_value());
-	assert(text_found->root == realized.root);
+	const auto raw_found = avm::find_projection(store, raw_description);
+	assert(raw_found.has_value());
+	assert(raw_found->root == realized.root);
 
 	const Json true_leaf = tagged("$symbol", "true");
 	const avm::ProjectionDescription true_description = avm::json_duplet::project_duplet_term(true_leaf, resolver);
@@ -133,15 +145,78 @@ int main()
 	assert(avm::decode_integer(store, integers, negative_root) == -7);
 	assert(negative_root == avm::realize_integer(store, integers, -7));
 
+	const std::string hello = "hello";
+	const std::vector<std::uint8_t> hello_bytes = bytes_of(hello);
+	const Json hello_leaf = tagged("$text", hello);
+	const std::size_t before_hello_projection = store.size();
+	const avm::ProjectionDescription hello_description = avm::json_duplet::project_duplet_term(hello_leaf, resolver);
+	assert(store.size() == before_hello_projection);
+	assert(!avm::find_projection(store, hello_description).has_value());
+	assert(store.size() == before_hello_projection);
+	const avm::LinkId hello_root = avm::realize_projection(store, hello_description).root;
+	assert(avm::decode_text(store, text, hello_root) == hello_bytes);
+	const std::size_t before_direct_hello = store.size();
+	assert(avm::realize_text(store, text, hello_bytes) == hello_root);
+	assert(store.size() == before_direct_hello);
+
+	const Json empty_text_leaf = tagged("$text", "");
+	const avm::ProjectionDescription empty_text_description =
+	    avm::json_duplet::project_duplet_term(empty_text_leaf, resolver);
+	const avm::LinkId empty_text_root = avm::realize_projection(store, empty_text_description).root;
+	const std::vector<std::uint8_t> empty_bytes;
+	assert(avm::decode_text(store, text, empty_text_root) == empty_bytes);
+	assert(empty_text_root == avm::realize_text(store, text, empty_bytes));
+
+	const std::string embedded_nul("A\0B", 3);
+	const std::vector<std::uint8_t> embedded_nul_bytes{'A', 0x00, 'B'};
+	const avm::ProjectionDescription nul_description =
+	    avm::json_duplet::project_duplet_term(tagged("$text", embedded_nul), resolver);
+	const avm::LinkId nul_root = avm::realize_projection(store, nul_description).root;
+	assert(avm::decode_text(store, text, nul_root) == embedded_nul_bytes);
+	assert(nul_root == avm::realize_text(store, text, embedded_nul_bytes));
+
+	const std::string raw_cyrillic = R"({"$text":"\u041f\u0440\u0438\u0432\u0435\u0442"})";
+	const std::vector<std::uint8_t> cyrillic_bytes{
+	    0xD0, 0x9F, 0xD1, 0x80, 0xD0, 0xB8, 0xD0, 0xB2, 0xD0, 0xB5, 0xD1, 0x82,
+	};
+	const avm::ProjectionDescription cyrillic_description =
+	    avm::json_duplet::project_duplet_term_text<Json>(raw_cyrillic, resolver);
+	const avm::LinkId cyrillic_root = avm::realize_projection(store, cyrillic_description).root;
+	assert(avm::decode_text(store, text, cyrillic_root) == cyrillic_bytes);
+	assert(cyrillic_root == avm::realize_text(store, text, cyrillic_bytes));
+
+	const std::string raw_composed = R"({"$text":"\u00e9"})";
+	const std::string composed_utf8("\xC3\xA9", 2);
+	const avm::ProjectionDescription escaped_composed =
+	    avm::json_duplet::project_duplet_term_text<Json>(raw_composed, resolver);
+	const avm::ProjectionDescription literal_composed =
+	    avm::json_duplet::project_duplet_term(tagged("$text", composed_utf8), resolver);
+	const avm::LinkId escaped_composed_root = avm::realize_projection(store, escaped_composed).root;
+	const avm::LinkId literal_composed_root = avm::realize_projection(store, literal_composed).root;
+	assert(escaped_composed_root == literal_composed_root);
+
+	const std::string raw_decomposed = R"({"$text":"e\u0301"})";
+	const avm::ProjectionDescription decomposed_description =
+	    avm::json_duplet::project_duplet_term_text<Json>(raw_decomposed, resolver);
+	const avm::LinkId decomposed_root = avm::realize_projection(store, decomposed_description).root;
+	const std::vector<std::uint8_t> decomposed_bytes{'e', 0xCC, 0x81};
+	assert(avm::decode_text(store, text, decomposed_root) == decomposed_bytes);
+	assert(decomposed_root != escaped_composed_root);
+
 	assert(projection_rejected(tagged("$symbol", "missing"), resolver));
 	assert(projection_rejected(tagged("$symbol", 7), resolver));
 	assert(projection_rejected(Json("integer_add"), resolver));
 	assert(projection_rejected(Json(7), resolver));
 	assert(projection_rejected(tagged("$integer", 1.5), resolver));
+	assert(projection_rejected(tagged("$text", 7), resolver));
 
 	Json mixed_leaf = tagged("$integer", 7);
 	mixed_leaf["extra"] = true;
 	assert(projection_rejected(mixed_leaf, resolver));
+
+	Json mixed_text_leaf = tagged("$text", "hello");
+	mixed_text_leaf["extra"] = true;
+	assert(projection_rejected(mixed_text_leaf, resolver));
 
 	const std::uint64_t too_large = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max()) + 1U;
 	assert(projection_rejected(tagged("$integer", too_large), resolver));
@@ -169,12 +244,15 @@ int main()
 	std::filesystem::remove(persistent_path);
 
 	avm::IntegerVocabulary persistent_integers{};
+	avm::TextVocabulary persistent_text{};
 	avm::LinkId persistent_value = avm::invalid_link_id;
 	{
 		avm::PersistentLinkStore persistent_store(persistent_path);
 		persistent_integers = avm::IntegerVocabulary::create(persistent_store);
+		persistent_text = avm::TextVocabulary::create(persistent_store);
 		const avm::json_duplet::SymbolAnchors persistent_symbols;
-		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_symbols);
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(
+		    persistent_integers, persistent_text, persistent_symbols);
 		const avm::ProjectionDescription persistent_description =
 		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
 		persistent_value = avm::realize_projection(persistent_store, persistent_description).root;
@@ -183,7 +261,8 @@ int main()
 	{
 		avm::PersistentLinkStore reopened(persistent_path);
 		const avm::json_duplet::SymbolAnchors persistent_symbols;
-		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_symbols);
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(
+		    persistent_integers, persistent_text, persistent_symbols);
 		const avm::ProjectionDescription persistent_description =
 		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
 		const std::size_t before_reopen_find = reopened.size();

--- a/test/json_duplet_values_test.cpp
+++ b/test/json_duplet_values_test.cpp
@@ -250,9 +250,7 @@ int main()
 		avm::PersistentLinkStore persistent_store(persistent_path);
 		persistent_integers = avm::IntegerVocabulary::create(persistent_store);
 		persistent_text = avm::TextVocabulary::create(persistent_store);
-		const avm::json_duplet::SymbolAnchors persistent_symbols;
-		const avm::json_duplet::NativeLeafResolver persistent_resolver(
-		    persistent_integers, persistent_text, persistent_symbols);
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_text, {});
 		const avm::ProjectionDescription persistent_description =
 		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
 		persistent_value = avm::realize_projection(persistent_store, persistent_description).root;
@@ -260,9 +258,7 @@ int main()
 	}
 	{
 		avm::PersistentLinkStore reopened(persistent_path);
-		const avm::json_duplet::SymbolAnchors persistent_symbols;
-		const avm::json_duplet::NativeLeafResolver persistent_resolver(
-		    persistent_integers, persistent_text, persistent_symbols);
+		const avm::json_duplet::NativeLeafResolver persistent_resolver(persistent_integers, persistent_text, {});
 		const avm::ProjectionDescription persistent_description =
 		    avm::json_duplet::project_duplet_term(tagged("$integer", 42), persistent_resolver);
 		const std::size_t before_reopen_find = reopened.size();


### PR DESCRIPTION
Closes #173. Part of #169/#128/#130.

## Что завершено

После #181 Native `duplet-json/1` получает четвёртую явную leaf-форму:

```json
{"$text":"hello"}
```

Она не создаёт JSON-specific строковый runtime type. Resolver берёт точные bytes строки после JSON parsing и строит `ProjectionDescription`, эквивалентный canonical byte-string `TextVocabulary`.

Нормативная grammar теперь:

```text
Leaf := LinkAnchor | SymbolAnchor | IntegerValue | TextValue

LinkAnchor := {"$link": positive_integer}
SymbolAnchor := {"$symbol": string}
IntegerValue := {"$integer": int64_json_integer}
TextValue := {"$text": string}
```

## Семантическая сходимость

Проверяется:

- project/find `$text:"hello"` не меняют store;
- realize даёт root, который `decode_text` возвращает как exact bytes `hello`;
- direct `realize_text` возвращает тот же root без роста store;
- empty string сходится к canonical empty Text;
- embedded NUL `A 00 B` сохраняется полностью;
- JSON `"\u041f..."` для `Привет` даёт exact UTF-8 bytes и тот же root, что direct Text API;
- JSON escape `\u00E9` и literal UTF-8 `é` сходятся;
- decomposed `e\u0301` остаётся другой byte identity;
- wrong/mixed `$text` deterministically rejected.

## Unicode policy

AVM не выполняет normalization. Canonical Text определён побайтово; JSON parser отвечает только за JSON escape decoding → строковые bytes frontend-а.

## Архитектурные границы

- `NativeLeafResolver` теперь принимает `IntegerVocabulary`, `TextVocabulary` и caller-owned `SymbolAnchors`;
- parser/projector по-прежнему не знает `LinkStore`/`Executor`;
- `$symbol` не создаёт unknown identity;
- Boolean/nil остаются singleton Bootstrap identities через explicit symbols;
- raw JSON scalars всё ещё запрещены как implicit values;
- context/reference expressions намеренно не объявлены value leaves и остаются #125/#126/#174.

## #173

После этого PR leaf/value resolver gate считается завершённым: `$link`, `$symbol`, canonical `$integer`, canonical `$text`, Boolean/nil singleton policy, find/realize split и persistent semantics зафиксированы. Reference expressions относятся к отдельному execution-context contract, а не к value resolver.