### PR TITLE
AVM 1.5: deterministic foreach по ordered link-list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/execution_outcome.h
     include/avm/execution_trace.h
     include/avm/executor.h
+    include/avm/foreach_runtime.h
     include/avm/integer_value.h
     include/avm/link_store.h
     include/avm/persistent_link_store.h
@@ -197,6 +198,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_semantic_execution_outcome_test
         test/semantic_execution_outcome_test.cpp
         semantic_execution_outcome_tests)
+    avm_add_core_test(avm_foreach_runtime_test test/foreach_runtime_test.cpp foreach_runtime_tests)
     avm_add_core_test(avm_integer_value_test test/integer_value_test.cpp integer_value_tests)
     avm_add_core_test(avm_text_value_test test/text_value_test.cpp text_value_tests)
     avm_add_core_test(avm_reference_test test/reference_test.cpp reference_tests)
@@ -284,6 +286,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_executor_test
         avm_semantic_context_test
         avm_semantic_execution_outcome_test
+        avm_foreach_runtime_test
         avm_integer_value_test
         avm_text_value_test
         avm_reference_test

--- a/docs/foreach-runtime.md
+++ b/docs/foreach-runtime.md
@@ -186,7 +186,7 @@ AVM conformance воспроизводит semantic denotation:
 
 Старый JSON wrapper `/result` не переносится как часть foreach semantics.
 
-## Observer contract
+## Контракт наблюдения
 
 Каждый body запускается обычным `Executor`.
 

--- a/docs/foreach-runtime.md
+++ b/docs/foreach-runtime.md
@@ -1,0 +1,213 @@
+# Детерминированный foreach в AVM
+
+Родительская задача: #187. Родительский gate: #127. Контекст исполнения: #125.
+
+## Назначение
+
+Старый `jsonRVM` имел операции `foreachobj` и `foreachsub`, связанные с JSON containers и mutable `vm_ctx`.
+
+AVM переносит только наблюдаемую вычислительную семантику:
+
+- ordered collection;
+- отдельный child context для каждого элемента;
+- ориентация item через `subject` или `object`;
+- ordered body results;
+- fail-fast;
+- обычный `Executor` и обычные observer events.
+
+JSON array/object как runtime-тип для этого не нужен.
+
+## Нормативная форма
+
+Используются две отдельные relation identity:
+
+```text
+(foreach_object, body, collection)
+(foreach_subject, body, collection)
+```
+
+Канонический триплет кодируется как обычно:
+
+```text
+Link(relation, Link(body, collection))
+```
+
+`body` — обычный executable `LinkId`.
+
+`collection` — ordered link-list из `program_model.h`, завершающийся явно переданной identity `list_nil`.
+
+## Почему body находится в subject выражения
+
+Direct triune entity имеет роли:
+
+```text
+relation = foreach orientation
+subject  = body
+object   = collection
+```
+
+Это не означает, что semantic child `$sub` обязан быть body.
+
+Execution entity и semantic context — разные уровни. Для каждой итерации body исполняется как обычная executable identity, а semantic child frame задаётся отдельно.
+
+## `foreach_object`
+
+Для каждого `item` из коллекции создаётся новый child:
+
+```text
+child.entity         = parent.entity
+child.relation_state = parent.relation_state
+child.subject        = parent.subject
+child.object         = item
+```
+
+Затем:
+
+```text
+Executor::execute_child_semantic_context_outcome(body, ...)
+```
+
+использует тот же canonical Executor.
+
+Так body может читать item через `SemanticContextRole::Object`, то есть AVM-аналог старого `$obj`.
+
+## `foreach_subject`
+
+Симметричная orientation:
+
+```text
+child.entity         = parent.entity
+child.relation_state = parent.relation_state
+child.subject        = item
+child.object         = parent.object
+```
+
+Body читает item через `SemanticContextRole::Subject`.
+
+Старый live oracle отдельно доказал только `foreachobj`; subject-orientation фиксируется собственным AVM conformance, а не выдаётся за исторически доказанное поведение jsonRVM.
+
+## Свежий child для каждой итерации
+
+Каждая итерация строит child **из одного и того же исходного parent `SemanticContextView`**.
+
+Если body возвращает:
+
+```text
+ExecutionOutcome{
+  result = X,
+  semantic = child.with_relation_state(Y)
+}
+```
+
+то `Y` не становится скрытым input state следующего item.
+
+Это принципиально отличает foreach от ordered same-context sequence #162:
+
+- sequence явно thread-ит output semantic state шага в следующий шаг;
+- foreach создаёт независимые sibling child contexts.
+
+Если нужно состояние между итерациями, оно должно быть представлено явно как данные/effect, а не как неявная утечка mutable context.
+
+## Результат
+
+`outcome.result` — ordered link-list body results:
+
+```text
+[item1, item2, item3]
+ -> [body(item1), body(item2), body(item3)]
+```
+
+Порядок полностью сохраняется.
+
+Пустая коллекция возвращает `list_nil`.
+
+Parent semantic state возвращается неизменным:
+
+```text
+outcome.semantic = parent semantic view
+```
+
+То есть result и state остаются раздельными, как требует `ExecutionOutcome`.
+
+## Materialization результата
+
+Входная коллекция читается через `decode_link_list` без записи.
+
+Body results сначала собираются в host-side временный vector только как промежуточный control-flow buffer. Canonical output list materialize-ится через `encode_link_list` **только после успешного завершения всех итераций**.
+
+Это даёт важный failure contract:
+
+- body первого item может совершить свои явные effects;
+- body второго item может упасть;
+- третий item не исполняется;
+- partial output list не создаётся.
+
+AVM не обещает rollback явных effects body: foreach не является транзакцией.
+
+## Порядок effects
+
+Iteration order равен order canonical link-list.
+
+Никакой implicit parallelism не разрешён:
+
+```text
+item1 -> item2 -> item3
+```
+
+Observable effects body происходят в том же порядке.
+
+Даже если в будущем pure projection сможет быть оптимизирована параллельно, effectful foreach не получает `std::execution::par` как semantic contract.
+
+## Отсутствующий semantic context
+
+Foreach зависит от child semantic roles, поэтому direct execution без `SemanticContextView` отвергается:
+
+```text
+Executor::execute(foreach_entity) -> error
+```
+
+Caller должен использовать explicit semantic execution path.
+
+Это лучше скрытого создания «текущего контекста» внутри handler-а.
+
+## Соответствие live oracle jsonRVM
+
+Frozen case `CASE-FOREACH-CONTEXT` возвращает:
+
+```json
+{"/result":[1,2,3]}
+```
+
+AVM conformance воспроизводит semantic denotation:
+
+1. ordered collection содержит identity `1,2,3`;
+2. body возвращает child object identity;
+3. `foreach_object` возвращает ordered list тех же identities.
+
+Старый JSON wrapper `/result` не переносится как часть foreach semantics.
+
+## Observer contract
+
+Каждый body запускается обычным `Executor`.
+
+Следовательно canonical observer получает обычные:
+
+```text
+Enter / Return / Fail
+```
+
+для foreach entity и для каждого body entity. Отдельного `ForeachExecutor` или специального observer channel нет.
+
+## Инварианты
+
+1. collection — link-native ordered list, не JSON array;
+2. body — обычный executable LinkId;
+3. для каждого item создаётся sibling child context;
+4. object/subject orientation разделены разными relation identities;
+5. result order равен input order;
+6. parent semantic state не меняется скрыто;
+7. child semantic mutation не протекает в следующий item;
+8. failure останавливает последующие items;
+9. partial result list не materialize-ится при failure;
+10. implicit parallelism запрещён;
+11. используется единственный canonical Executor.

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -5,6 +5,7 @@
 #include "avm/execution_outcome.h"
 #include "avm/execution_trace.h"
 #include "avm/executor.h"
