### PR TITLE
AVM 1.5: canonical reference algebra и observational resolver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/program_model.h
     include/avm/projection.h
     include/avm/raw_carrier.h
+    include/avm/reference.h
     include/avm/relations_model.h
     include/avm/relations_query.h
     include/avm/semantic_context.h
@@ -198,6 +199,7 @@ if(AVM_BUILD_CORE_TESTS)
         semantic_execution_outcome_tests)
     avm_add_core_test(avm_integer_value_test test/integer_value_test.cpp integer_value_tests)
     avm_add_core_test(avm_text_value_test test/text_value_test.cpp text_value_tests)
+    avm_add_core_test(avm_reference_test test/reference_test.cpp reference_tests)
     avm_add_core_test(avm_triune_primitives_test test/triune_primitives_test.cpp triune_primitives_tests)
     avm_add_core_test(avm_execution_observer_test test/execution_observer_test.cpp execution_observer_tests)
     avm_add_core_test(avm_execution_trace_test test/execution_trace_test.cpp execution_trace_tests)
@@ -276,6 +278,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_semantic_execution_outcome_test
         avm_integer_value_test
         avm_text_value_test
+        avm_reference_test
         avm_triune_primitives_test
         avm_execution_observer_test
         avm_execution_trace_test

--- a/docs/reference-algebra.md
+++ b/docs/reference-algebra.md
@@ -1,0 +1,289 @@
+# Каноническая алгебра ссылок AVM
+
+Родительская задача: #183. Родительский gate: #126. Основание контекста: #125.
+
+## Назначение
+
+Старый `jsonRVM` объединял в одной строковой ссылке сразу несколько механизмов:
+
+- местоимения `$ent/$rel/$sub/$obj`;
+- переход к родительскому контексту через дополнительные `$`;
+- абсолютные имена;
+- JSON member/path traversal;
+- lazy database lookup;
+- lvalue creation.
+
+AVM разделяет эти уровни.
+
+Core получает **каноническую структурную ссылку**, состоящую только из `LinkId` и `Link(begin,end)`. Строка `$...` является только frontend syntax и компилируется отдельно в #184.
+
+Нормативная граница:
+
+```text
+frontend syntax
+ -> canonical Reference LinkId
+ -> resolve_reference(reference, SemanticContextView)
+ -> optional<LinkId>
+```
+
+`resolve_reference` наблюдает существующий store и semantic context. Он ничего не materialize.
+
+## Грамматика
+
+```text
+ContextSelector := Current | Parent(ContextSelector)
+
+Reference :=
+    Role(ContextSelector, Entity)
+  | Role(ContextSelector, RelationState)
+  | Role(ContextSelector, Subject)
+  | Role(ContextSelector, Object)
+  | Named(LinkId)
+  | Begin(Reference)
+  | End(Reference)
+  | RelationPart(Reference)
+  | SubjectPart(Reference)
+  | ObjectPart(Reference)
+```
+
+## ReferenceVocabulary
+
+`ReferenceVocabulary` содержит независимые identity:
+
+```text
+current_context
+parent_context
+entity_role
+relation_state_role
+subject_role
+object_role
+named_reference
+begin_reference
+end_reference
+relation_part_reference
+subject_part_reference
+object_part_reference
+```
+
+Все anchors должны существовать и быть различны.
+
+## Current и Parent
+
+Текущий selector является identity:
+
+```text
+Current := current_context
+```
+
+Один переход к parent:
+
+```text
+Parent(selector) := Link(parent_context, selector)
+```
+
+Поэтому глубина не требует отдельных vocabulary identities:
+
+```text
+Parent(Current)
+Parent(Parent(Current))
+Parent^N(Current)
+```
+
+Материализуется только **выражение selector**, а не dynamic context.
+
+При разрешении количество `Parent` применяется к immutable `SemanticContextView::ancestor(N)`.
+
+Корневая семантика наследуется из #125:
+
+```text
+ancestor(N > depth) = root
+```
+
+Следовательно любая глубина над root детерминированно saturate-ится на root.
+
+## Role
+
+Role reference кодируется:
+
+```text
+Link(role_marker, context_selector)
+```
+
+Соответствия:
+
+```text
+entity_role         -> SemanticContextRole::Entity
+relation_state_role -> SemanticContextRole::RelationState
+subject_role        -> SemanticContextRole::Subject
+object_role         -> SemanticContextRole::Object
+```
+
+Критический инвариант:
+
+```text
+relation_state_role != ExecutionContext.relation controller identity
+```
+
+То есть будущий `$rel` разрешается в semantic `relation_state`, а не в controller текущего dispatch.
+
+## Named
+
+Известная абсолютная identity кодируется:
+
+```text
+Named(X) := Link(named_reference, X)
+```
+
+`X` уже обязана существовать в store.
+
+`Named`:
+
+- не содержит текстового имени;
+- не вызывает database/API lookup;
+- не создаёт point для неизвестного имени;
+- является результатом frontend name-resolution policy.
+
+Например frontend может иметь явную таблицу:
+
+```text
+"ent1" -> X
+```
+
+и скомпилировать её в `Named(X)`.
+
+## Begin и End
+
+Структурные projections:
+
+```text
+Begin(R) := Link(begin_reference, R)
+End(R)   := Link(end_reference, R)
+```
+
+После recursive resolve внутренней ссылки они наблюдающе возвращают:
+
+```text
+store.get(target).begin
+store.get(target).end
+```
+
+Никакой materialization при чтении нет.
+
+## Части RelationEntity
+
+```text
+RelationPart(R)
+SubjectPart(R)
+ObjectPart(R)
+```
+
+после resolution `R` применяют canonical `decode_relation_entity`:
+
+```text
+entity = Link(rel, Link(sub,obj))
+```
+
+и возвращают соответственно `rel`, `sub`, `obj`.
+
+Это structural AVM semantics. Оно не является JSON object member traversal.
+
+## Find и realize reference-expression
+
+Canonical expression строится через раздельные операции:
+
+```text
+find_context_selector
+realize_context_selector
+
+find_context_role_reference
+realize_context_role_reference
+
+find_named_reference
+realize_named_reference
+
+find_reference_projection
+realize_reference_projection
+```
+
+`find_*` вызывает только `LinkStore::find` и не меняет store.
+
+`realize_*` является явной materialization boundary и использует `intern`.
+
+Повторная realization возвращает тот же canonical LinkId.
+
+## Resolve
+
+```text
+resolve_reference(store, vocabulary, reference, context)
+```
+
+возвращает:
+
+```text
+optional<LinkId>
+```
+
+Политика:
+
+- отсутствующий root reference -> miss;
+- role, содержащая отсутствующий LinkId в ephemeral context -> miss;
+- malformed existing reference structure -> deterministic error;
+- неизвестный vocabulary marker -> deterministic error;
+- structural projection malformed target -> deterministic Relations Model error;
+- read path не вызывает `intern/create_point`.
+
+Есть явный `max_depth` для защиты от патологически глубокой external structure. Он ограничивает операцию resolve, но не определяет semantic identity корректной ссылки.
+
+## Persistent contract
+
+Reference LinkId является обычной canonical link structure.
+
+После reopen:
+
+- vocabulary anchors сохраняют identity;
+- явно materialized reference сохраняет identity;
+- `resolve_reference` с эквивалентным `SemanticContextView` возвращает то же значение;
+- повторный `realize_*` не увеличивает store.
+
+Dynamic semantic context при этом не обязан materialize-иться и сам по себе persistent identity не получает.
+
+## Что намеренно не входит
+
+### Текстовый `$...`
+
+Компиляция:
+
+```text
+$ent
+$$rel
+$$$sub
+```
+
+остается adapter gate #184.
+
+### JSON pointer/member path
+
+`foo/bar/0` не является core reference syntax. JSON container traversal не переносится автоматически.
+
+### Lazy named lookup
+
+Внешняя database/capability загрузка не входит в pure resolver. Если она понадобится, это отдельный effect/capability contract #129.
+
+### Запись/lvalue
+
+`resolve_reference` только наблюдает.
+
+Старое поведение `operator[]`, создающее отсутствующий member при write, не смешивается с reference read. Explicit write/effect semantics проектируется отдельно только при наличии compatibility evidence.
+
+## Инварианты
+
+1. reference expression состоит только из links;
+2. dynamic semantic context не materialize-ится при resolve;
+3. `$rel`-эквивалент всегда означает `RelationState`, не controller identity;
+4. arbitrary parent depth композиционен;
+5. root traversal saturates;
+6. `find/resolve` не пишут;
+7. `realize` явен и идемпотентен;
+8. named reference не выполняет hidden lookup;
+9. JSON/Anum parser не входит в core;
+10. persistent и in-memory backends имеют одинаковую structural semantics.

