### PR TITLE
AVM 1.5: independent execution projection и deterministic effect order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(AVM_CORE_PUBLIC_HEADERS
     include/avm/execution_trace.h
     include/avm/executor.h
     include/avm/foreach_runtime.h
+    include/avm/independent_projection.h
     include/avm/integer_value.h
     include/avm/link_store.h
     include/avm/persistent_link_store.h
@@ -199,6 +200,10 @@ if(AVM_BUILD_CORE_TESTS)
         test/semantic_execution_outcome_test.cpp
         semantic_execution_outcome_tests)
     avm_add_core_test(avm_foreach_runtime_test test/foreach_runtime_test.cpp foreach_runtime_tests)
+    avm_add_core_test(
+        avm_independent_projection_test
+        test/independent_projection_test.cpp
+        independent_projection_tests)
     avm_add_core_test(avm_integer_value_test test/integer_value_test.cpp integer_value_tests)
     avm_add_core_test(avm_text_value_test test/text_value_test.cpp text_value_tests)
     avm_add_core_test(avm_reference_test test/reference_test.cpp reference_tests)
@@ -287,6 +292,7 @@ if(AVM_BUILD_CORE_TESTS)
         avm_semantic_context_test
         avm_semantic_execution_outcome_test
         avm_foreach_runtime_test
+        avm_independent_projection_test
         avm_integer_value_test
         avm_text_value_test
         avm_reference_test