+#include "avm/foreach_runtime.h"
 #include "avm/integer_value.h"
 #include "avm/link_store.h"
 #include "avm/persistent_link_store.h"

--- a/include/avm/foreach_runtime.h
+++ b/include/avm/foreach_runtime.h
@@ -1,0 +1,121 @@
+#pragma once
+
+#include "avm/executor.h"
+#include "avm/program_model.h"
+
+#include <cstddef>
+#include <limits>
+#include <set>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace avm
+{
+
+struct ForeachVocabulary
+{
+	LinkId object_relation;
+	LinkId subject_relation;
+
+	static ForeachVocabulary create(LinkStore &store)
+	{
+		return ForeachVocabulary{
+		    store.create_point(),
+		    store.create_point(),
+		};
+	}
+};
+
+inline void validate_foreach_vocabulary(const LinkStore &store, const ForeachVocabulary &vocabulary, LinkId list_nil)
+{
+	const LinkId ids[] = {
+	    vocabulary.object_relation,
+	    vocabulary.subject_relation,
+	    list_nil,
+	};
+
+	std::set<LinkId> unique;
+	for (const LinkId id : ids)
+	{
+		if (!store.contains(id))
+			throw std::invalid_argument("foreach vocabulary contains an unknown LinkId");
+		if (!unique.insert(id).second)
+			throw std::invalid_argument("foreach relation identities and list nil must be distinct");
+	}
+}
+
+namespace foreach_detail
+{
+
+enum class Orientation
+{
+	Object,
+	Subject,
+};
+
+inline SemanticContextFrame child_frame(const SemanticContextView &parent, Orientation orientation, LinkId item)
+{
+	const SemanticContextFrame current = parent.current();
+	if (orientation == Orientation::Object)
+	{
+		return SemanticContextFrame{
+		    current.entity,
+		    current.relation_state,
+		    current.subject,
+		    item,
+		};
+	}
+
+	return SemanticContextFrame{
+	    current.entity,
+	    current.relation_state,
+	    item,
+	    current.object,
+	};
+}
+
+inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executor &executor, LinkId list_nil,
+                                        Orientation orientation)
+{
+	if (!context.semantic)
+		throw std::logic_error("foreach execution requires an explicit semantic context");
+
+	const std::vector<LinkId> items =
+	    decode_link_list(executor.store(), context.object, list_nil, std::numeric_limits<std::size_t>::max());
+	std::vector<LinkId> results;
+	results.reserve(items.size());
+
+	for (const LinkId item : items)
+	{
+		const SemanticContextFrame child = child_frame(context.semantic, orientation, item);
+		const ExecutionOutcome outcome = executor.execute_child_semantic_context_outcome(context.subject, context, child);
+		results.push_back(outcome.result);
+	}
+
+	const LinkId result_list = encode_link_list(executor.store(), results, list_nil);
+	return ExecutionOutcome{result_list, context.semantic};
+}
+
+} // namespace foreach_detail
+
+inline void register_foreach_runtime(Executor &executor, const ForeachVocabulary &vocabulary, LinkId list_nil)
+{
+	validate_foreach_vocabulary(executor.store(), vocabulary, list_nil);
+
+	executor.register_native(vocabulary.object_relation,
+	                         [list_nil](const ExecutionContext &context, Executor &current_executor)
+	                         {
+		                         return foreach_detail::execute_foreach(
+		                             context, current_executor, list_nil, foreach_detail::Orientation::Object);
+	                         });
+
+	executor.register_native(vocabulary.subject_relation,
+	                         [list_nil](const ExecutionContext &context, Executor &current_executor)
+	                         {
+		                         return foreach_detail::execute_foreach(
+		                             context, current_executor, list_nil, foreach_detail::Orientation::Subject);
+	                         });
+}
+
+} // namespace avm