--- a/docs/reference-algebra.md
+++ b/docs/reference-algebra.md
@@ -46,7 +46,7 @@ Reference :=
   | ObjectPart(Reference)
 ```
 
-## ReferenceVocabulary
+## Словарь ReferenceVocabulary
 
 `ReferenceVocabulary` содержит независимые identity:
 
@@ -101,7 +101,7 @@ ancestor(N > depth) = root
 
 Следовательно любая глубина над root детерминированно saturate-ится на root.
 
-## Role
+## Ролевая ссылка Role
 
 Role reference кодируется:
 
@@ -126,7 +126,7 @@ relation_state_role != ExecutionContext.relation controller identity
 
 То есть будущий `$rel` разрешается в semantic `relation_state`, а не в controller текущего dispatch.
 
-## Named
+## Именованная ссылка Named
 
 Известная абсолютная identity кодируется:
 
@@ -211,7 +211,7 @@ realize_reference_projection
 
 Повторная realization возвращает тот же canonical LinkId.
 
-## Resolve
+## Разрешение ссылки
 
 ```text
 resolve_reference(store, vocabulary, reference, context)
@@ -232,9 +232,9 @@ optional<LinkId>
 - structural projection malformed target -> deterministic Relations Model error;
 - read path не вызывает `intern/create_point`.
 
-Есть явный `max_depth` для защиты от патологически глубокой external structure. Он ограничивает операцию resolve, но не определяет semantic identity корректной ссылки.
+Есть явный `max_depth` для защиты от патологически глубокой external structure. По умолчанию искусственного предела нет: caller может задать собственный операционный лимит. Лимит не определяет semantic identity корректной ссылки.
 
-## Persistent contract
+## Контракт persistence
 
 Reference LinkId является обычной canonical link structure.
 
@@ -261,11 +261,11 @@ $$$sub
 
 остается adapter gate #184.
 
-### JSON pointer/member path
+### Пути JSON pointer/member
 
 `foo/bar/0` не является core reference syntax. JSON container traversal не переносится автоматически.
 