--- a/docs/execution-projection.md
+++ b/docs/execution-projection.md
@@ -1,0 +1,280 @@
+# Независимая проекция исполнения
+
+Родительская задача: #188. Общий gate: #127. Epic: #122.
+
+## Назначение
+
+В старом `jsonRVM` обычный JSON object без `$ref` и `$rel` выполнял сразу несколько функций:
+
+1. ключ object-а разрешался как изменяемый destination;
+2. значение исполнялось как программа;
+3. для каждого элемента создавался отдельный `vm_ctx`;
+4. набор элементов запускался через `std::execution::par`;
+5. ошибки собирались после выполнения workers.
+
+Эти свойства нельзя переносить в AVM одной монолитной операцией. Иначе JSON object, lvalue mutation и host scheduler снова стали бы частью semantic core.
+
+Поэтому AVM разделяет:
+
+- независимое вычисление нескольких executable bodies;
+- ordered same-context sequence;
+- foreach по collection;
+- structural `ProjectionDescription`;
+- destination/write semantics;
+- будущую оптимизацию scheduler-а.
+
+## Не путать с `ProjectionDescription`
+
+`ProjectionDescription` из `projection.h` — это структурный план построения дуплетов:
+
+```text
+external structure
+ -> ProjectionDescription
+ -> find_projection | realize_projection
+ -> canonical LinkId graph
+```
+
+Он не исполняет программы, не содержит execution context и не задаёт порядок effects.
+
+Независимая проекция исполнения — другой контракт:
+
+```text
+canonical executable bodies
+ -> Executor
+ -> ordered body results
+ -> canonical result list
+```
+
+Эти два понятия намеренно не объединяются одним API.
+
+## Каноническая форма
+
+Используется отдельная relation identity:
+
+```text
+(independent_projection, body_list, list_nil)
+```
+
+В терминах `RelationEntity`:
+
+```text
+relation = independent_projection
+subject  = body_list
+object   = list_nil
+```
+
+`body_list` — canonical ordered link-list обычных executable `LinkId`.
+
+`list_nil` — явная identity конца и входной, и выходной последовательности.
+
+JSON object/array не являются частью этой формы.
+
+## Контекст body
+
+Каждый body получает **один и тот же входной `SemanticContextView`**.
+
+Если исходный context равен `C`, то:
+
+```text
+body1(C)
+body2(C)
+body3(C)
+```
+
+а не:
+
+```text
+C1 = body1(C)
+C2 = body2(C1)
+C3 = body3(C2)
+```
+
+Второй вариант уже является state-threading sequence и реализован отдельно через sequence semantics #162.
+
+Returned semantic state конкретного body не становится неявным input следующего body.
+
+Это позволяет моделировать независимые проекции без mutable shared `vm_ctx`.
+
+## Execution nesting
+
+Body исполняется тем же canonical `Executor`:
+
+```text
+Executor::execute_outcome_in_context(
+    body,
+    projection_context.semantic,
+    projection_entity,
+    projection_context.frame)
+```
+
+Поэтому execution observer видит обычную вложенность:
+
+```text
+Enter(projection)
+  Enter(body1)
+  Return(body1)
+  Enter(body2)
+  Return(body2)
+Return(projection)
+```
+
+Отдельного `ProjectionExecutor` или scheduler-specific execution path нет.
+
+## Результат
+
+Body results сохраняются в том же порядке:
+
+```text
+[b1, b2, b3]
+ -> [result(b1), result(b2), result(b3)]
+```
+
+Результат кодируется тем же canonical ordered link-list и тем же `list_nil`.
+
+Parent semantic state возвращается отдельно и без изменения:
+
+```text
+ExecutionOutcome{
+  result = result_list,
+  semantic = original_semantic_context
+}
+```
+
+## Граница materialization
+
+Входной `body_list` полностью декодируется до начала исполнения bodies. Read path не создаёт links.
+
+Во время исполнения body results временно накапливаются только как host-side vector `LinkId`.
+
+Canonical output list создаётся через `encode_link_list` **только после успешного завершения всех bodies**.
+
+Следствие:
+
+- если `body1` завершился успешно;
+- `body2` завершился ошибкой;
+- `body3` не исполняется;
+- partial output list не materialize-ится.
+
+При этом AVM не обещает rollback явных effects, которые уже выполнил `body1`. Независимая проекция не является транзакцией.
+
+## Порядок и effects
+
+Первый contract выполняет bodies строго в canonical list order.
+
+Это даёт детерминированный observable order:
+
+```text
+body1 -> body2 -> body3
+```
+
+Если bodies имеют effects, они наблюдаются в том же порядке.
+
+Если требуется иной порядок, он должен быть представлен явной structural program form, а не выбором host scheduler-а.
+
+## Почему `std::execution::par` не является семантикой
+
+Pinned `jsonRVM` использовал `std::execution::par` после подготовки `callctx` для членов JSON object.
+
+Но эта деталь одновременно зависела от:
+
+- mutable JSON destinations;
+- host thread scheduler;
+- mutex-ов JSON containers;
+- post-hoc aggregation exceptions.
+
+Ни один из этих implementation details не определяет canonical identity вычисления AVM.
+
+Поэтому implicit parallel execution в AVM 1.5 запрещено.
+
+В будущем proven-pure projection может быть оптимизирована параллельно только если доказано сохранение:
+
+- canonical result;
+- result order;
+- failure behavior;
+- observer contract;
+- отсутствия observable effects и conflicts.
+
+До такого доказательства последовательное исполнение является нормативным.
+
+## Отличие от sequence
+
+Sequence #162:
+
+- исполняет ordered bodies;
+- явно передаёт output semantic state шага в следующий шаг;
+- предназначена для последовательной эволюции state.
+
+Independent projection:
+
+- исполняет ordered bodies;
+- каждому body даёт один исходный semantic state;
+- игнорирует body-local semantic transition при переходе к соседнему body;
+- собирает отдельный ordered result list.
+
+То есть различие является семантическим, а не scheduler optimization.
+
+## Отличие от foreach
+
+Foreach #187:
+
+- принимает collection items;
+- создаёт свежий child semantic frame для каждого item;
+- помещает item в `subject` или `object` role child context.
+
+Independent projection:
+
+- принимает список executable bodies;
+- не создаёт child semantic frame;
+- все bodies видят тот же semantic context.
+
+Обе операции являются ordered и fail-fast, но решают разные задачи.
+
+## Destination и write semantics
+
+Legacy JSON key выполнял роль lvalue destination. Этот аспект **не входит** в independent projection.
+
+AVM не должен восстанавливать скрытую конструкцию:
+
+```text
+JSON key
+ -> mutable destination pointer
+ -> create missing member on write
+```
+
+Если migration corpus требует записи результата в модель, это должно быть выражено отдельной canonical write/materialization/effect operation поверх reference contract #126 и будущего data-model/effect contract.
+
+Read resolution и execution projection не создают destination автоматически.
+
+## Связь с semantic migrator
+
+#174 может использовать independent projection как frontend-neutral target для той части legacy lambda-structure, где observable contract сводится к независимому вычислению результатов.
+
+При этом #174 не должен заявлять полную parity старого plain-object lvalue behavior, пока destination/write semantics не представлены отдельным explicit contract.
+
+JSON wrapper вроде `/result` в oracle fixture может оставаться harness/output projection, если differential assertion проверяет вычисленное значение, а не mutation модели.
+
+## Persistent equivalence
+
+Canonical identity программы и результата не зависит от process lifetime.
+
+После первого исполнения output list сходится к canonical links. После close/reopen того же `PersistentLinkStore`:
+
+- relation/body/result identities сохраняются;
+- тот же projection root исполняется обычным `Executor` после регистрации native handlers;
+- возвращается тот же exact output `LinkId`;
+- повторное исполнение не увеличивает store.
+
+## Инварианты
+
+1. `ProjectionDescription` остаётся structural find/realize API;
+2. execution projection имеет отдельную relation identity;
+3. body list является canonical link-list;
+4. каждый body получает один исходный immutable semantic context;
+5. semantic state между bodies не thread-ится;
+6. result order равен body order;
+7. failure — fail-fast;
+8. partial output list не materialize-ится;
+9. явные effects не откатываются;
+10. implicit parallelism запрещён;
+11. используется единственный `Executor`;
+12. JSON lvalue/member semantics не входят в core contract.