--- a/include/avm/foreach_runtime.h
+++ b/include/avm/foreach_runtime.h
@@ -89,7 +89,8 @@ inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executo
 	for (const LinkId item : items)
 	{
 		const SemanticContextFrame child = child_frame(context.semantic, orientation, item);
-		const ExecutionOutcome outcome = executor.execute_child_semantic_context_outcome(context.subject, context, child);
+		const ExecutionOutcome outcome =
+		    executor.execute_child_semantic_context_outcome(context.subject, context, child);
 		results.push_back(outcome.result);
 	}
 
@@ -103,19 +104,21 @@ inline void register_foreach_runtime(Executor &executor, const ForeachVocabulary
 {
 	validate_foreach_vocabulary(executor.store(), vocabulary, list_nil);
 
-	executor.register_native(vocabulary.object_relation,
-	                         [list_nil](const ExecutionContext &context, Executor &current_executor)
-	                         {
-		                         return foreach_detail::execute_foreach(
-		                             context, current_executor, list_nil, foreach_detail::Orientation::Object);
-	                         });
+	executor.register_native(
+	    vocabulary.object_relation,
+	    [list_nil](const ExecutionContext &context, Executor &current_executor)
+	    {
+		    return foreach_detail::execute_foreach(context, current_executor, list_nil,
+		                                           foreach_detail::Orientation::Object);
+	    });
 
-	executor.register_native(vocabulary.subject_relation,
-	                         [list_nil](const ExecutionContext &context, Executor &current_executor)
-	                         {
-		                         return foreach_detail::execute_foreach(
-		                             context, current_executor, list_nil, foreach_detail::Orientation::Subject);
-	                         });
+	executor.register_native(
+	    vocabulary.subject_relation,
+	    [list_nil](const ExecutionContext &context, Executor &current_executor)
+	    {
+		    return foreach_detail::execute_foreach(context, current_executor, list_nil,
+		                                           foreach_detail::Orientation::Subject);
+	    });
 }
 
 } // namespace avm

--- a/include/avm/foreach_runtime.h
+++ b/include/avm/foreach_runtime.h
@@ -98,25 +98,26 @@ inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executo
 	return ExecutionOutcome{result_list, context.semantic};
 }
 