-### Lazy named lookup
+### Ленивый поиск имен
 
 Внешняя database/capability загрузка не входит в pure resolver. Если она понадобится, это отдельный effect/capability contract #129.
 

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -11,6 +11,7 @@
 #include "avm/program_model.h"
 #include "avm/projection.h"
 #include "avm/raw_carrier.h"
+#include "avm/reference.h"
 #include "avm/relations_model.h"
 #include "avm/relations_query.h"
 #include "avm/semantic_context.h"

--- a/include/avm/reference.h
+++ b/include/avm/reference.h
@@ -256,9 +256,9 @@ inline LinkId realize_reference_projection(LinkStore &store, const ReferenceVoca
 	return store.intern(reference_detail::projection_marker(vocabulary, projection), inner_reference);
 }
 
-inline std::optional<LinkId> resolve_reference(
-    const LinkStore &store, const ReferenceVocabulary &vocabulary, LinkId reference, const SemanticContextView &context,
-    std::size_t max_depth = std::numeric_limits<std::size_t>::max())
+inline std::optional<LinkId> resolve_reference(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                               LinkId reference, const SemanticContextView &context,
+                                               std::size_t max_depth = std::numeric_limits<std::size_t>::max())
 {
 	validate_reference_vocabulary(store, vocabulary);
 	if (!store.contains(reference))

--- a/include/avm/reference.h
+++ b/include/avm/reference.h
@@ -1,0 +1,313 @@
+#pragma once
+
+#include "avm/relations_model.h"
+#include "avm/semantic_context.h"
+
+#include <cstddef>
+#include <optional>
+#include <set>
+#include <stdexcept>
+
+namespace avm
+{
+
+struct ReferenceVocabulary
+{
+	LinkId current_context;
+	LinkId parent_context;
+	LinkId entity_role;
+	LinkId relation_state_role;
+	LinkId subject_role;
+	LinkId object_role;
+	LinkId named_reference;
+	LinkId begin_reference;
+	LinkId end_reference;
+	LinkId relation_part_reference;
+	LinkId subject_part_reference;
+	LinkId object_part_reference;
+
+	static ReferenceVocabulary create(LinkStore &store)
+	{
+		ReferenceVocabulary vocabulary{};
+		vocabulary.current_context = store.create_point();
+		vocabulary.parent_context = store.create_point();
+		vocabulary.entity_role = store.create_point();
+		vocabulary.relation_state_role = store.create_point();
+		vocabulary.subject_role = store.create_point();
+		vocabulary.object_role = store.create_point();
+		vocabulary.named_reference = store.create_point();
+		vocabulary.begin_reference = store.create_point();
+		vocabulary.end_reference = store.create_point();
+		vocabulary.relation_part_reference = store.create_point();
+		vocabulary.subject_part_reference = store.create_point();
+		vocabulary.object_part_reference = store.create_point();
+		return vocabulary;
+	}
+};
+
+inline void validate_reference_vocabulary(const LinkStore &store, const ReferenceVocabulary &vocabulary)
+{
+	std::set<LinkId> unique;
+	const auto require_identity = [&store, &unique](LinkId id)
+	{
+		if (!store.contains(id))
+			throw std::invalid_argument("reference vocabulary contains an unknown LinkId");
+		if (!unique.insert(id).second)
+			throw std::invalid_argument("reference vocabulary identities must be distinct");
+	};
+
+	require_identity(vocabulary.current_context);
+	require_identity(vocabulary.parent_context);
+	require_identity(vocabulary.entity_role);
+	require_identity(vocabulary.relation_state_role);
+	require_identity(vocabulary.subject_role);
+	require_identity(vocabulary.object_role);
+	require_identity(vocabulary.named_reference);
+	require_identity(vocabulary.begin_reference);
+	require_identity(vocabulary.end_reference);
+	require_identity(vocabulary.relation_part_reference);
+	require_identity(vocabulary.subject_part_reference);
+	require_identity(vocabulary.object_part_reference);
+}
+
+enum class ReferenceRole
+{
+	Entity,
+	RelationState,
+	Subject,
+	Object,
+};
+
+enum class ReferenceProjection
+{
+	Begin,
+	End,
+	RelationPart,
+	SubjectPart,
+	ObjectPart,
+};
+
+namespace reference_detail
+{
+
+inline LinkId role_marker(const ReferenceVocabulary &vocabulary, ReferenceRole role)
+{
+	switch (role)
+	{
+	case ReferenceRole::Entity:
+		return vocabulary.entity_role;
+	case ReferenceRole::RelationState:
+		return vocabulary.relation_state_role;
+	case ReferenceRole::Subject:
+		return vocabulary.subject_role;
+	case ReferenceRole::Object:
+		return vocabulary.object_role;
+	}
+	throw std::logic_error("unknown reference role");
+}
+
+inline SemanticContextRole semantic_role(ReferenceRole role)
+{
+	switch (role)
+	{
+	case ReferenceRole::Entity:
+		return SemanticContextRole::Entity;
+	case ReferenceRole::RelationState:
+		return SemanticContextRole::RelationState;
+	case ReferenceRole::Subject:
+		return SemanticContextRole::Subject;
+	case ReferenceRole::Object:
+		return SemanticContextRole::Object;
+	}
+	throw std::logic_error("unknown reference role");
+}
+
+inline std::optional<ReferenceRole> marker_role(const ReferenceVocabulary &vocabulary, LinkId marker)
+{
+	if (marker == vocabulary.entity_role)
+		return ReferenceRole::Entity;
+	if (marker == vocabulary.relation_state_role)
+		return ReferenceRole::RelationState;
+	if (marker == vocabulary.subject_role)
+		return ReferenceRole::Subject;
+	if (marker == vocabulary.object_role)
+		return ReferenceRole::Object;
+	return std::nullopt;
+}
+
+inline LinkId projection_marker(const ReferenceVocabulary &vocabulary, ReferenceProjection projection)
+{
+	switch (projection)
+	{
+	case ReferenceProjection::Begin:
+		return vocabulary.begin_reference;
+	case ReferenceProjection::End:
+		return vocabulary.end_reference;
+	case ReferenceProjection::RelationPart:
+		return vocabulary.relation_part_reference;
+	case ReferenceProjection::SubjectPart:
+		return vocabulary.subject_part_reference;
+	case ReferenceProjection::ObjectPart:
+		return vocabulary.object_part_reference;
+	}
+	throw std::logic_error("unknown reference projection");
+}
+
+inline std::size_t context_selector_depth(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                          LinkId selector, std::size_t max_depth)
+{
+	std::size_t depth = 0;
+	LinkId current = selector;
+	while (current != vocabulary.current_context)
+	{
+		if (depth >= max_depth)
+			throw std::runtime_error("context selector exceeds configured depth limit");
+		if (!store.contains(current))
+			throw std::runtime_error("context selector references an unknown LinkId");
+		const Link step = store.get(current);
+		if (step.begin != vocabulary.parent_context)
+			throw std::runtime_error("context selector is not Current or Parent(selector)");
+		current = step.end;
+		++depth;
+	}
+	return depth;
+}
+
+} // namespace reference_detail
+
+inline std::optional<LinkId> find_context_selector(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                                   std::size_t parent_levels)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	LinkId selector = vocabulary.current_context;
+	for (std::size_t level = 0; level < parent_levels; ++level)
+	{
+		const auto parent = store.find(vocabulary.parent_context, selector);
+		if (!parent)
+			return std::nullopt;
+		selector = *parent;
+	}
+	return selector;
+}
+
+inline LinkId realize_context_selector(LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                       std::size_t parent_levels)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	LinkId selector = vocabulary.current_context;
+	for (std::size_t level = 0; level < parent_levels; ++level)
+		selector = store.intern(vocabulary.parent_context, selector);
+	return selector;
+}
+
+inline std::optional<LinkId> find_context_role_reference(const LinkStore &store,
+                                                         const ReferenceVocabulary &vocabulary, ReferenceRole role,
+                                                         std::size_t parent_levels = 0)
+{
+	const auto selector = find_context_selector(store, vocabulary, parent_levels);
+	if (!selector)
+		return std::nullopt;
+	return store.find(reference_detail::role_marker(vocabulary, role), *selector);
+}
+
+inline LinkId realize_context_role_reference(LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                             ReferenceRole role, std::size_t parent_levels = 0)
+{
+	const LinkId selector = realize_context_selector(store, vocabulary, parent_levels);
+	return store.intern(reference_detail::role_marker(vocabulary, role), selector);
+}
+
+inline std::optional<LinkId> find_named_reference(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                                  LinkId target)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	if (!store.contains(target))
+		return std::nullopt;
+	return store.find(vocabulary.named_reference, target);
+}
+
+inline LinkId realize_named_reference(LinkStore &store, const ReferenceVocabulary &vocabulary, LinkId target)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	if (!store.contains(target))
+		throw std::invalid_argument("named reference target is not present in LinkStore");
+	return store.intern(vocabulary.named_reference, target);
+}
+
+inline std::optional<LinkId> find_reference_projection(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                                       ReferenceProjection projection, LinkId inner_reference)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	if (!store.contains(inner_reference))
+		return std::nullopt;
+	return store.find(reference_detail::projection_marker(vocabulary, projection), inner_reference);
+}
+
+inline LinkId realize_reference_projection(LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                           ReferenceProjection projection, LinkId inner_reference)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	if (!store.contains(inner_reference))
+		throw std::invalid_argument("inner reference is not present in LinkStore");
+	return store.intern(reference_detail::projection_marker(vocabulary, projection), inner_reference);
+}
+
+inline std::optional<LinkId> resolve_reference(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                               LinkId reference, const SemanticContextView &context,
+                                               std::size_t max_depth = 1000000)
+{
+	validate_reference_vocabulary(store, vocabulary);
+	if (!store.contains(reference))
+		return std::nullopt;
+
+	std::size_t remaining_depth = max_depth;
+	const auto resolve = [&](auto &&self, LinkId current) -> std::optional<LinkId>
+	{
+		if (remaining_depth == 0)
+			throw std::runtime_error("reference expression exceeds configured depth limit");
+		--remaining_depth;
+
+		if (!store.contains(current))
+			return std::nullopt;
+		const Link expression = store.get(current);
+
+		if (const auto role = reference_detail::marker_role(vocabulary, expression.begin))
+		{
+			const std::size_t parent_levels =
+			    reference_detail::context_selector_depth(store, vocabulary, expression.end, max_depth);
+			const LinkId value = context.ancestor(parent_levels).role(reference_detail::semantic_role(*role));
+			if (!store.contains(value))
+				return std::nullopt;
+			return value;
+		}
+
+		if (expression.begin == vocabulary.named_reference)
+			return expression.end;
+
+		const auto inner = self(self, expression.end);
+		if (!inner)
+			return std::nullopt;
+
+		if (expression.begin == vocabulary.begin_reference)
+			return store.get(*inner).begin;
+		if (expression.begin == vocabulary.end_reference)
+			return store.get(*inner).end;
+
+		if (expression.begin == vocabulary.relation_part_reference ||
+		    expression.begin == vocabulary.subject_part_reference || expression.begin == vocabulary.object_part_reference)
+		{
+			const RelationEntity entity = decode_relation_entity(store, *inner);
+			if (expression.begin == vocabulary.relation_part_reference)
+				return entity.relation;
+			if (expression.begin == vocabulary.subject_part_reference)
+				return entity.subject;
+			return entity.object;
+		}
+
+		throw std::runtime_error("LinkId is not a canonical reference expression");
+	};
+
+	return resolve(resolve, reference);
+}
+
+} // namespace avm