--- a/docs/execution-projection.md
+++ b/docs/execution-projection.md
@@ -95,7 +95,7 @@ Returned semantic state конкретного body не становится н
 
 Это позволяет моделировать независимые проекции без mutable shared `vm_ctx`.
 
-## Execution nesting
+## Вложенность исполнения
 
 Body исполняется тем же canonical `Executor`:
 
@@ -253,7 +253,7 @@ Read resolution и execution projection не создают destination авто
 
 JSON wrapper вроде `/result` в oracle fixture может оставаться harness/output projection, если differential assertion проверяет вычисленное значение, а не mutation модели.
 
-## Persistent equivalence
+## Эквивалентность после reopen
 
 Canonical identity программы и результата не зависит от process lifetime.
 

--- a/include/avm/avm.h
+++ b/include/avm/avm.h
@@ -6,6 +6,7 @@
 #include "avm/execution_trace.h"
 #include "avm/executor.h"
 #include "avm/foreach_runtime.h"
+#include "avm/independent_projection.h"
 #include "avm/integer_value.h"
 #include "avm/link_store.h"
 #include "avm/persistent_link_store.h"

--- a/include/avm/independent_projection.h
+++ b/include/avm/independent_projection.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "avm/executor.h"
+#include "avm/program_model.h"
+
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+namespace avm
+{
+
+struct IndependentProjectionVocabulary
+{
+	LinkId relation;
+
+	static IndependentProjectionVocabulary create(LinkStore &store)
+	{
+		return IndependentProjectionVocabulary{store.create_point()};
+	}
+};
+
+inline void validate_independent_projection_vocabulary(const LinkStore &store,
+                                                       const IndependentProjectionVocabulary &vocabulary)
+{
+	if (!store.contains(vocabulary.relation))
+		throw std::invalid_argument("independent projection relation is not present in LinkStore");
+}
+
+namespace independent_projection_detail
+{
+
+inline ExecutionOutcome execute(const ExecutionContext &context, Executor &executor)
+{
+	if (!context.semantic)
+		throw std::logic_error("independent projection requires an explicit semantic context");
+
+	const LinkId list_nil = context.object;
+	const std::vector<LinkId> bodies =
+	    decode_link_list(executor.store(), list_nil, context.subject, std::numeric_limits<std::size_t>::max());
+
+	std::vector<LinkId> results;
+	results.reserve(bodies.size());
+	for (const LinkId body : bodies)
+	{
+		const ExecutionOutcome outcome =
+		    executor.execute_outcome_in_context(body, context.semantic, context.entity, context.frame);
+		results.push_back(outcome.result);
+	}
+
+	const LinkId result_list = encode_link_list(executor.store(), list_nil, results);
+	return ExecutionOutcome{result_list, context.semantic};
+}
+
+struct Handler
+{
+	ExecutionOutcome operator()(const ExecutionContext &context, Executor &executor) const
+	{
+		return execute(context, executor);
+	}
+};
+
+} // namespace independent_projection_detail
+
+inline void register_independent_projection_runtime(Executor &executor,
+                                                    const IndependentProjectionVocabulary &vocabulary)
+{
+	validate_independent_projection_vocabulary(executor.store(), vocabulary);
+	executor.register_native(vocabulary.relation, independent_projection_detail::Handler{});
+}
+
+} // namespace avm