-inline NativeRelationHandler handler(LinkId list_nil, Orientation orientation)
+struct Handler
 {
-	return [list_nil, orientation](const ExecutionContext &context, Executor &executor)
+	LinkId list_nil;
+	Orientation orientation;
+
+	ExecutionOutcome operator()(const ExecutionContext &context, Executor &executor) const
 	{
 		return execute_foreach(context, executor, list_nil, orientation);
-	};
-}
+	}
+};
 
 } // namespace foreach_detail
 
 inline void register_foreach_runtime(Executor &executor, const ForeachVocabulary &vocabulary, LinkId list_nil)
 {
 	validate_foreach_vocabulary(executor.store(), vocabulary, list_nil);
-	const NativeRelationHandler object_handler =
-	    foreach_detail::handler(list_nil, foreach_detail::Orientation::Object);
-	const NativeRelationHandler subject_handler =
-	    foreach_detail::handler(list_nil, foreach_detail::Orientation::Subject);
-	executor.register_native(vocabulary.object_relation, object_handler);
-	executor.register_native(vocabulary.subject_relation, subject_handler);
+	executor.register_native(vocabulary.object_relation,
+	                         foreach_detail::Handler{list_nil, foreach_detail::Orientation::Object});
+	executor.register_native(vocabulary.subject_relation,
+	                         foreach_detail::Handler{list_nil, foreach_detail::Orientation::Subject});
 }
 
 } // namespace avm

--- a/include/avm/foreach_runtime.h
+++ b/include/avm/foreach_runtime.h
@@ -82,7 +82,7 @@ inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executo
 		throw std::logic_error("foreach execution requires an explicit semantic context");
 
 	const std::vector<LinkId> items =
-	    decode_link_list(executor.store(), context.object, list_nil, std::numeric_limits<std::size_t>::max());
+	    decode_link_list(executor.store(), list_nil, context.object, std::numeric_limits<std::size_t>::max());
 	std::vector<LinkId> results;
 	results.reserve(items.size());
 
@@ -93,7 +93,7 @@ inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executo
 		results.push_back(outcome.result);
 	}
 
-	const LinkId result_list = encode_link_list(executor.store(), results, list_nil);
+	const LinkId result_list = encode_link_list(executor.store(), list_nil, results);
 	return ExecutionOutcome{result_list, context.semantic};
 }
 

--- a/include/avm/foreach_runtime.h
+++ b/include/avm/foreach_runtime.h
@@ -98,27 +98,25 @@ inline ExecutionOutcome execute_foreach(const ExecutionContext &context, Executo
 	return ExecutionOutcome{result_list, context.semantic};
 }
 
+inline NativeRelationHandler handler(LinkId list_nil, Orientation orientation)
+{
+	return [list_nil, orientation](const ExecutionContext &context, Executor &executor)
+	{
+		return execute_foreach(context, executor, list_nil, orientation);
+	};
+}
+
 } // namespace foreach_detail
 
 inline void register_foreach_runtime(Executor &executor, const ForeachVocabulary &vocabulary, LinkId list_nil)
 {
 	validate_foreach_vocabulary(executor.store(), vocabulary, list_nil);
-
-	executor.register_native(
-	    vocabulary.object_relation,
-	    [list_nil](const ExecutionContext &context, Executor &current_executor)
-	    {
-		    return foreach_detail::execute_foreach(context, current_executor, list_nil,
-		                                           foreach_detail::Orientation::Object);
-	    });
-
-	executor.register_native(
-	    vocabulary.subject_relation,
-	    [list_nil](const ExecutionContext &context, Executor &current_executor)
-	    {
-		    return foreach_detail::execute_foreach(context, current_executor, list_nil,
-		                                           foreach_detail::Orientation::Subject);
-	    });
+	const NativeRelationHandler object_handler =
+	    foreach_detail::handler(list_nil, foreach_detail::Orientation::Object);
+	const NativeRelationHandler subject_handler =
+	    foreach_detail::handler(list_nil, foreach_detail::Orientation::Subject);
+	executor.register_native(vocabulary.object_relation, object_handler);
+	executor.register_native(vocabulary.subject_relation, subject_handler);
 }
 
 } // namespace avm

--- a/test/foreach_runtime_test.cpp
+++ b/test/foreach_runtime_test.cpp
@@ -104,7 +104,8 @@ int main()
 
 	const avm::LinkId subject_body_relation = store.create_point();
 	std::vector<avm::LinkId> subject_seen;