--- a/include/avm/reference.h
+++ b/include/avm/reference.h
@@ -4,6 +4,7 @@
 #include "avm/semantic_context.h"
 
 #include <cstddef>
+#include <limits>
 #include <optional>
 #include <set>
 #include <stdexcept>
@@ -158,12 +159,16 @@ inline std::size_t context_selector_depth(const LinkStore &store, const Referenc
 {
 	std::size_t depth = 0;
 	LinkId current = selector;
+	std::set<LinkId> visited;
 	while (current != vocabulary.current_context)
 	{
 		if (depth >= max_depth)
 			throw std::runtime_error("context selector exceeds configured depth limit");
 		if (!store.contains(current))
 			throw std::runtime_error("context selector references an unknown LinkId");
+		if (!visited.insert(current).second)
+			throw std::runtime_error("cycle detected in context selector");
+
 		const Link step = store.get(current);
 		if (step.begin != vocabulary.parent_context)
 			throw std::runtime_error("context selector is not Current or Parent(selector)");
@@ -200,9 +205,8 @@ inline LinkId realize_context_selector(LinkStore &store, const ReferenceVocabula
 	return selector;
 }
 
-inline std::optional<LinkId> find_context_role_reference(const LinkStore &store,
-                                                         const ReferenceVocabulary &vocabulary, ReferenceRole role,
-                                                         std::size_t parent_levels = 0)
+inline std::optional<LinkId> find_context_role_reference(const LinkStore &store, const ReferenceVocabulary &vocabulary,
+                                                         ReferenceRole role, std::size_t parent_levels = 0)
 {
 	const auto selector = find_context_selector(store, vocabulary, parent_levels);
 	if (!selector)
@@ -252,9 +256,9 @@ inline LinkId realize_reference_projection(LinkStore &store, const ReferenceVoca
 	return store.intern(reference_detail::projection_marker(vocabulary, projection), inner_reference);
 }
 
-inline std::optional<LinkId> resolve_reference(const LinkStore &store, const ReferenceVocabulary &vocabulary,
-                                               LinkId reference, const SemanticContextView &context,
-                                               std::size_t max_depth = 1000000)
+inline std::optional<LinkId> resolve_reference(
+    const LinkStore &store, const ReferenceVocabulary &vocabulary, LinkId reference, const SemanticContextView &context,
+    std::size_t max_depth = std::numeric_limits<std::size_t>::max())
 {
 	validate_reference_vocabulary(store, vocabulary);
 	if (!store.contains(reference))
@@ -282,7 +286,11 @@ inline std::optional<LinkId> resolve_reference(const LinkStore &store, const Ref
 		}
 
 		if (expression.begin == vocabulary.named_reference)
+		{
+			if (!store.contains(expression.end))
+				return std::nullopt;
 			return expression.end;
+		}
 
 		const auto inner = self(self, expression.end);
 		if (!inner)
@@ -293,13 +301,15 @@ inline std::optional<LinkId> resolve_reference(const LinkStore &store, const Ref
 		if (expression.begin == vocabulary.end_reference)
 			return store.get(*inner).end;
 
-		if (expression.begin == vocabulary.relation_part_reference ||
-		    expression.begin == vocabulary.subject_part_reference || expression.begin == vocabulary.object_part_reference)
+		const bool relation_part = expression.begin == vocabulary.relation_part_reference;
+		const bool subject_part = expression.begin == vocabulary.subject_part_reference;
+		const bool object_part = expression.begin == vocabulary.object_part_reference;
+		if (relation_part || subject_part || object_part)
 		{
 			const RelationEntity entity = decode_relation_entity(store, *inner);
-			if (expression.begin == vocabulary.relation_part_reference)
+			if (relation_part)
 				return entity.relation;
-			if (expression.begin == vocabulary.subject_part_reference)
+			if (subject_part)
 				return entity.subject;
 			return entity.object;
 		}

--- a/include/avm/reference.h
+++ b/include/avm/reference.h
@@ -292,29 +292,29 @@ inline std::optional<LinkId> resolve_reference(const LinkStore &store, const Ref
 			return expression.end;
 		}
 
+		const bool begin_projection = expression.begin == vocabulary.begin_reference;
+		const bool end_projection = expression.begin == vocabulary.end_reference;
+		const bool relation_part = expression.begin == vocabulary.relation_part_reference;
+		const bool subject_part = expression.begin == vocabulary.subject_part_reference;
+		const bool object_part = expression.begin == vocabulary.object_part_reference;
+		if (!begin_projection && !end_projection && !relation_part && !subject_part && !object_part)
+			throw std::runtime_error("LinkId is not a canonical reference expression");
+
 		const auto inner = self(self, expression.end);
 		if (!inner)
 			return std::nullopt;
 
-		if (expression.begin == vocabulary.begin_reference)
+		if (begin_projection)
 			return store.get(*inner).begin;
-		if (expression.begin == vocabulary.end_reference)
+		if (end_projection)
 			return store.get(*inner).end;
 
-		const bool relation_part = expression.begin == vocabulary.relation_part_reference;
-		const bool subject_part = expression.begin == vocabulary.subject_part_reference;
-		const bool object_part = expression.begin == vocabulary.object_part_reference;
-		if (relation_part || subject_part || object_part)
-		{
-			const RelationEntity entity = decode_relation_entity(store, *inner);
-			if (relation_part)
-				return entity.relation;
-			if (subject_part)
-				return entity.subject;
-			return entity.object;
-		}
-
-		throw std::runtime_error("LinkId is not a canonical reference expression");
+		const RelationEntity entity = decode_relation_entity(store, *inner);
+		if (relation_part)
+			return entity.relation;
+		if (subject_part)
+			return entity.subject;
+		return entity.object;
 	};
 
 	return resolve(resolve, reference);

--- a/test/reference_test.cpp
+++ b/test/reference_test.cpp
@@ -1,0 +1,198 @@
+#include "avm/persistent_link_store.h"
+#include "avm/reference.h"
+
+#include <cassert>
+#include <filesystem>
+#include <functional>
+
+namespace
+{
+
+bool rejected(const std::function<void()> &operation)
+{
+	try
+	{
+		operation();
+		return false;
+	}
+	catch (const std::exception &)
+	{
+		return true;
+	}
+}
+
+avm::SemanticContextFrame frame(avm::LinkStore &store)
+{
+	return avm::SemanticContextFrame{
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	};
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::ReferenceVocabulary vocabulary = avm::ReferenceVocabulary::create(store);
+	avm::validate_reference_vocabulary(store, vocabulary);
+
+	const avm::SemanticContextFrame root_frame = frame(store);
+	const avm::SemanticContextFrame child1_frame = frame(store);
+	const avm::SemanticContextFrame child2_frame = frame(store);
+	const avm::SemanticContextFrame child3_frame = frame(store);
+	const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+	const avm::SemanticContextView child1 = root.child(child1_frame);
+	const avm::SemanticContextView child2 = child1.child(child2_frame);
+	const avm::SemanticContextView child3 = child2.child(child3_frame);
+
+	const std::size_t before_find = store.size();
+	assert(!avm::find_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 3).has_value());
+	assert(store.size() == before_find);
+
+	const avm::LinkId current_entity =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Entity);
+	const avm::LinkId current_relation =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::RelationState);
+	const avm::LinkId current_subject =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject);
+	const avm::LinkId current_object =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Object);
+
+	assert(avm::resolve_reference(store, vocabulary, current_entity, child3) == child3_frame.entity);
+	assert(avm::resolve_reference(store, vocabulary, current_relation, child3) == child3_frame.relation_state);
+	assert(avm::resolve_reference(store, vocabulary, current_subject, child3) == child3_frame.subject);
+	assert(avm::resolve_reference(store, vocabulary, current_object, child3) == child3_frame.object);
+
+	const avm::LinkId parent_subject =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 1);
+	const avm::LinkId grandparent_subject =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 2);
+	const avm::LinkId root_subject =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 3);
+	const avm::LinkId saturated_subject =
+	    avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 100);
+
+	assert(avm::resolve_reference(store, vocabulary, parent_subject, child3) == child2_frame.subject);
+	assert(avm::resolve_reference(store, vocabulary, grandparent_subject, child3) == child1_frame.subject);
+	assert(avm::resolve_reference(store, vocabulary, root_subject, child3) == root_frame.subject);
+	assert(avm::resolve_reference(store, vocabulary, saturated_subject, child3) == root_frame.subject);
+
+	const std::size_t before_repeat = store.size();
+	assert(avm::realize_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 3) == root_subject);
+	assert(store.size() == before_repeat);
+	assert(avm::find_context_role_reference(store, vocabulary, avm::ReferenceRole::Subject, 3) == root_subject);
+
+	const avm::LinkId named_target = store.create_point();
+	const std::size_t before_named_find = store.size();
+	assert(!avm::find_named_reference(store, vocabulary, named_target).has_value());
+	assert(store.size() == before_named_find);
+	const avm::LinkId named = avm::realize_named_reference(store, vocabulary, named_target);
+	assert(avm::resolve_reference(store, vocabulary, named, child3) == named_target);
+	const std::size_t before_named_repeat = store.size();
+	assert(avm::realize_named_reference(store, vocabulary, named_target) == named);
+	assert(store.size() == before_named_repeat);
+
+	const avm::LinkId begin_value = store.create_point();
+	const avm::LinkId end_value = store.create_point();
+	const avm::LinkId pair = store.intern(begin_value, end_value);
+	const avm::LinkId pair_reference = avm::realize_named_reference(store, vocabulary, pair);
+	const avm::LinkId begin_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::Begin, pair_reference);
+	const avm::LinkId end_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::End, pair_reference);
+	assert(avm::resolve_reference(store, vocabulary, begin_reference, child3) == begin_value);
+	assert(avm::resolve_reference(store, vocabulary, end_reference, child3) == end_value);
+
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId entity = avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+	const avm::LinkId entity_reference = avm::realize_named_reference(store, vocabulary, entity);
+	const avm::LinkId relation_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::RelationPart, entity_reference);
+	const avm::LinkId subject_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::SubjectPart, entity_reference);
+	const avm::LinkId object_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::ObjectPart, entity_reference);
+	assert(avm::resolve_reference(store, vocabulary, relation_reference, child3) == relation);
+	assert(avm::resolve_reference(store, vocabulary, subject_reference, child3) == subject);
+	assert(avm::resolve_reference(store, vocabulary, object_reference, child3) == object);
+
+	const avm::LinkId nested_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::End, entity_reference);
+	const avm::LinkId nested_subject_reference =
+	    avm::realize_reference_projection(store, vocabulary, avm::ReferenceProjection::Begin, nested_reference);
+	assert(avm::resolve_reference(store, vocabulary, nested_subject_reference, child3) == subject);
+
+	const avm::LinkId controller_identity = store.create_point();
+	assert(controller_identity != child3_frame.relation_state);
+	assert(avm::resolve_reference(store, vocabulary, current_relation, child3) == child3_frame.relation_state);
+	assert(avm::resolve_reference(store, vocabulary, current_relation, child3) != controller_identity);
+
+	const avm::LinkId missing_reference = store.size() + 1000;
+	const std::size_t before_missing = store.size();
+	assert(!avm::resolve_reference(store, vocabulary, missing_reference, child3).has_value());
+	assert(store.size() == before_missing);
+
+	const avm::SemanticContextFrame missing_role_frame{
+	    child3_frame.entity,
+	    child3_frame.relation_state,
+	    store.size() + 2000,
+	    child3_frame.object,
+	};
+	const avm::SemanticContextView missing_role_context = child2.child(missing_role_frame);
+	const std::size_t before_missing_role = store.size();
+	assert(!avm::resolve_reference(store, vocabulary, current_subject, missing_role_context).has_value());
+	assert(store.size() == before_missing_role);
+
+	const avm::LinkId unknown_marker = store.create_point();
+	const avm::LinkId malformed_reference = store.intern(unknown_marker, named_target);
+	assert(rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, malformed_reference, child3)); }));
+
+	const avm::LinkId bad_selector = store.intern(vocabulary.named_reference, vocabulary.current_context);
+	const avm::LinkId bad_role_reference = store.intern(vocabulary.subject_role, bad_selector);
+	assert(rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, bad_role_reference, child3)); }));
+
+	assert(rejected([&]
+	                { static_cast<void>(avm::resolve_reference(store, vocabulary, saturated_subject, child3, 2)); }));
+
+	avm::ReferenceVocabulary duplicate_vocabulary = vocabulary;
+	duplicate_vocabulary.object_role = duplicate_vocabulary.subject_role;
+	assert(rejected([&] { avm::validate_reference_vocabulary(store, duplicate_vocabulary); }));
+
+	const std::filesystem::path persistent_path =
+	    std::filesystem::temp_directory_path() / "avm_reference_test.links";
+	std::filesystem::remove(persistent_path);
+
+	avm::ReferenceVocabulary persistent_vocabulary{};
+	avm::SemanticContextFrame persistent_root_frame{};
+	avm::SemanticContextFrame persistent_child_frame{};
+	avm::LinkId persistent_reference = avm::invalid_link_id;
+	{
+		avm::PersistentLinkStore persistent_store(persistent_path);
+		persistent_vocabulary = avm::ReferenceVocabulary::create(persistent_store);
+		persistent_root_frame = frame(persistent_store);
+		persistent_child_frame = frame(persistent_store);
+		persistent_reference = avm::realize_context_role_reference(
+		    persistent_store, persistent_vocabulary, avm::ReferenceRole::Object, 1);
+	}
+	{
+		avm::PersistentLinkStore reopened(persistent_path);
+		const avm::SemanticContextView persistent_context =
+		    avm::SemanticContextView::root(persistent_root_frame).child(persistent_child_frame);
+		const std::size_t before_resolve = reopened.size();
+		assert(avm::resolve_reference(reopened, persistent_vocabulary, persistent_reference, persistent_context) ==
+		       persistent_root_frame.object);
+		assert(reopened.size() == before_resolve);
+		const std::size_t before_realize = reopened.size();
+		assert(avm::realize_context_role_reference(reopened, persistent_vocabulary, avm::ReferenceRole::Object, 1) ==
+		       persistent_reference);
+		assert(reopened.size() == before_realize);
+	}
+	std::filesystem::remove(persistent_path);
+
+	return 0;
+}

