### PR TITLE
AVM 1.5: сохранить semantic state в pure Integer arithmetic

### DIFF
--- a/include/avm/integer_value.h
+++ b/include/avm/integer_value.h
@@ -279,8 +279,6 @@ inline ExecutionOutcome execute_integer_binary(const ExecutionContext &context, 
 	const std::int64_t left = decode_integer(executor.store(), vocabulary, context.subject);
 	const std::int64_t right = decode_integer(executor.store(), vocabulary, context.object);
 	const LinkId result = realize_integer(executor.store(), vocabulary, operation(left, right));
-	if (context.semantic)
-		return ExecutionOutcome{result, context.semantic.with_relation_state(result)};
 	return ExecutionOutcome{result};
 }
 

--- a/test/integer_value_test.cpp
+++ b/test/integer_value_test.cpp
@@ -45,6 +45,14 @@ avm::LinkId arithmetic_entity(avm::LinkStore &store, avm::LinkId relation, avm::
 	return avm::encode_relation_entity(store, avm::RelationEntity{relation, left, right});
 }
 
+class RecordingObserver final : public avm::ExecutionObserver
+{
+public:
+	void observe(const avm::ExecutionEvent &event) override { events.push_back(event); }
+
+	std::vector<avm::ExecutionEvent> events;
+};
+
 } // namespace
 
 int main()
@@ -134,10 +142,32 @@ int main()
 	    store.create_point(),
 	    store.create_point(),
 	});
+
+	RecordingObserver observer;
+	executor.set_observer(&observer);
+
 	const avm::ExecutionOutcome semantic_add = executor.execute_outcome_in_context(add_7_3, root);
 	assert(semantic_add.result == ten);
-	assert(semantic_add.semantic.role(avm::SemanticContextRole::RelationState) == ten);
+	assert(semantic_add.semantic == root);
 	assert(root.role(avm::SemanticContextRole::RelationState) == zero);
+
+	const avm::ExecutionOutcome semantic_subtract = executor.execute_outcome_in_context(subtract_9_4, root);
+	assert(avm::decode_integer(store, vocabulary, semantic_subtract.result) == 5);
+	assert(semantic_subtract.semantic == root);
+
+	const avm::ExecutionOutcome semantic_multiply = executor.execute_outcome_in_context(multiply_6_7, root);
+	assert(avm::decode_integer(store, vocabulary, semantic_multiply.result) == 42);
+	assert(semantic_multiply.semantic == root);
+
+	const avm::ExecutionOutcome semantic_divide = executor.execute_outcome_in_context(divide_8_2, root);
+	assert(avm::decode_integer(store, vocabulary, semantic_divide.result) == 4);
+	assert(semantic_divide.semantic == root);
+
+	assert(!observer.events.empty());
+	const avm::ExecutionEvent &last_event = observer.events.back();
+	assert(last_event.kind == avm::ExecutionEventKind::Return);
+	assert(last_event.semantic_result == root);
+	executor.set_observer(nullptr);
 
 	const avm::LinkId int_max = avm::realize_integer(store, vocabulary, std::numeric_limits<std::int64_t>::max());
 	const avm::LinkId int_min = avm::realize_integer(store, vocabulary, std::numeric_limits<std::int64_t>::min());


### PR DESCRIPTION
Closes #191. Part of #128/#122. Required before #174 semantic migrator.

## Исправленная регрессия

После восстановления canonical Integer runtime `execute_integer_binary()` явно возвращал:

```cpp
ExecutionOutcome{result, context.semantic.with_relation_state(result)}
```

Это превращало pure Integer operation в скрытый `$rel := result` transition и противоречило принятому #153/#162 contract: обычный result не переписывает semantic state автоматически.

## Новый контракт

`integer_add/subtract/multiply/divide`:

1. observationally decode `subject/object`;
2. выполняют checked host arithmetic;
3. явно realize canonical Integer result;
4. возвращают только result identity;
5. unified Executor наследует входной `SemanticContextView` unchanged.

Materialization canonical result остаётся явным value-producing store effect и не смешивается с context-state transition.

## Legacy compatibility

jsonRVM composition, где arithmetic обновляла `$rel`, не исчезает: #174 semantic migrator должен выражать этот переход явной structural state-transition/composition семантикой поверх pure Integer relation.

## Division

Принятый #165 ADR не меняется: signed C++20 truncation toward zero; deterministic failures для divide-by-zero и `INT64_MIN / -1`. Ранний exact-division plan #163 закрыт как superseded by #165.

## Conformance

`integer_value_test` теперь проверяет:

- canonical arithmetic results не изменились;
- add/sub/mul/divide с одним и тем же semantic input возвращают тот же semantic state;
- input view остаётся immutable;
- observer `Return.semantic_result` равен исходному context;
- прежние overflow/div0/persistence cases сохраняются.

Нет изменений JSON/Anum, Executor registry, value encoding или persistence format.