-	const auto subject_body_handler = [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	const auto subject_body_handler =
+	    [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
 	{
 		assert(semantic_role(context, avm::SemanticContextRole::Object) == root_frame.object);
 		const avm::LinkId item = semantic_role(context, avm::SemanticContextRole::Subject);
@@ -167,8 +168,7 @@ int main()
 	assert(missing_context_rejected);
 
 	const avm::LinkId malformed_list = store.intern(item1, item2);
-	const avm::LinkId malformed_foreach =
-	    relation_entity(store, foreach.object_relation, object_body, malformed_list);
+	const avm::LinkId malformed_foreach = relation_entity(store, foreach.object_relation, object_body, malformed_list);
 	const std::size_t before_malformed = store.size();
 	bool malformed_rejected = false;
 	try

--- a/test/foreach_runtime_test.cpp
+++ b/test/foreach_runtime_test.cpp
@@ -9,15 +9,20 @@
 namespace
 {
 
+avm::LinkId relation_entity(avm::LinkStore &store, avm::LinkId relation, avm::LinkId subject, avm::LinkId object)
+{
+	return avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+}
+
 avm::LinkId executable(avm::LinkStore &store, avm::LinkId relation)
 {
-	return avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        relation,
-	        store.create_point(),
-	        store.create_point(),
-	    });
+	return relation_entity(store, relation, store.create_point(), store.create_point());
+}
+
+avm::LinkId semantic_role(const avm::ExecutionContext &context, avm::SemanticContextRole role)
+{
+	assert(context.semantic);
+	return context.semantic.role(role);
 }
 
 class RecordingObserver final : public avm::ExecutionObserver
@@ -57,45 +62,31 @@ int main()
 	const avm::LinkId object_body_relation = store.create_point();
 	std::vector<avm::LinkId> object_seen;
 	std::vector<avm::LinkId> relation_state_seen;
-	executor.register_native(object_body_relation,
-	                         [&](const avm::ExecutionContext &context, avm::Executor &)
-	                         {
-		                         assert(context.semantic);
-		                         assert(context.semantic.depth() == 1);
-		                         assert(context.semantic.parent().current() == root_frame);
-		                         assert(context.semantic.role(avm::SemanticContextRole::Entity) == root_frame.entity);
-		                         assert(context.semantic.role(avm::SemanticContextRole::Subject) == root_frame.subject);
-		                         assert(context.semantic.role(avm::SemanticContextRole::RelationState) ==
-		                                root_frame.relation_state);
+	const auto object_body_handler = [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	{
+		assert(context.semantic.depth() == 1);
+		assert(context.semantic.parent().current() == root_frame);
+		assert(semantic_role(context, avm::SemanticContextRole::Entity) == root_frame.entity);
+		assert(semantic_role(context, avm::SemanticContextRole::Subject) == root_frame.subject);
+		assert(semantic_role(context, avm::SemanticContextRole::RelationState) == root_frame.relation_state);
 
-		                         const avm::LinkId item =
-		                             context.semantic.role(avm::SemanticContextRole::Object);
-		                         object_seen.push_back(item);
-		                         relation_state_seen.push_back(
-		                             context.semantic.role(avm::SemanticContextRole::RelationState));
-		                         return avm::ExecutionOutcome{
-		                             item,
-		                             context.semantic.with_relation_state(item),
-		                         };
-	                         });
+		const avm::LinkId item = semantic_role(context, avm::SemanticContextRole::Object);
+		object_seen.push_back(item);
+		relation_state_seen.push_back(semantic_role(context, avm::SemanticContextRole::RelationState));
+		return avm::ExecutionOutcome{item, context.semantic.with_relation_state(item)};
+	};
+	executor.register_native(object_body_relation, object_body_handler);
+
 	const avm::LinkId object_body = executable(store, object_body_relation);
-	const avm::LinkId object_foreach = avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        foreach.object_relation,
-	        object_body,
-	        input,
-	    });
-
+	const avm::LinkId object_foreach = relation_entity(store, foreach.object_relation, object_body, input);
 	const avm::ExecutionOutcome object_outcome = executor.execute_outcome_in_context(object_foreach, root);
+
 	assert(avm::decode_link_list(store, list_nil, object_outcome.result) == items);
 	assert(object_outcome.semantic == root);
 	assert(object_seen == items);
-	assert(relation_state_seen == std::vector<avm::LinkId>({
-	                                    root_frame.relation_state,
-	                                    root_frame.relation_state,
-	                                    root_frame.relation_state,
-	                                }));
+	assert(relation_state_seen.size() == items.size());
+	for (const avm::LinkId state : relation_state_seen)
+		assert(state == root_frame.relation_state);
 
 	std::size_t foreach_enter = 0;
 	std::size_t body_enter = 0;
@@ -113,37 +104,24 @@ int main()
 
 	const avm::LinkId subject_body_relation = store.create_point();
 	std::vector<avm::LinkId> subject_seen;
-	executor.register_native(subject_body_relation,
-	                         [&](const avm::ExecutionContext &context, avm::Executor &)
-	                         {
-		                         assert(context.semantic);
-		                         assert(context.semantic.role(avm::SemanticContextRole::Object) == root_frame.object);
-		                         const avm::LinkId item =
-		                             context.semantic.role(avm::SemanticContextRole::Subject);
-		                         subject_seen.push_back(item);
-		                         return avm::ExecutionOutcome{item, context.semantic};
-	                         });
-	const avm::LinkId subject_body = executable(store, subject_body_relation);
-	const avm::LinkId subject_foreach = avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        foreach.subject_relation,
-	        subject_body,
-	        input,
-	    });
+	const auto subject_body_handler = [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	{
+		assert(semantic_role(context, avm::SemanticContextRole::Object) == root_frame.object);
+		const avm::LinkId item = semantic_role(context, avm::SemanticContextRole::Subject);
+		subject_seen.push_back(item);
+		return avm::ExecutionOutcome{item, context.semantic};
+	};
+	executor.register_native(subject_body_relation, subject_body_handler);
 
+	const avm::LinkId subject_body = executable(store, subject_body_relation);
+	const avm::LinkId subject_foreach = relation_entity(store, foreach.subject_relation, subject_body, input);
 	const avm::ExecutionOutcome subject_outcome = executor.execute_outcome_in_context(subject_foreach, root);
+
 	assert(avm::decode_link_list(store, list_nil, subject_outcome.result) == items);
 	assert(subject_outcome.semantic == root);
 	assert(subject_seen == items);
 
-	const avm::LinkId empty_foreach = avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        foreach.object_relation,
-	        object_body,
-	        list_nil,
-	    });
+	const avm::LinkId empty_foreach = relation_entity(store, foreach.object_relation, object_body, list_nil);
 	const std::size_t before_empty = store.size();
 	const avm::ExecutionOutcome empty_outcome = executor.execute_outcome_in_context(empty_foreach, root);
 	assert(empty_outcome.result == list_nil);