--- a/test/reference_test.cpp
+++ b/test/reference_test.cpp
@@ -2,6 +2,7 @@
 #include "avm/reference.h"
 
 #include <cassert>
+#include <exception>
 #include <filesystem>
 #include <functional>
 
@@ -150,21 +151,25 @@ int main()
 
 	const avm::LinkId unknown_marker = store.create_point();
 	const avm::LinkId malformed_reference = store.intern(unknown_marker, named_target);
-	assert(rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, malformed_reference, child3)); }));
+	const bool malformed_rejected =
+	    rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, malformed_reference, child3)); });
+	assert(malformed_rejected);
 
 	const avm::LinkId bad_selector = store.intern(vocabulary.named_reference, vocabulary.current_context);
 	const avm::LinkId bad_role_reference = store.intern(vocabulary.subject_role, bad_selector);
-	assert(rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, bad_role_reference, child3)); }));
+	const bool bad_selector_rejected =
+	    rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, bad_role_reference, child3)); });
+	assert(bad_selector_rejected);
 
-	assert(rejected([&]
-	                { static_cast<void>(avm::resolve_reference(store, vocabulary, saturated_subject, child3, 2)); }));
+	const bool depth_rejected =
+	    rejected([&] { static_cast<void>(avm::resolve_reference(store, vocabulary, saturated_subject, child3, 2)); });
+	assert(depth_rejected);
 
 	avm::ReferenceVocabulary duplicate_vocabulary = vocabulary;
 	duplicate_vocabulary.object_role = duplicate_vocabulary.subject_role;
 	assert(rejected([&] { avm::validate_reference_vocabulary(store, duplicate_vocabulary); }));
 