--- a/test/independent_projection_test.cpp
+++ b/test/independent_projection_test.cpp
@@ -1,0 +1,314 @@
+#include "avm/independent_projection.h"
+#include "avm/persistent_link_store.h"
+#include "avm/relations_model.h"
+
+#include <cassert>
+#include <chrono>
+#include <filesystem>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+avm::LinkId relation_entity(avm::LinkStore &store, avm::LinkId relation, avm::LinkId subject, avm::LinkId object)
+{
+	return avm::encode_relation_entity(store, avm::RelationEntity{relation, subject, object});
+}
+
+avm::LinkId executable(avm::LinkStore &store, avm::LinkId relation)
+{
+	return relation_entity(store, relation, store.create_point(), store.create_point());
+}
+
+class RecordingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override { events.push_back(event); }
+
+	std::vector<avm::ExecutionEvent> events;
+};
+
+std::filesystem::path temporary_path(const std::string &suffix)
+{
+	const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+	return std::filesystem::temp_directory_path() /
+	       ("avm-independent-projection-" + std::to_string(nonce) + "-" + suffix + ".bin");
+}
+
+struct FileCleanup
+{
+	std::filesystem::path path;
+	~FileCleanup()
+	{
+		std::error_code error;
+		std::filesystem::remove_all(path, error);
+	}
+};
+
+void register_fixed_body(avm::Executor &executor, avm::LinkId relation, avm::LinkId result)
+{
+	executor.register_native(relation,
+	                         [result](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         assert(context.semantic);
+		                         return avm::ExecutionOutcome{
+		                             result,
+		                             context.semantic.with_relation_state(result),
+		                         };
+	                         });
+}
+
+void test_independent_projection()
+{
+	avm::InMemoryLinkStore store;
+	const avm::LinkId list_nil = store.create_point();
+	const avm::IndependentProjectionVocabulary projection = avm::IndependentProjectionVocabulary::create(store);
+
+	const avm::LinkId result1 = store.create_point();
+	const avm::LinkId result2 = store.create_point();
+	const avm::LinkId result3 = store.create_point();
+	const std::vector<avm::LinkId> expected_results{result1, result2, result3};
+
+	const avm::LinkId body_relation1 = store.create_point();
+	const avm::LinkId body_relation2 = store.create_point();
+	const avm::LinkId body_relation3 = store.create_point();
+	const avm::LinkId body1 = executable(store, body_relation1);
+	const avm::LinkId body2 = executable(store, body_relation2);
+	const avm::LinkId body3 = executable(store, body_relation3);
+	const std::vector<avm::LinkId> bodies{body1, body2, body3};
+	const avm::LinkId body_list = avm::encode_link_list(store, list_nil, bodies);
+	const avm::LinkId projection_entity = relation_entity(store, projection.relation, body_list, list_nil);
+
+	const avm::SemanticContextFrame root_frame{
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	    store.create_point(),
+	};
+	const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+
+	RecordingObserver observer;
+	avm::Executor executor(store, &observer);
+	avm::register_independent_projection_runtime(executor, projection);
+
+	std::vector<avm::SemanticContextView> seen_semantics;
+	std::vector<std::optional<avm::LinkId>> seen_parents;
+	const auto register_body = [&](avm::LinkId relation, avm::LinkId result)
+	{
+		executor.register_native(relation,
+		                         [&, result](const avm::ExecutionContext &context, avm::Executor &)
+		                         {
+			                         assert(context.semantic);
+			                         seen_semantics.push_back(context.semantic);
+			                         seen_parents.push_back(context.parent);
+			                         return avm::ExecutionOutcome{
+			                             result,
+			                             context.semantic.with_relation_state(result),
+			                         };
+		                         });
+	};
+	register_body(body_relation1, result1);
+	register_body(body_relation2, result2);
+	register_body(body_relation3, result3);
+
+	const std::size_t before_first = store.size();
+	const avm::ExecutionOutcome first = executor.execute_outcome_in_context(projection_entity, root);
+	assert(avm::decode_link_list(store, list_nil, first.result) == expected_results);
+	assert(first.semantic == root);
+	assert(seen_semantics.size() == bodies.size());
+	assert(seen_parents.size() == bodies.size());
+	for (std::size_t index = 0; index < bodies.size(); ++index)
+	{
+		assert(seen_semantics[index] == root);
+		assert(seen_semantics[index].current().relation_state == root_frame.relation_state);
+		assert(seen_parents[index] == projection_entity);
+	}
+	assert(store.size() >= before_first);
+
+	assert(observer.events.size() == 8);
+	assert(observer.events[0].kind == avm::ExecutionEventKind::Enter);
+	assert(observer.events[0].context.entity == projection_entity);
+	for (std::size_t index = 0; index < bodies.size(); ++index)
+	{
+		const std::size_t enter = 1 + index * 2;
+		const std::size_t returned = enter + 1;
+		assert(observer.events[enter].kind == avm::ExecutionEventKind::Enter);
+		assert(observer.events[enter].context.entity == bodies[index]);
+		assert(observer.events[enter].context.parent == projection_entity);
+		assert(observer.events[returned].kind == avm::ExecutionEventKind::Return);
+		assert(observer.events[returned].context.entity == bodies[index]);
+		assert(observer.events[returned].result == expected_results[index]);
+	}
+	assert(observer.events[7].kind == avm::ExecutionEventKind::Return);
+	assert(observer.events[7].context.entity == projection_entity);
+	assert(observer.events[7].result == first.result);
+	assert(observer.events[7].semantic_result == root);
+
+	const std::size_t converged_size = store.size();
+	const avm::ExecutionOutcome repeated = executor.execute_outcome_in_context(projection_entity, root);
+	assert(repeated.result == first.result);
+	assert(repeated.semantic == root);
+	assert(store.size() == converged_size);
+
+	const avm::LinkId empty_projection = relation_entity(store, projection.relation, list_nil, list_nil);
+	const std::size_t before_empty = store.size();
+	const avm::ExecutionOutcome empty = executor.execute_outcome_in_context(empty_projection, root);
+	assert(empty.result == list_nil);
+	assert(empty.semantic == root);
+	assert(store.size() == before_empty);
+
+	bool missing_context_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute(projection_entity));
+	}
+	catch (const std::logic_error &)
+	{
+		missing_context_rejected = true;
+	}
+	assert(missing_context_rejected);
+
+	const avm::LinkId fail_relation1 = store.create_point();
+	const avm::LinkId fail_relation2 = store.create_point();
+	const avm::LinkId fail_relation3 = store.create_point();
+	const avm::LinkId fail_body1 = executable(store, fail_relation1);
+	const avm::LinkId fail_body2 = executable(store, fail_relation2);
+	const avm::LinkId fail_body3 = executable(store, fail_relation3);
+	const avm::LinkId fail_bodies =
+	    avm::encode_link_list(store, list_nil, {fail_body1, fail_body2, fail_body3});
+	const avm::LinkId failing_projection = relation_entity(store, projection.relation, fail_bodies, list_nil);
+
+	std::vector<avm::LinkId> failure_seen;
+	executor.register_native(fail_relation1,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         failure_seen.push_back(context.entity);
+		                         return avm::ExecutionOutcome{result1, context.semantic};
+	                         });
+	executor.register_native(fail_relation2,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &) -> avm::ExecutionOutcome
+	                         {
+		                         failure_seen.push_back(context.entity);
+		                         throw std::runtime_error("expected independent projection failure");
+	                         });
+	executor.register_native(fail_relation3,
+	                         [&](const avm::ExecutionContext &context, avm::Executor &)
+	                         {
+		                         failure_seen.push_back(context.entity);
+		                         return avm::ExecutionOutcome{result3, context.semantic};
+	                         });
+
+	const std::size_t before_failure = store.size();
+	bool failed = false;
+	try
+	{
+		static_cast<void>(executor.execute_outcome_in_context(failing_projection, root));
+	}
+	catch (const std::runtime_error &)
+	{
+		failed = true;
+	}
+	assert(failed);
+	assert(failure_seen == std::vector<avm::LinkId>({fail_body1, fail_body2}));
+	assert(store.size() == before_failure);
+
+	const avm::LinkId malformed_body_list = store.intern(body1, result1);
+	const avm::LinkId malformed_projection =
+	    relation_entity(store, projection.relation, malformed_body_list, list_nil);
+	const std::size_t before_malformed = store.size();
+	const std::size_t bodies_before_malformed = seen_semantics.size();
+	bool malformed_rejected = false;
+	try
+	{
+		static_cast<void>(executor.execute_outcome_in_context(malformed_projection, root));
+	}
+	catch (const std::runtime_error &)
+	{
+		malformed_rejected = true;
+	}
+	assert(malformed_rejected);
+	assert(seen_semantics.size() == bodies_before_malformed);
+	assert(store.size() == before_malformed);
+}
+
+void test_persistent_reopen()
+{
+	const std::filesystem::path path = temporary_path("reopen");
+	FileCleanup cleanup{path};
+
+	avm::LinkId list_nil = avm::invalid_link_id;
+	avm::LinkId projection_relation = avm::invalid_link_id;
+	avm::LinkId body_relation1 = avm::invalid_link_id;
+	avm::LinkId body_relation2 = avm::invalid_link_id;
+	avm::LinkId body1 = avm::invalid_link_id;
+	avm::LinkId body2 = avm::invalid_link_id;
+	avm::LinkId result1 = avm::invalid_link_id;
+	avm::LinkId result2 = avm::invalid_link_id;
+	avm::LinkId projection_entity = avm::invalid_link_id;
+	avm::LinkId result_list = avm::invalid_link_id;
+	avm::SemanticContextFrame root_frame{};
+	std::size_t converged_size = 0;
+
+	{
+		avm::PersistentLinkStore store(path);
+		list_nil = store.create_point();
+		const avm::IndependentProjectionVocabulary projection =
+		    avm::IndependentProjectionVocabulary::create(store);
+		projection_relation = projection.relation;
+		result1 = store.create_point();
+		result2 = store.create_point();
+		body_relation1 = store.create_point();
+		body_relation2 = store.create_point();
+		body1 = executable(store, body_relation1);
+		body2 = executable(store, body_relation2);
+		const avm::LinkId body_list = avm::encode_link_list(store, list_nil, {body1, body2});
+		projection_entity = relation_entity(store, projection_relation, body_list, list_nil);
+		root_frame = avm::SemanticContextFrame{
+		    store.create_point(),
+		    store.create_point(),
+		    store.create_point(),
+		    store.create_point(),
+		};
+		const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+
+		avm::Executor executor(store);
+		avm::register_independent_projection_runtime(executor, projection);
+		register_fixed_body(executor, body_relation1, result1);
+		register_fixed_body(executor, body_relation2, result2);
+
+		const avm::ExecutionOutcome outcome = executor.execute_outcome_in_context(projection_entity, root);
+		assert(avm::decode_link_list(store, list_nil, outcome.result) == std::vector<avm::LinkId>({result1, result2}));
+		result_list = outcome.result;
+		converged_size = store.size();
+	}
+
+	{
+		avm::PersistentLinkStore store(path);
+		assert(store.size() == converged_size);
+		const avm::IndependentProjectionVocabulary projection{projection_relation};
+		const avm::SemanticContextView root = avm::SemanticContextView::root(root_frame);
+		avm::Executor executor(store);
+		avm::register_independent_projection_runtime(executor, projection);
+		register_fixed_body(executor, body_relation1, result1);
+		register_fixed_body(executor, body_relation2, result2);
+
+		const std::size_t before = store.size();
+		const avm::ExecutionOutcome outcome = executor.execute_outcome_in_context(projection_entity, root);
+		assert(outcome.result == result_list);
+		assert(outcome.semantic == root);
+		assert(avm::decode_link_list(store, list_nil, outcome.result) == std::vector<avm::LinkId>({result1, result2}));
+		assert(store.size() == before);
+	}
+}
+
+} // namespace
+
+int main()
+{
+	test_independent_projection();
+	test_persistent_reopen();
+	return 0;
+}