@@ -151,24 +129,18 @@ int main()
 
 	const avm::LinkId fail_body_relation = store.create_point();
 	std::vector<avm::LinkId> failure_seen;
-	executor.register_native(fail_body_relation,
-	                         [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
-	                         {
-		                         const avm::LinkId item =
-		                             context.semantic.role(avm::SemanticContextRole::Object);
-		                         failure_seen.push_back(item);
-		                         if (item == item2)
-			                         throw std::runtime_error("expected foreach body failure");
-		                         return avm::ExecutionOutcome{item, context.semantic};
-	                         });
+	const auto fail_body_handler = [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	{
+		const avm::LinkId item = semantic_role(context, avm::SemanticContextRole::Object);
+		failure_seen.push_back(item);
+		if (item == item2)
+			throw std::runtime_error("expected foreach body failure");
+		return avm::ExecutionOutcome{item, context.semantic};
+	};
+	executor.register_native(fail_body_relation, fail_body_handler);
+
 	const avm::LinkId fail_body = executable(store, fail_body_relation);
-	const avm::LinkId failing_foreach = avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        foreach.object_relation,
-	        fail_body,
-	        input,
-	    });
+	const avm::LinkId failing_foreach = relation_entity(store, foreach.object_relation, fail_body, input);
 	const std::size_t before_failure = store.size();
 	bool failed = false;
 	try
@@ -195,13 +167,8 @@ int main()
 	assert(missing_context_rejected);
 
 	const avm::LinkId malformed_list = store.intern(item1, item2);
-	const avm::LinkId malformed_foreach = avm::encode_relation_entity(
-	    store,
-	    avm::RelationEntity{
-	        foreach.object_relation,
-	        object_body,
-	        malformed_list,
-	    });
+	const avm::LinkId malformed_foreach =
+	    relation_entity(store, foreach.object_relation, object_body, malformed_list);
 	const std::size_t before_malformed = store.size();
 	bool malformed_rejected = false;
 	try