-	const std::filesystem::path persistent_path =
-	    std::filesystem::temp_directory_path() / "avm_reference_test.links";
+	const std::filesystem::path persistent_path = std::filesystem::temp_directory_path() / "avm_reference_test.links";
 	std::filesystem::remove(persistent_path);
 
 	avm::ReferenceVocabulary persistent_vocabulary{};
@@ -176,8 +181,9 @@ int main()
 		persistent_vocabulary = avm::ReferenceVocabulary::create(persistent_store);
 		persistent_root_frame = frame(persistent_store);
 		persistent_child_frame = frame(persistent_store);
-		persistent_reference = avm::realize_context_role_reference(
-		    persistent_store, persistent_vocabulary, avm::ReferenceRole::Object, 1);
+		const auto object_role = avm::ReferenceRole::Object;
+		persistent_reference =
+		    avm::realize_context_role_reference(persistent_store, persistent_vocabulary, object_role, 1);
 	}
 	{
 		avm::PersistentLinkStore reopened(persistent_path);
@@ -187,9 +193,12 @@ int main()
 		assert(avm::resolve_reference(reopened, persistent_vocabulary, persistent_reference, persistent_context) ==
 		       persistent_root_frame.object);
 		assert(reopened.size() == before_resolve);
+
 		const std::size_t before_realize = reopened.size();
-		assert(avm::realize_context_role_reference(reopened, persistent_vocabulary, avm::ReferenceRole::Object, 1) ==
-		       persistent_reference);
+		const auto object_role = avm::ReferenceRole::Object;
+		const avm::LinkId repeated =
+		    avm::realize_context_role_reference(reopened, persistent_vocabulary, object_role, 1);
+		assert(repeated == persistent_reference);
 		assert(reopened.size() == before_realize);
 	}
 	std::filesystem::remove(persistent_path);