--- a/test/independent_projection_test.cpp
+++ b/test/independent_projection_test.cpp
@@ -177,8 +177,7 @@ void test_independent_projection()
 	const avm::LinkId fail_body1 = executable(store, fail_relation1);
 	const avm::LinkId fail_body2 = executable(store, fail_relation2);
 	const avm::LinkId fail_body3 = executable(store, fail_relation3);
-	const avm::LinkId fail_bodies =
-	    avm::encode_link_list(store, list_nil, {fail_body1, fail_body2, fail_body3});
+	const avm::LinkId fail_bodies = avm::encode_link_list(store, list_nil, {fail_body1, fail_body2, fail_body3});
 	const avm::LinkId failing_projection = relation_entity(store, projection.relation, fail_bodies, list_nil);
 
 	std::vector<avm::LinkId> failure_seen;
@@ -216,8 +215,7 @@ void test_independent_projection()
 	assert(store.size() == before_failure);
 
 	const avm::LinkId malformed_body_list = store.intern(body1, result1);
-	const avm::LinkId malformed_projection =
-	    relation_entity(store, projection.relation, malformed_body_list, list_nil);
+	const avm::LinkId malformed_projection = relation_entity(store, projection.relation, malformed_body_list, list_nil);
 	const std::size_t before_malformed = store.size();
 	const std::size_t bodies_before_malformed = seen_semantics.size();
 	bool malformed_rejected = false;