--- a/test/foreach_runtime_test.cpp
+++ b/test/foreach_runtime_test.cpp
@@ -1,0 +1,219 @@
+#include "avm/foreach_runtime.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace
+{
+
+avm::LinkId executable(avm::LinkStore &store, avm::LinkId relation)
+{
+	return avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        relation,
+	        store.create_point(),
+	        store.create_point(),
+	    });
+}
+
+class RecordingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override { events.push_back(event); }
+
+	std::vector<avm::ExecutionEvent> events;
+};
+
+} // namespace
+
+int main()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId list_nil = store.create_point();
+	const avm::ForeachVocabulary foreach = avm::ForeachVocabulary::create(store);
+
+	const avm::LinkId item1 = store.create_point();
+	const avm::LinkId item2 = store.create_point();
+	const avm::LinkId item3 = store.create_point();
+	const std::vector<avm::LinkId> items{item1, item2, item3};
+	const avm::LinkId input = avm::encode_link_list(store, items, list_nil);
+
+	const avm::SemanticContextFrame root_frame{
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	};
+	const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	avm::register_foreach_runtime(executor, foreach, list_nil);
+
+	const avm::LinkId object_body_relation = store.create_point();
+	std::vector<avm::LinkId> object_seen;
+	std::vector<avm::LinkId> relation_state_seen;
+	executor.register_native(object_body_relation,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         assert(context.semantic);
+		                         assert(context.semantic.depth() == 1);
+		                         assert(context.semantic.parent().current() == root_frame);
+		                         assert(context.semantic.role(avm::SemanticContextRole::Entity) == root_frame.entity);
+		                         assert(context.semantic.role(avm::SemanticContextRole::Subject) == root_frame.subject);
+		                         assert(context.semantic.role(avm::SemanticContextRole::RelationState) ==
+		                                root_frame.relation_state);
+
+		                         const avm::LinkId item =
+		                             context.semantic.role(avm::SemanticContextRole::Object);
+		                         object_seen.push_back(item);
+		                         relation_state_seen.push_back(
+		                             context.semantic.role(avm::SemanticContextRole::RelationState));
+		                         return avm::ExecutionOutcome{
+		                             item,
+		                             context.semantic.with_relation_state(item),
+		                         };
+	                         });
+	const avm::LinkId object_body = executable(store, object_body_relation);
+	const avm::LinkId object_foreach = avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        foreach.object_relation,
+	        object_body,
+	        input,
+	    });
+
+	const avm::ExecutionOutcome object_outcome = executor.execute_outcome_in_context(object_foreach, root);
+	assert(avm::decode_link_list(store, object_outcome.result, list_nil) == items);
+	assert(object_outcome.semantic == root);
+	assert(object_seen == items);
+	assert(relation_state_seen == std::vector<avm::LinkId>({
+	                                    root_frame.relation_state,
+	                                    root_frame.relation_state,
+	                                    root_frame.relation_state,
+	                                }));
+
+	std::size_t foreach_enter = 0;
+	std::size_t body_enter = 0;
+	for (const avm::ExecutionEvent &event : observer.events)
+	{
+		if (event.kind != avm::ExecutionEventKind::Enter)
+			continue;
+		if (event.context.entity == object_foreach)
+			++foreach_enter;
+		if (event.context.entity == object_body)
+			++body_enter;
+	}
+	assert(foreach_enter == 1);
+	assert(body_enter == items.size());
+
+	const avm::LinkId subject_body_relation = store.create_point();
+	std::vector<avm::LinkId> subject_seen;
+	executor.register_native(subject_body_relation,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         assert(context.semantic);
+		                         assert(context.semantic.role(avm::SemanticContextRole::Object) == root_frame.object);
+		                         const avm::LinkId item =
+		                             context.semantic.role(avm::SemanticContextRole::Subject);
+		                         subject_seen.push_back(item);
+		                         return avm::ExecutionOutcome{item, context.semantic};
+	                         });
+	const avm::LinkId subject_body = executable(store, subject_body_relation);
+	const avm::LinkId subject_foreach = avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        foreach.subject_relation,
+	        subject_body,
+	        input,
+	    });
+
+	const avm::ExecutionOutcome subject_outcome = executor.execute_outcome_in_context(subject_foreach, root);
+	assert(avm::decode_link_list(store, subject_outcome.result, list_nil) == items);
+	assert(subject_outcome.semantic == root);
+	assert(subject_seen == items);
+
+	const avm::LinkId empty_foreach = avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        foreach.object_relation,
+	        object_body,
+	        list_nil,
+	    });
+	const std::size_t before_empty = store.size();
+	const avm::ExecutionOutcome empty_outcome = executor.execute_outcome_in_context(empty_foreach, root);
+	assert(empty_outcome.result == list_nil);
+	assert(store.size() == before_empty);
+
+	const avm::LinkId fail_body_relation = store.create_point();
+	std::vector<avm::LinkId> failure_seen;
+	executor.register_native(fail_body_relation,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	                         {
+		                         const avm::LinkId item =
+		                             context.semantic.role(avm::SemanticContextRole::Object);
+		                         failure_seen.push_back(item);
+		                         if (item == item2)
+			                         throw std::runtime_error("expected foreach body failure");
+		                         return avm::ExecutionOutcome{item, context.semantic};
+	                         });
+	const avm::LinkId fail_body = executable(store, fail_body_relation);
+	const avm::LinkId failing_foreach = avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        foreach.object_relation,
+	        fail_body,
+	        input,
+	    });
+	const std::size_t before_failure = store.size();
+	bool failed = false;
+	try
+	{
+		static_cast<void>(executor.execute_outcome_in_context(failing_foreach, root));
+	}
+	catch (const std::runtime_error &)
+	{
+		failed = true;
+	}
+	assert(failed);
+	assert(failure_seen == std::vector<avm::LinkId>({item1, item2}));
+	assert(store.size() == before_failure);
+
+	bool missing_context_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(object_foreach));
+	}
+	catch (const std::logic_error &)
+	{
+		missing_context_rejected = true;
+	}
+	assert(missing_context_rejected);
+
+	const avm::LinkId malformed_list = store.intern(item1, item2);
+	const avm::LinkId malformed_foreach = avm::encode_relation_entity(
+	    store,
+	    avm::RelationEntity{
+	        foreach.object_relation,
+	        object_body,
+	        malformed_list,
+	    });
+	const std::size_t before_malformed = store.size();
+	bool malformed_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute_outcome_in_context(malformed_foreach, root));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_rejected = true;
+	}
+	assert(malformed_rejected);
+	assert(store.size() == before_malformed);
+
+	return 0;
+}