### PR DESCRIPTION
Closes #183. Part of #126/#122. Uses completed semantic context foundation #125.

## Что реализовано

Добавлен parser-free `include/avm/reference.h` с канонической reference algebra:

```text
ContextSelector := Current | Parent(ContextSelector)

Reference :=
    Role(ContextSelector, Entity|RelationState|Subject|Object)
  | Named(LinkId)
  | Begin(Reference)
  | End(Reference)
  | RelationPart(Reference)
  | SubjectPart(Reference)
  | ObjectPart(Reference)
```

## Representation

`ReferenceVocabulary` задаёт независимые anchors. Dynamic semantic context **не materialize-ится**.

```text
Current          = current_context
Parent(X)        = Link(parent_context, X)
Role(X, Subject) = Link(subject_role, X)
Named(A)         = Link(named_reference, A)
Begin(R)         = Link(begin_reference, R)
...
```

Материализуется только reference expression.

## API

Разделены:

- `find_context_selector` / `realize_context_selector`;
- `find_context_role_reference` / `realize_context_role_reference`;
- `find_named_reference` / `realize_named_reference`;
- `find_reference_projection` / `realize_reference_projection`;
- `resolve_reference` — только наблюдение существующего store + `SemanticContextView`.

## Критический context contract

`ReferenceRole::RelationState` разрешается через:

