### PR TITLE
AVM 1.5: компилировать `$ent/$$obj/...` в canonical references

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,14 @@ if(AVM_BUILD_CORE_TESTS)
         protocol_adapter_boundary_tests)
     avm_add_core_test(avm_persistent_link_store_test test/persistent_link_store_test.cpp persistent_link_store_tests)
 
+    add_executable(avm_legacy_reference_compiler_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/legacy_reference_compiler_test.cpp")
+    target_link_libraries(avm_legacy_reference_compiler_test PRIVATE avm_core)
+    target_include_directories(avm_legacy_reference_compiler_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/adapters")
+    avm_apply_quality(avm_legacy_reference_compiler_test)
+    avm_enable_test_assertions(avm_legacy_reference_compiler_test)
+    add_test(NAME legacy_reference_compiler_tests COMMAND avm_legacy_reference_compiler_test)
+
     add_executable(avm_inspection_session_test "${CMAKE_CURRENT_SOURCE_DIR}/test/inspection_session_test.cpp")
     target_link_libraries(avm_inspection_session_test PRIVATE avm_core)
     target_include_directories(avm_inspection_session_test PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/tools")
@@ -294,6 +302,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_raw_carrier_test
         avm_protocol_adapter_boundary_test
         avm_persistent_link_store_test
+        avm_legacy_reference_compiler_test
         avm_inspection_session_test
         avm_persistent_inspection_session_test
         avm_vertical_slice_test

--- a/adapters/legacy_reference_compiler.h
+++ b/adapters/legacy_reference_compiler.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include "avm/projection.h"
+#include "avm/reference.h"
+
+#include <map>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace avm::legacy_reference
+{
+
+class CompileError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+using NamedAnchors = std::map<std::string, LinkId>;
+
+namespace detail
+{
+
+inline std::vector<std::string_view> split_path(std::string_view source)
+{
+	if (source.empty())
+		throw CompileError("legacy reference is empty");
+
+	std::vector<std::string_view> segments;
+	std::size_t begin = 0;
+	while (begin <= source.size())
+	{
+		const std::size_t slash = source.find('/', begin);
+		const std::size_t end = slash == std::string_view::npos ? source.size() : slash;
+		if (end == begin)
+			throw CompileError("legacy reference contains an empty path segment");
+		segments.push_back(source.substr(begin, end - begin));
+		if (slash == std::string_view::npos)
+			break;
+		begin = slash + 1;
+	}
+	return segments;
+}
+
+inline LinkId role_marker(const ReferenceVocabulary &vocabulary, ReferenceRole role)
+{
+	switch (role)
+	{
+	case ReferenceRole::Entity:
+		return vocabulary.entity_role;
+	case ReferenceRole::RelationState:
+		return vocabulary.relation_state_role;
+	case ReferenceRole::Subject:
+		return vocabulary.subject_role;
+	case ReferenceRole::Object:
+		return vocabulary.object_role;
+	}
+	throw std::logic_error("unknown legacy reference role");
+}
+
+inline ReferenceRole parse_role(std::string_view role)
+{
+	if (role == "ent")
+		return ReferenceRole::Entity;
+	if (role == "rel")
+		return ReferenceRole::RelationState;
+	if (role == "sub")
+		return ReferenceRole::Subject;
+	if (role == "obj")
+		return ReferenceRole::Object;
+	throw CompileError("unknown legacy context role");
+}
+
+inline LinkId projection_marker(const ReferenceVocabulary &vocabulary, std::string_view segment)
+{
+	if (segment == "begin")
+		return vocabulary.begin_reference;
+	if (segment == "end")
+		return vocabulary.end_reference;
+	if (segment == "relation")
+		return vocabulary.relation_part_reference;
+	if (segment == "subject")
+		return vocabulary.subject_part_reference;
+	if (segment == "object")
+		return vocabulary.object_part_reference;
+	throw CompileError("unsupported legacy path segment; JSON member traversal is not a canonical AVM reference");
+}
+
+class ProjectionBuilder
+{
+public:
+	explicit ProjectionBuilder(const ReferenceVocabulary &vocabulary) : vocabulary_(vocabulary) {}
+
+	ProjectionRef context_reference(std::string_view source)
+	{
+		std::size_t dollars = 0;
+		while (dollars < source.size() && source[dollars] == '$')
+			++dollars;
+		if (dollars == 0 || dollars == source.size())
+			throw CompileError("malformed legacy context reference");
+
+		const ReferenceRole role = parse_role(source.substr(dollars));
+		ProjectionRef selector = ProjectionRef::anchor(vocabulary_.current_context);
+		for (std::size_t level = 1; level < dollars; ++level)
+			selector = append(vocabulary_.parent_context, selector);
+		return append(role_marker(vocabulary_, role), selector);
+	}
+
+	ProjectionRef named_reference(std::string_view name, const NamedAnchors &names)
+	{
+		const auto target = names.find(std::string(name));
+		if (target == names.end())
+			throw CompileError("unknown legacy absolute reference name");
+		if (target->second == invalid_link_id)
+			throw CompileError("legacy absolute reference resolves to invalid LinkId 0");
+		return append(vocabulary_.named_reference, ProjectionRef::anchor(target->second));
+	}
+
+	ProjectionRef structural_projection(std::string_view segment, ProjectionRef inner)
+	{
+		return append(projection_marker(vocabulary_, segment), inner);
+	}
+
+	ProjectionDescription finish(ProjectionRef root)
+	{
+		description_.root = root;
+		return description_;
+	}
+
+private:
+	ProjectionRef append(LinkId marker, ProjectionRef end)
+	{
+		const ProjectionNodeId node_id = description_.nodes.size();
+		description_.nodes.push_back(ProjectionNode{ProjectionRef::anchor(marker), end});
+		return ProjectionRef::node(node_id);
+	}
+
+	const ReferenceVocabulary &vocabulary_;
+	ProjectionDescription description_{};
+};
+
+} // namespace detail
+
+inline ProjectionDescription compile(std::string_view source, const ReferenceVocabulary &vocabulary,
+                                     const NamedAnchors &names = {})
+{
+	const std::vector<std::string_view> segments = detail::split_path(source);
+	detail::ProjectionBuilder builder(vocabulary);
+
+	ProjectionRef reference = segments.front().front() == '$' ? builder.context_reference(segments.front())
+	                                                        : builder.named_reference(segments.front(), names);
+	for (std::size_t index = 1; index < segments.size(); ++index)
+		reference = builder.structural_projection(segments[index], reference);
+	return builder.finish(reference);
+}
+
+} // namespace avm::legacy_reference

--- a/adapters/legacy_reference_compiler.h
+++ b/adapters/legacy_reference_compiler.h
@@ -149,8 +149,9 @@ inline ProjectionDescription compile(std::string_view source, const ReferenceVoc
 	const std::vector<std::string_view> segments = detail::split_path(source);
 	detail::ProjectionBuilder builder(vocabulary);
 
-	ProjectionRef reference = segments.front().front() == '$' ? builder.context_reference(segments.front())
-	                                                        : builder.named_reference(segments.front(), names);
+	ProjectionRef reference = builder.named_reference(segments.front(), names);
+	if (segments.front().front() == '$')
+		reference = builder.context_reference(segments.front());
 	for (std::size_t index = 1; index < segments.size(); ++index)
 		reference = builder.structural_projection(segments[index], reference);
 	return builder.finish(reference);

--- a/adapters/legacy_reference_compiler.h
+++ b/adapters/legacy_reference_compiler.h
@@ -93,6 +93,25 @@ class ProjectionBuilder
 public:
 	explicit ProjectionBuilder(const ReferenceVocabulary &vocabulary) : vocabulary_(vocabulary) {}
 
+	ProjectionRef base_reference(std::string_view source, const NamedAnchors &names)
+	{
+		if (source.front() == '$')
+			return context_reference(source);
+		return named_reference(source, names);
+	}
+
+	ProjectionRef structural_projection(std::string_view segment, ProjectionRef inner)
+	{
+		return append(projection_marker(vocabulary_, segment), inner);
+	}
+
+	ProjectionDescription finish(ProjectionRef root)
+	{
+		description_.root = root;
+		return description_;
+	}
+
+private:
 	ProjectionRef context_reference(std::string_view source)
 	{
 		std::size_t dollars = 0;
@@ -118,18 +137,6 @@ public:
 		return append(vocabulary_.named_reference, ProjectionRef::anchor(target->second));
 	}
 
-	ProjectionRef structural_projection(std::string_view segment, ProjectionRef inner)
-	{
-		return append(projection_marker(vocabulary_, segment), inner);
-	}
-
-	ProjectionDescription finish(ProjectionRef root)
-	{
-		description_.root = root;
-		return description_;
-	}
-
-private:
 	ProjectionRef append(LinkId marker, ProjectionRef end)
 	{
 		const ProjectionNodeId node_id = description_.nodes.size();
@@ -149,9 +156,7 @@ inline ProjectionDescription compile(std::string_view source, const ReferenceVoc
 	const std::vector<std::string_view> segments = detail::split_path(source);
 	detail::ProjectionBuilder builder(vocabulary);
 
-	ProjectionRef reference = builder.named_reference(segments.front(), names);
-	if (segments.front().front() == '$')
-		reference = builder.context_reference(segments.front());
+	ProjectionRef reference = builder.base_reference(segments.front(), names);
 	for (std::size_t index = 1; index < segments.size(); ++index)
 		reference = builder.structural_projection(segments[index], reference);
 	return builder.finish(reference);

--- a/docs/legacy-reference-compiler.md
+++ b/docs/legacy-reference-compiler.md
@@ -1,0 +1,249 @@
+# Компилятор legacy-ссылок jsonRVM в AVM
+
+Родительская задача: #184. Родительский gate: #126. Каноническая алгебра: #183.
+
+## Назначение
+
+Синтаксис ссылок старого `jsonRVM` не становится runtime-языком AVM.
+
+Он существует только на frontend boundary:
+
+```text
+legacy source string
+ -> legacy_reference::compile
+ -> ProjectionDescription
+ -> find_projection | realize_projection
+ -> canonical Reference LinkId
+ -> resolve_reference
+```
+
+Сам compiler:
+
+- не принимает `LinkStore`;
+- не вызывает `find`, `intern` или `create_point`;
+- не знает `Executor`;
+- не выполняет database lookup;
+- не интерпретирует JSON containers;
+- не хранит global current context.
+
+## Контекстные местоимения
+
+Поддерживается точная форма:
+
+```text
+$ent
+$rel
+$sub
+$obj
+$$ent
+$$rel
+$$sub
+$$obj
+$$$...
+```
+
+Количество `$` определяет parent depth:
+
+```text
+N знаков '$'
+ -> Parent^(N - 1)(Current)
+```
+
+После этого выбирается роль:
+
+```text
+ent -> Entity
+rel -> RelationState
+sub -> Subject
+obj -> Object
+```
+
+Критически важно:
+
+```text
+$rel -> SemanticContextRole::RelationState
+```
+
+а не `ExecutionContext.relation` controller identity.
+
+Traversal выше root не требует отдельного правила compiler-а. После materialization canonical reference разрешается через `SemanticContextView::ancestor(N)`, который saturate-ится на root.
+
+## Соответствие frozen jsonRVM evidence
+
+`compat/jsonrvm-golden.json` фиксирует `CASE-RELATIVE-ADDRESSING` из jsonRVM commit:
+
+```text
+843b3326141e090ccd1a106ba0a4a21ce72805b7
+```
+
+Там наблюдаются группы:
+
+```text
+$ent  $rel  $sub  $obj
+$$ent $$rel $$sub $$obj
+$$$ent ...
+$$$$ent ...
+```
+
+AVM сохраняет **денотацию context depth + role**, а не старую JSON-container representation результата.
+
+Например старый observable path:
+
+```text
+$$$$sub/id
+```
+
+разделяется на два понятия:
+
+1. `$$$$sub` — semantic reference, переносится в canonical AVM reference;
+2. `/id` — доступ к полю старого JSON container, не является частью reference semantics AVM.
+
+Поэтому compiler принимает `$$$$sub`, но детерминированно отвергает `$$$$sub/id`.
+
+## Абсолютные имена
+
+Поддерживается pure named resolution через таблицу, явно принадлежащую caller-у:
+
+```text
+"ent1" -> LinkId X
+"ent2" -> LinkId Y
+```
+
+Source:
+
+```text
+ent1
+```
+
+компилируется в projection для:
+
+```text
+Named(X)
+```
+
+Compiler не проверяет store existence `X`, потому что store ему недоступен.
+
+Дальше policy разделена:
+
+- `find_projection` даст miss, если anchor отсутствует;
+- `realize_projection` отвергнет отсутствующий anchor до mutation;
+- никакого implicit `create_point` или database fetch нет.
+
+Неизвестное текстовое имя — `CompileError`.
+
+Это переносит чистую часть `CASE-ABSOLUTE-ADDRESSING`, не перенося скрытый storage lookup jsonRVM.
+
+## Структурные суффиксы AVM
+
+После базовой ссылки разрешены только операции, имеющие точный смысл в модели связей:
+
+```text
+/begin
+/end
+/relation
+/subject
+/object
+```
+
+Примеры:
+
+```text
+pair/begin
+entity/subject
+entity/end/begin
+$ent/end
+```
+
+Они компилируются композиционно в:
+
+```text
+Begin(reference)
+End(reference)
+RelationPart(reference)
+SubjectPart(reference)
+ObjectPart(reference)
+```
+
+и затем разрешаются canonical `resolve_reference`.
+
+## Что намеренно отвергается
+
+### JSON member paths
+
+Не поддерживаются:
+
+```text
+$ent/id
+ent1/id
+ent1/val
+ent1/val/id
+```
+
+`id` и `val` не имеют встроенного structural meaning в AVM.
+
+### Индексы JSON-массивов
+
+Не поддерживается:
+
+```text
+ent1/0
+```
+
+Ordered collection semantics относится к отдельному data-model gate, а не к reference compiler.
+
+### Неявные имена
+
+Не поддерживается обращение к неизвестному имени с попыткой загрузить его из базы.
+
+### Lvalue creation
+
+Read/reference compiler ничего не создаёт в target model. Старое write-time создание JSON member не смешивается с pure reference semantics.
+
+## Грамматика
+
+```text
+LegacyReference := Base StructuralSuffix*
+
+Base := ContextRole | AbsoluteName
+
+ContextRole := '$'+ ('ent' | 'rel' | 'sub' | 'obj')
+AbsoluteName := caller-known exact name
+
+StructuralSuffix :=
+    '/begin'
+  | '/end'
+  | '/relation'
+  | '/subject'
+  | '/object'
+```
+
+Пустые path segments запрещены.
+
+## Почему результат — ProjectionDescription
+
+Compiler не возвращает сразу `LinkId`.
+
+Это принципиально сохраняет общий AVM pipeline:
+
+```text
+syntax
+ -> neutral structural projection
+ -> explicit find или realize
+```
+
+Следовательно даже frontend compiler конструктивно не способен скрыто materialize canonical reference expression.
+
+Одинаковый source при одинаковых vocabulary/names после `realize_projection` сходится к одному canonical `LinkId` через обычный `LinkStore::intern`.
+
+## Инварианты
+
+1. compiler не зависит от `LinkStore` и `Executor`;
+2. `$rel` означает semantic `RelationState`;
+3. arbitrary `$` depth композиционен;
+4. неизвестное имя не вызывает hidden lookup;
+5. JSON member traversal не маскируется под AVM reference;
+6. structural suffix состоит только из операций канонической алгебры #183;
+7. compile не materialize;
+8. `find_projection` остаётся наблюдающим;
+9. `realize_projection` — единственная materialization boundary;
+10. textual legacy syntax не попадает в AVM core.

--- a/docs/legacy-reference-compiler.md
+++ b/docs/legacy-reference-compiler.md
@@ -168,7 +168,7 @@ ObjectPart(reference)
 
 ## Что намеренно отвергается
 
-### JSON member paths
+### Пути к членам JSON
 
 Не поддерживаются:
 
@@ -195,7 +195,7 @@ Ordered collection semantics относится к отдельному data-mod
 
 Не поддерживается обращение к неизвестному имени с попыткой загрузить его из базы.
 
-### Lvalue creation
+### Создание lvalue
 
 Read/reference compiler ничего не создаёт в target model. Старое write-time создание JSON member не смешивается с pure reference semantics.
 

--- a/test/legacy_reference_compiler_test.cpp
+++ b/test/legacy_reference_compiler_test.cpp
@@ -1,0 +1,196 @@
+#include "legacy_reference_compiler.h"
+
+#include "avm/projection.h"
+#include "avm/reference.h"
+#include "avm/relations_model.h"
+#include "avm/semantic_context.h"
+
+#include <array>
+#include <cassert>
+#include <functional>
+#include <string_view>
+
+namespace
+{
+
+bool compile_rejected(std::string_view source, const avm::ReferenceVocabulary &vocabulary,
+                      const avm::legacy_reference::NamedAnchors &names = {})
+{
+	try
+	{
+		static_cast<void>(avm::legacy_reference::compile(source, vocabulary, names));
+		return false;
+	}
+	catch (const avm::legacy_reference::CompileError &)
+	{
+		return true;
+	}
+}
+
+avm::SemanticContextFrame frame(avm::LinkStore &store)
+{
+	return avm::SemanticContextFrame{
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	};
+}
+
+avm::LinkId compile_realize_resolve(avm::LinkStore &store, const avm::ReferenceVocabulary &vocabulary,
+                                    const avm::SemanticContextView &context, std::string_view source,
+                                    const avm::legacy_reference::NamedAnchors &names = {})
+{
+	const avm::ProjectionDescription description = avm::legacy_reference::compile(source, vocabulary, names);
+	const avm::LinkId reference = avm::realize_projection(store, description).root;
+	const auto result = avm::resolve_reference(store, vocabulary, reference, context);
+	assert(result.has_value());
+	return *result;
+}
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::ReferenceVocabulary vocabulary = avm::ReferenceVocabulary::create(store);
+
+	const avm::SemanticContextFrame root_frame = frame(store);
+	const avm::SemanticContextFrame child1_frame = frame(store);
+	const avm::SemanticContextFrame child2_frame = frame(store);
+	const avm::SemanticContextFrame child3_frame = frame(store);
+	const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+	const avm::SemanticContextView child1 = root.child(child1_frame);
+	const avm::SemanticContextView child2 = child1.child(child2_frame);
+	const avm::SemanticContextView child3 = child2.child(child3_frame);
+
+	struct RelativeCase
+	{
+		std::string_view source;
+		avm::LinkId expected;
+	};
+
+	const std::array<RelativeCase, 16> relative_cases{{
+	    {"$ent", child3_frame.entity},
+	    {"$rel", child3_frame.relation_state},
+	    {"$sub", child3_frame.subject},
+	    {"$obj", child3_frame.object},
+	    {"$$ent", child2_frame.entity},
+	    {"$$rel", child2_frame.relation_state},
+	    {"$$sub", child2_frame.subject},
+	    {"$$obj", child2_frame.object},
+	    {"$$$ent", child1_frame.entity},
+	    {"$$$rel", child1_frame.relation_state},
+	    {"$$$sub", child1_frame.subject},
+	    {"$$$obj", child1_frame.object},
+	    {"$$$$ent", root_frame.entity},
+	    {"$$$$rel", root_frame.relation_state},
+	    {"$$$$sub", root_frame.subject},
+	    {"$$$$obj", root_frame.object},
+	}};
+
+	for (const RelativeCase &test_case : relative_cases)
+	{
+		const std::size_t before_compile = store.size();
+		const avm::ProjectionDescription description =
+		    avm::legacy_reference::compile(test_case.source, vocabulary);
+		assert(store.size() == before_compile);
+
+		const std::size_t before_find = store.size();
+		assert(!avm::find_projection(store, description).has_value());
+		assert(store.size() == before_find);
+
+		const avm::LinkId reference = avm::realize_projection(store, description).root;
+		assert(avm::resolve_reference(store, vocabulary, reference, child3) == test_case.expected);
+
+		const std::size_t before_repeat = store.size();
+		const avm::ProjectionDescription repeated_description =
+		    avm::legacy_reference::compile(test_case.source, vocabulary);
+		assert(avm::realize_projection(store, repeated_description).root == reference);
+		assert(store.size() == before_repeat);
+	}
+
+	assert(compile_realize_resolve(store, vocabulary, child3, "$$$$$$$$sub") == root_frame.subject);
+
+	const avm::LinkId controller_identity = store.create_point();
+	assert(controller_identity != child3_frame.relation_state);
+	assert(compile_realize_resolve(store, vocabulary, child3, "$rel") == child3_frame.relation_state);
+	assert(compile_realize_resolve(store, vocabulary, child3, "$rel") != controller_identity);
+
+	const avm::LinkId ent1 = store.create_point();
+	const avm::LinkId ent2 = store.create_point();
+	avm::legacy_reference::NamedAnchors names;
+	names.emplace("ent1", ent1);
+	names.emplace("ent2", ent2);
+	assert(compile_realize_resolve(store, vocabulary, child3, "ent1", names) == ent1);
+	assert(compile_realize_resolve(store, vocabulary, child3, "ent2", names) == ent2);
+
+	const avm::LinkId begin = store.create_point();
+	const avm::LinkId end = store.create_point();
+	const avm::LinkId pair = store.intern(begin, end);
+	names.emplace("pair", pair);
+	assert(compile_realize_resolve(store, vocabulary, child3, "pair/begin", names) == begin);
+	assert(compile_realize_resolve(store, vocabulary, child3, "pair/end", names) == end);
+
+	const avm::LinkId relation = store.create_point();
+	const avm::LinkId subject = store.create_point();
+	const avm::LinkId object = store.create_point();
+	const avm::LinkId relation_entity =
+	    avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+	names.emplace("relation_entity", relation_entity);
+	assert(compile_realize_resolve(store, vocabulary, child3, "relation_entity/relation", names) == relation);
+	assert(compile_realize_resolve(store, vocabulary, child3, "relation_entity/subject", names) == subject);
+	assert(compile_realize_resolve(store, vocabulary, child3, "relation_entity/object", names) == object);
+	assert(compile_realize_resolve(store, vocabulary, child3, "relation_entity/end/begin", names) == subject);
+
+	const avm::LinkId child_entity = child3_frame.entity;
+	const avm::Link child_entity_link = store.get(child_entity);
+	assert(compile_realize_resolve(store, vocabulary, child3, "$ent/begin") == child_entity_link.begin);
+	assert(compile_realize_resolve(store, vocabulary, child3, "$ent/end") == child_entity_link.end);
+
+	assert(compile_rejected("", vocabulary, names));
+	assert(compile_rejected("$", vocabulary, names));
+	assert(compile_rejected("$$", vocabulary, names));
+	assert(compile_rejected("$foo", vocabulary, names));
+	assert(compile_rejected("ent", vocabulary, names));
+	assert(compile_rejected("missing", vocabulary, names));
+	assert(compile_rejected("/ent1", vocabulary, names));
+	assert(compile_rejected("ent1/", vocabulary, names));
+	assert(compile_rejected("ent1//begin", vocabulary, names));
+
+	// Frozen jsonRVM evidence contains /id and /val as JSON-container access.
+	// They are deliberately not promoted into canonical AVM reference semantics.
+	assert(compile_rejected("$ent/id", vocabulary, names));
+	assert(compile_rejected("$$$$sub/id", vocabulary, names));
+	assert(compile_rejected("ent1/id", vocabulary, names));
+	assert(compile_rejected("ent1/val", vocabulary, names));
+	assert(compile_rejected("ent1/0", vocabulary, names));
+	assert(compile_rejected("ent1/val/id", vocabulary, names));
+
+	avm::legacy_reference::NamedAnchors invalid_names;
+	invalid_names.emplace("invalid", avm::invalid_link_id);
+	assert(compile_rejected("invalid", vocabulary, invalid_names));
+
+	avm::legacy_reference::NamedAnchors unknown_target_names;
+	const avm::LinkId unknown_target = store.size() + 1000;
+	unknown_target_names.emplace("future", unknown_target);
+	const avm::ProjectionDescription unknown_target_description =
+	    avm::legacy_reference::compile("future", vocabulary, unknown_target_names);
+	const std::size_t before_unknown_find = store.size();
+	assert(!avm::find_projection(store, unknown_target_description).has_value());
+	assert(store.size() == before_unknown_find);
+
+	bool unknown_realize_rejected = false;
+	try
+	{
+		static_cast<void>(avm::realize_projection(store, unknown_target_description));
+	}
+	catch (const std::invalid_argument &)
+	{
+		unknown_realize_rejected = true;
+	}
+	assert(unknown_realize_rejected);
+	assert(store.size() == before_unknown_find);
+
+	return 0;
+}

--- a/test/legacy_reference_compiler_test.cpp
+++ b/test/legacy_reference_compiler_test.cpp
@@ -103,7 +103,8 @@ int main()
 		assert(avm::resolve_reference(store, vocabulary, reference, child3) == test_case.expected);
 
 		const std::size_t before_repeat = store.size();
-		const avm::ProjectionDescription repeated_description = avm::legacy_reference::compile(test_case.source, vocabulary);
+		const avm::ProjectionDescription repeated_description =
+		    avm::legacy_reference::compile(test_case.source, vocabulary);
 		assert(avm::realize_projection(store, repeated_description).root == reference);
 		assert(store.size() == before_repeat);
 	}

--- a/test/legacy_reference_compiler_test.cpp
+++ b/test/legacy_reference_compiler_test.cpp
@@ -92,8 +92,7 @@ int main()
 	for (const RelativeCase &test_case : relative_cases)
 	{
 		const std::size_t before_compile = store.size();
-		const avm::ProjectionDescription description =
-		    avm::legacy_reference::compile(test_case.source, vocabulary);
+		const avm::ProjectionDescription description = avm::legacy_reference::compile(test_case.source, vocabulary);
 		assert(store.size() == before_compile);
 
 		const std::size_t before_find = store.size();
@@ -104,8 +103,7 @@ int main()
 		assert(avm::resolve_reference(store, vocabulary, reference, child3) == test_case.expected);
 
 		const std::size_t before_repeat = store.size();
-		const avm::ProjectionDescription repeated_description =
-		    avm::legacy_reference::compile(test_case.source, vocabulary);
+		const avm::ProjectionDescription repeated_description = avm::legacy_reference::compile(test_case.source, vocabulary);
 		assert(avm::realize_projection(store, repeated_description).root == reference);
 		assert(store.size() == before_repeat);
 	}


### PR DESCRIPTION
Closes #184. Part of #126/#122. Depends on merged #183/#185.

## Что реализовано

Добавлен `adapters/legacy_reference_compiler.h`:

```text
legacy source string
 -> ProjectionDescription
 -> find_projection | realize_projection
 -> canonical Reference LinkId
 -> resolve_reference
```

Compiler конструктивно не принимает `LinkStore` и не может materialize links.

## Контекстные ссылки

Поддерживается точная форма:

```text
$ent  $rel  $sub  $obj
$$ent $$rel $$sub $$obj
$$$...
```

`N` знаков `$` компилируются в `Parent^(N-1)(Current)`.

`$rel` всегда компилируется в `ReferenceRole::RelationState`, не в controller identity.

## Frozen jsonRVM evidence

Conformance покрывает все 16 role/depth комбинаций из `CASE-RELATIVE-ADDRESSING` (`$`...`$$$$`, ent/rel/sub/obj) для pinned jsonRVM commit `843b3326141e090ccd1a106ba0a4a21ce72805b7`.

Старый `/id` в путях вроде `$$$$sub/id` трактуется как JSON-container representation и намеренно не становится AVM reference semantics.

## Абсолютные имена

Caller явно передаёт:

```text
"ent1" -> LinkId X
```

Compiler строит `Named(X)` projection. Unknown name — deterministic `CompileError`; database fetch/create point отсутствуют.

Имя может содержать ненулевой target, которого ещё нет в store: compiler остаётся чистым, `find_projection` даёт miss, `realize_projection` отвергает отсутствующий anchor до mutation.

## Структурные суффиксы

Разрешены только AVM-операции:

```text
/begin
/end
/relation
/subject
/object
```

Они композиционно строят canonical `Begin/End/RelationPart/SubjectPart/ObjectPart` references.

Намеренно отвергаются:

```text
/id
/val
/0
/val/id
```

то есть JSON pointer/member/index traversal не возвращается в runtime.

## Conformance

Новый test проверяет:

- 16 frozen relative role/depth cases;
- root saturation при большой `$`-глубине;
- `$rel -> relation_state`;
- `ent1/ent2` explicit name resolution;
- pair begin/end;
- RelationEntity relation/subject/object;
- nested `/end/begin`;
- structural suffix после context role;
- malformed/unknown names/path segments;
- `/id`, `/val`, numeric path reject;
- compile не меняет store;
- find miss не пишет;
- repeated realize canonical/idempotent;
- unknown future anchor: find miss и realize fail без mutation.

## Veto соблюдён

Нет string switch в Executor, JSON pointer parser в core, hidden DB lookup, lvalue create-on-read, global name registry или второго executor.