--- a/test/foreach_runtime_test.cpp
+++ b/test/foreach_runtime_test.cpp
@@ -104,8 +104,7 @@ int main()
 
 	const avm::LinkId subject_body_relation = store.create_point();
 	std::vector<avm::LinkId> subject_seen;
-	const auto subject_body_handler =
-	    [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	const auto subject_body_handler = [&](const avm::ExecutionContext &context, avm::Executor &)
 	{
 		assert(semantic_role(context, avm::SemanticContextRole::Object) == root_frame.object);
 		const avm::LinkId item = semantic_role(context, avm::SemanticContextRole::Subject);

--- a/test/foreach_runtime_test.cpp
+++ b/test/foreach_runtime_test.cpp
@@ -40,7 +40,7 @@ int main()
 	const avm::LinkId item2 = store.create_point();
 	const avm::LinkId item3 = store.create_point();
 	const std::vector<avm::LinkId> items{item1, item2, item3};
-	const avm::LinkId input = avm::encode_link_list(store, items, list_nil);
+	const avm::LinkId input = avm::encode_link_list(store, list_nil, items);
 
 	const avm::SemanticContextFrame root_frame{
 	    store.create_point(),
@@ -88,7 +88,7 @@ int main()
 	    });
 
 	const avm::ExecutionOutcome object_outcome = executor.execute_outcome_in_context(object_foreach, root);
-	assert(avm::decode_link_list(store, object_outcome.result, list_nil) == items);
+	assert(avm::decode_link_list(store, list_nil, object_outcome.result) == items);
 	assert(object_outcome.semantic == root);
 	assert(object_seen == items);
 	assert(relation_state_seen == std::vector<avm::LinkId>({
@@ -133,7 +133,7 @@ int main()
 	    });
 
 	const avm::ExecutionOutcome subject_outcome = executor.execute_outcome_in_context(subject_foreach, root);
-	assert(avm::decode_link_list(store, subject_outcome.result, list_nil) == items);
+	assert(avm::decode_link_list(store, list_nil, subject_outcome.result) == items);
 	assert(subject_outcome.semantic == root);
 	assert(subject_seen == items);
 


### PR DESCRIPTION
Closes #187. Part of #127/#122. Required by semantic migrator #174 for frozen `foreach-object-context` evidence.

## Что реализовано

Добавлен frontend-neutral foreach runtime поверх существующих `Executor`, `SemanticContextView` и canonical ordered link-list:

```text
(foreach_object, body, collection)
(foreach_subject, body, collection)
```

`body` — обычный executable `LinkId`; `collection` — link-native list с явным `list_nil`.

## Контекст итераций

Каждый item получает свежий sibling child context от одного исходного parent state.

`foreach_object` заменяет child `$obj`-роль на item, `foreach_subject` — child `$sub`-роль. Изменённый semantic state одного body не протекает скрыто в следующую итерацию.

## Порядок и failures

- строгий canonical list order;
- fail-fast;
- последующие items после failure не исполняются;
- output list materialize-ится только после успеха всех body-вызовов;
- partial result list при failure не создаётся;
- явные body effects не откатываются: foreach не является транзакцией;
- implicit parallelism отсутствует.

## Frozen jsonRVM evidence

Conformance воспроизводит semantic denotation `CASE-FOREACH-CONTEXT`: body читает child object и результатом является ordered list тех же identities `[1,2,3]`.

Старый oracle доказал только object orientation; subject orientation покрыта отдельно AVM conformance и не выдаётся за historical evidence.

## Observer/runtime boundary

Используется только существующий canonical `Executor`; каждый body создаёт обычные Enter/Return/Fail events. Нет `ForeachExecutor`, JSON collection runtime или hidden mutable current context.

## Package/CI

`foreach_runtime.h` добавлен в public installed surface, `foreach_runtime_tests` включён в `avm_core_tests`, поэтому gate проходит strict warnings-as-errors, ASan/UBSan и portable Linux/Windows/macOS matrix.

## Документация

Добавлен русский `docs/foreach-runtime.md` с нормативным contract, failure/materialization boundary и отличием foreach от same-context sequence #162.