```text
SemanticContextRole::RelationState
```

и **никогда** не означает `ExecutionContext.relation` controller identity.

`Parent^N(Current)` вычисляет глубину структурно, затем применяет `SemanticContextView::ancestor(N)`. Поэтому traversal выше root saturates на root без materialization dynamic context.

## Structural projections

- `Begin/End` наблюдающе читают `Link{begin,end}`;
- `RelationPart/SubjectPart/ObjectPart` используют canonical `decode_relation_entity`;
- `Named(LinkId)` не делает database/API lookup и не содержит текстового имени.

## Conformance

Новый `reference_test` проверяет:

- current Entity/RelationState/Subject/Object;
- parent traversal 1/2/3/100 уровней;
- root saturation;
- `$rel`-эквивалент != controller identity;
- find miss без store mutation;
- repeated realize idempotent;
- Named identity;
- Begin/End;
- Relation/Subject/Object parts;
- nested structural projection;
- missing role identity -> observational miss;
- malformed marker/selector -> deterministic error;
- configurable depth guard;
- duplicate vocabulary reject;
- persistent close/reopen + same canonical reference identity.

## Veto соблюдён

Нет:

- string `$ent` parsing в core;
- JSON pointer/member traversal;
- hidden DB fetch;
- implicit materialization в resolve;
- dynamic context links;
- второго Executor.

## Документация

Добавлен русский контракт `docs/reference-algebra.md`.

Следующий gate #184 компилирует legacy textual `$ent/$$obj/...` и explicit known names в эту структуру как frontend adapter.