@@ -255,8 +253,7 @@ void test_persistent_reopen()
 	{
 		avm::PersistentLinkStore store(path);
 		list_nil = store.create_point();
-		const avm::IndependentProjectionVocabulary projection =
-		    avm::IndependentProjectionVocabulary::create(store);
+		const avm::IndependentProjectionVocabulary projection = avm::IndependentProjectionVocabulary::create(store);
 		projection_relation = projection.relation;
 		result1 = store.create_point();
 		result2 = store.create_point();


### PR DESCRIPTION
Closes #188. Completes remaining execution-projection part of #127. Epic #122. Depends on merged #187/#189.

## Источник решения

Аудит pinned `jsonRVM@843b3326141e090ccd1a106ba0a4a21ce72805b7` показал, что legacy plain JSON object смешивал три независимых слоя:

1. JSON key -> mutable lvalue destination;
2. value -> executable body в отдельном `vm_ctx`;
3. `std::execution::par` -> host scheduler.

AVM не переносит это монолитно.

## Новый frontend-neutral contract

Добавлена отдельная от structural `ProjectionDescription` execution form:

```text
(independent_projection, body_list, list_nil)
```

- `subject` = canonical ordered link-list executable body identities;
- `object` = explicit terminator identity;
- каждый body исполняется тем же `Executor`;
- каждый body получает один и тот же immutable `SemanticContextView`;
- body-local returned semantic state не thread-ится в следующий body;
- результаты собираются в canonical ordered link-list;
- parent semantic output остаётся исходным context.

## Отличие от существующих contracts

- `ProjectionDescription` остаётся только topological `find/realize` plan, без execution semantics;
- sequence #162 thread-ит semantic state между ordered steps;
- foreach #187 создаёт fresh child semantic frame для каждого collection item;
- independent projection запускает sibling executable bodies в одном semantic context и собирает results.

## Failure/materialization/effects

- input list полностью декодируется до исполнения;
- body execution строго в list order;
- fail-fast на первом failure;
- последующие bodies не исполняются;
- partial result list не materialize-ится;
- явные effects уже выполненных bodies не откатываются;
- implicit parallelism отсутствует.

Будущая parallel optimization допустима только для proven-pure projection при доказанном сохранении result/order/failure/observer/effect contract.

## Legacy lvalue boundary

JSON member names и create-on-write lvalue semantics намеренно не входят в этот runtime. Если migration corpus требует write, он должен быть выражен отдельным explicit reference/write/data-model/effect contract. PR не заявляет полную parity legacy plain-object mutation.

## Conformance

Новый core test проверяет:

- same immutable semantic input для всех bodies;
- отсутствие semantic-state bleed;
- ordered results;
- точный nested observer order;
- empty projection без store growth;
- repeated execution canonical/idempotent;
- missing semantic context reject;
- fail-fast и отсутствие partial result materialization;
- malformed body-list reject до body execution;
- `PersistentLinkStore` close/reopen: exact output LinkId и нулевой store growth после convergence.

## Package/docs

- `independent_projection.h` входит в installed public surface и `<avm/avm.h>`;
- test включён в `avm_core_tests`;
- добавлен русский ADR `docs/execution-projection.md`;
- никакого JSON/Anum parser, второго Executor, hidden mutable context или scheduler dependency.