### PR TITLE
AVM 1.5: первый jsonRVM semantic migrator vertical slice

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,16 @@ if(AVM_BUILD_CORE_TESTS)
     avm_enable_test_assertions(avm_json_duplet_values_test)
     add_test(NAME json_duplet_values_tests COMMAND avm_json_duplet_values_test)
 
+    add_executable(avm_jsonrvm_semantic_migrator_test
+        "${CMAKE_CURRENT_SOURCE_DIR}/test/jsonrvm_semantic_migrator_test.cpp")
+    avm_add_json_adapter_includes(avm_jsonrvm_semantic_migrator_test)
+    avm_apply_quality(avm_jsonrvm_semantic_migrator_test)
+    avm_enable_test_assertions(avm_jsonrvm_semantic_migrator_test)
+    add_test(
+        NAME jsonrvm_semantic_migrator_tests
+        COMMAND avm_jsonrvm_semantic_migrator_test
+            "${CMAKE_CURRENT_SOURCE_DIR}/compat/jsonrvm-legacy-fixtures/arithmetic-add.json")
+
     add_custom_target(avm_core_tests DEPENDS
         avm_assertions_enabled_test
         avm_link_store_test
@@ -318,7 +328,8 @@ if(AVM_BUILD_CORE_TESTS)
         avm_json_value_codec_test
         avm_json_duplet_converter_test
         avm_json_duplet_projection_test
-        avm_json_duplet_values_test)
+        avm_json_duplet_values_test
+        avm_jsonrvm_semantic_migrator_test)
 endif()
 
 if(AVM_BUILD_ANUM_ADAPTER_TESTS)

--- a/adapters/jsonrvm_semantic_migrator.h
+++ b/adapters/jsonrvm_semantic_migrator.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+namespace avm::jsonrvm_migration
+{
+
+class MigrationError : public std::runtime_error
+{
+public:
+	using std::runtime_error::runtime_error;
+};
+
+template <typename Json> struct MigrationResult
+{
+	Json document;
+	std::string observable_json_pointer;
+};
+
+namespace detail
+{
+
+inline const char *integer_relation_symbol(const std::string &legacy_operator)
+{
+	if (legacy_operator == "+")
+		return "integer_add";
+	if (legacy_operator == "-")
+		return "integer_subtract";
+	if (legacy_operator == "*")
+		return "integer_multiply";
+	if (legacy_operator == "/")
+		return "integer_divide";
+	throw MigrationError("unsupported legacy arithmetic relation: " + legacy_operator);
+}
+
+template <typename Json> std::int64_t require_integer_operand(const Json &value, const std::string &path)
+{
+	if (value.is_number_unsigned())
+	{
+		const std::uint64_t raw = value.template get<std::uint64_t>();
+		const auto max = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+		if (raw > max)
+			throw MigrationError(path + ": integer operand exceeds int64 migration domain");
+		return static_cast<std::int64_t>(raw);
+	}
+
+	if (value.is_number_integer())
+		return value.template get<std::int64_t>();
+
+	throw MigrationError(path + ": expected an integer operand");
+}
+
+template <typename Json> Json tagged(const char *marker, Json value)
+{
+	Json result = Json::object();
+	result[marker] = std::move(value);
+	return result;
+}
+
+template <typename Json> Json duplet(Json begin, Json end)
+{
+	Json result = Json::object();
+	result["<<"] = std::move(begin);
+	result[">>"] = std::move(end);
+	return result;
+}
+
+template <typename Json> Json migrate_arithmetic_relation(const Json &relation)
+{
+	if (!relation.is_object())
+		throw MigrationError("$.$rel/result: arithmetic relation must be an object");
+	if (!relation.contains("$rel") || !relation.contains("$sub") || !relation.contains("$obj") || relation.size() != 3)
+		throw MigrationError("$.$rel/result: expected exactly $rel, $sub and $obj");
+
+	const Json &encoded_relation = relation.at("$rel");
+	if (!encoded_relation.is_string())
+		throw MigrationError("$.$rel/result.$rel: arithmetic relation must be a string");
+	const std::string legacy_operator = encoded_relation.template get<std::string>();
+	const char *symbol = integer_relation_symbol(legacy_operator);
+
+	const std::int64_t subject = require_integer_operand(relation.at("$sub"), "$.$rel/result.$sub");
+	const std::int64_t object = require_integer_operand(relation.at("$obj"), "$.$rel/result.$obj");
+
+	return duplet(tagged<Json>("$symbol", symbol),
+	              duplet(tagged<Json>("$integer", subject), tagged<Json>("$integer", object)));
+}
+
+} // namespace detail
+
+template <typename Json> MigrationResult<Json> migrate_program(const Json &legacy)
+{
+	if (!legacy.is_object())
+		throw MigrationError("$: legacy jsonRVM program must be an object");
+	if (!legacy.contains("$rel/result") || legacy.size() != 1)
+		throw MigrationError("$: first migration gate expects exactly the frozen $rel/result envelope");
+
+	Json document = Json::object();
+	document["$avm"] = "duplet-json/1";
+	document["$root"] = detail::migrate_arithmetic_relation(legacy.at("$rel/result"));
+	return MigrationResult<Json>{std::move(document), "/result"};
+}
+
+} // namespace avm::jsonrvm_migration

--- a/docs/jsonrvm-semantic-migrator.md
+++ b/docs/jsonrvm-semantic-migrator.md
@@ -1,0 +1,218 @@
+# Semantic migrator jsonRVM → AVM
+
+Родительская задача: #174. Первый executable gate: #195. Native Duplet JSON umbrella: #169.
+
+## Назначение
+
+Semantic migrator переносит **наблюдаемую семантику** legacy jsonRVM в уже принятые link-native contracts AVM.
+
+Он принципиально отличается от structural converter `json_duplet_converter.h`.
+
+Structural converter отвечает только за механическую форму:
+
+```text
+(rel, sub, obj) -> Link(rel, Link(sub, obj))
+```
+
+и не знает специальных runtime значений `$rel`, `$sub`, `$obj`, `$ref`, sequence, foreach или legacy mutable context.
+
+Semantic migrator, напротив, знает выбранный **source-language subset**, но не исполняет его.
+
+```text
+legacy JSON source
+    ↓
+semantic compilation
+    ↓
+Native Duplet JSON
+    ↓
+существующий Native JSON projection
+    ↓
+canonical LinkId program
+    ↓
+существующий Executor
+```
+
+В проекте по-прежнему существует только один semantic execution path.
+
+## Граница первого gate
+
+#195 поддерживает frozen arithmetic fixture:
+
+```text
+compat/jsonrvm-legacy-fixtures/arithmetic-add.json
+```
+
+Source form:
+
+```json
+{
+  "$rel/result": {
+    "$rel": "+",
+    "$sub": 1,
+    "$obj": 1
+  }
+}
+```
+
+Pinned jsonRVM oracle возвращает observable `result = 2`.
+
+На первом gate внешний ключ `$rel/result` рассматривается только как legacy output envelope. Он **не** становится generic Object/Map value AVM.
+
+Внутреннее arithmetic expression компилируется в direct triune relation:
+
+```text
+(integer_add, Integer(1), Integer(1))
+```
+
+и затем в Native Duplet JSON:
+
+```json
+{
+  "$avm": "duplet-json/1",
+  "$root": {
+    "<<": {"$symbol": "integer_add"},
+    ">>": {
+      "<<": {"$integer": 1},
+      ">>": {"$integer": 1}
+    }
+  }
+}
+```
+
+`integer_add` здесь является только protocol-level symbolic anchor. Caller явно связывает его с `IntegerVocabulary::add_relation`.
+
+Migrator не создаёт LinkId и не владеет таблицей canonical identities.
+
+## Поддержанные arithmetic relations
+
+Первый slice использует уже принятый Integer vocabulary:
+
+```text
++ -> integer_add
+- -> integer_subtract
+* -> integer_multiply
+/ -> integer_divide
+```
+
+Operands должны принадлежать signed `int64` migration domain первого Integer implementation.
+
+Arithmetic semantics не переопределяется migrator-ом. В частности division следует принятому #165 contract: signed C++20 truncation toward zero с deterministic failure на division by zero и `INT64_MIN / -1` уже внутри Integer relation.
+
+Migrator только выбирает relation identity и canonical operand denotations.
+
+## Result и semantic state
+
+После #191 pure Integer arithmetic возвращает canonical result и **не** делает скрытый:
+
+```text
+$rel := result
+```
+
+Это обязательная граница.
+
+Legacy jsonRVM использовал mutable context slots, поэтому в более сложных programs arithmetic result мог одновременно становиться новым relation-state.
+
+Такое поведение не возвращается в Integer primitive ради совместимости.
+
+Следующий migration gate должен выразить legacy state transition явно поверх:
+
+- `ExecutionOutcome`;
+- immutable `SemanticContextView`;
+- ordered sequence state threading #153/#162;
+- canonical reference/state operations.
+
+Тем самым:
+
+```text
+value computation != state transition
+```
+
+остаётся истинным и после полной миграции.
+
+## Observable output metadata
+
+`MigrationResult` содержит:
+
+```text
+document
+observable_json_pointer
+```
+
+`document` является единственным AVM program artifact.
+
+`observable_json_pointer` — metadata differential harness-а, позволяющая сопоставить canonical AVM result с legacy oracle field `/result`.
+
+Она не materialize-ится в LinkStore и не является runtime value.
+
+Такой boundary позволяет проверить старый внешний JSON result без создания generic mutable JSON object внутри AVM.
+
+## Ошибки migration boundary
+
+Первый gate детерминированно отвергает:
+
+- non-object root;
+- root без exact `$rel/result` envelope;
+- дополнительные root members;
+- arithmetic object без exact `$rel/$sub/$obj`;
+- non-string `$rel`;
+- неизвестный arithmetic operator;
+- non-integer subject/object;
+- integer вне текущего signed `int64` migration domain.
+
+Эти ошибки возникают **до** Native Duplet projection и до любой materialization.
+
+Runtime arithmetic failures, например division by zero, остаются ответственностью canonical Integer relation и не эмулируются migrator-ом.
+
+## Lifetime boundary
+
+После `migrate_program` исходный legacy JSON DOM больше не нужен.
+
+Native document является самостоятельным внешним artifact. После его projection/realization canonical program graph также не зависит от lifetime JSON DOM.
+
+Это исключает возврат старой архитектуры, где JSON одновременно был AST, data model и mutable runtime state.
+
+## Differential evidence
+
+Для каждого поддержанного construct нужны два независимых доказательства:
+
+1. pinned jsonRVM oracle фиксирует observable behavior source fixture;
+2. AVM test проходит полный новый pipeline и сравнивает semantic result.
+
+Нельзя объявлять совместимость только потому, что generated JSON визуально похож на source.
+
+Для `CASE-ARITHMETIC`:
+
+```text
+jsonRVM oracle -> 2
+AVM migrated program -> canonical Integer(2)
+decode Integer -> 2
+```
+
+Это и есть observable semantic equivalence первого gate.
+
+## Следующие gates
+
+После arithmetic vertical slice расширение идёт construct-by-construct:
+
+1. ordered sequence;
+2. explicit legacy relation-state transition;
+3. `CASE-PURE-RELATION-COMPOSITION`;
+4. Boolean branch;
+5. foreach-object через уже принятый #187;
+6. missing/reference behavior через #126;
+7. оставшиеся corpus constructs только после отдельного semantic decision.
+
+Не поддержанные while/switch/catch/effects не получают заглушек и не интерпретируются частично.
+
+## Архитектурные запреты
+
+1. migrator не принимает `LinkStore`;
+2. migrator не вызывает `Executor`;
+3. migrator не регистрирует native relations;
+4. migrator не хранит global current context;
+5. legacy JSON не становится runtime value AVM;
+6. Native Duplet parser не получает legacy-special cases;
+7. frozen jsonRVM не изменяется;
+8. unsupported construct отвергается вместо скрытого fallback к старому interpreter;
+9. compatibility state transition не прячется в pure Integer/Text primitives;
+10. каждый новый supported construct получает oracle-backed conformance.

--- a/test/jsonrvm_semantic_migrator_test.cpp
+++ b/test/jsonrvm_semantic_migrator_test.cpp
@@ -1,0 +1,141 @@
+#include "json_duplet_values.h"
+#include "jsonrvm_semantic_migrator.h"
+
+#include "avm/executor.h"
+#include "avm/integer_value.h"
+#include "avm/projection.h"
+#include "avm/relations_model.h"
+#include "avm/text_value.h"
+
+#include "nlohmann/json.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace
+{
+
+using Json = nlohmann::ordered_json;
+
+Json load_json(const char *path)
+{
+	std::ifstream stream(path);
+	if (!stream)
+		throw std::runtime_error(std::string("cannot open fixture: ") + path);
+	Json value;
+	stream >> value;
+	return value;
+}
+
+Json arithmetic_fixture(const char *operation, Json subject, Json object)
+{
+	Json relation = Json::object();
+	relation["$rel"] = operation;
+	relation["$sub"] = std::move(subject);
+	relation["$obj"] = std::move(object);
+
+	Json fixture = Json::object();
+	fixture["$rel/result"] = std::move(relation);
+	return fixture;
+}
+
+bool migration_rejected(const Json &legacy)
+{
+	try
+	{
+		static_cast<void>(avm::jsonrvm_migration::migrate_program(legacy));
+		return false;
+	}
+	catch (const avm::jsonrvm_migration::MigrationError &)
+	{
+		return true;
+	}
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+	if (argc != 2)
+		throw std::runtime_error("expected arithmetic fixture path");
+
+	const Json frozen = load_json(argv[1]);
+	const avm::jsonrvm_migration::MigrationResult<Json> migration =
+	    avm::jsonrvm_migration::migrate_program(frozen);
+
+	assert(migration.observable_json_pointer == "/result");
+	assert(migration.document.is_object());
+	assert(migration.document.at("$avm") == "duplet-json/1");
+
+	Json frozen_copy = frozen;
+	frozen_copy.clear();
+
+	avm::InMemoryLinkStore store;
+	const avm::IntegerVocabulary integers = avm::IntegerVocabulary::create(store);
+	const avm::TextVocabulary text = avm::TextVocabulary::create(store);
+
+	avm::json_duplet::SymbolAnchors symbols;
+	symbols.emplace("integer_add", integers.add_relation);
+	symbols.emplace("integer_subtract", integers.subtract_relation);
+	symbols.emplace("integer_multiply", integers.multiply_relation);
+	symbols.emplace("integer_divide", integers.divide_relation);
+	const avm::json_duplet::NativeLeafResolver resolver(integers, text, symbols);
+
+	const std::size_t before_projection = store.size();
+	const avm::ProjectionDescription description =
+	    avm::json_duplet::project_duplet_document(migration.document, resolver);
+	assert(store.size() == before_projection);
+	assert(!avm::find_projection(store, description).has_value());
+	assert(store.size() == before_projection);
+
+	const avm::LinkId program = avm::realize_projection(store, description).root;
+	const avm::RelationEntity decoded = avm::decode_relation_entity(store, program);
+	assert(decoded.relation == integers.add_relation);
+	assert(avm::decode_integer(store, integers, decoded.subject) == 1);
+	assert(avm::decode_integer(store, integers, decoded.object) == 1);
+
+	avm::Executor executor(store);
+	avm::register_integer_arithmetic(executor, integers);
+	const avm::LinkId result = executor.execute(program);
+	assert(avm::decode_integer(store, integers, result) == 2);
+
+	const Json operations[] = {
+	    arithmetic_fixture("+", 7, 3),
+	    arithmetic_fixture("-", 9, 4),
+	    arithmetic_fixture("*", 6, 7),
+	    arithmetic_fixture("/", -7, 2),
+	};
+	const std::int64_t expected[] = {10, 5, 42, -3};
+
+	for (std::size_t index = 0; index < 4; ++index)
+	{
+		const auto migrated = avm::jsonrvm_migration::migrate_program(operations[index]);
+		const avm::ProjectionDescription operation_description =
+		    avm::json_duplet::project_duplet_document(migrated.document, resolver);
+		const avm::LinkId operation_program = avm::realize_projection(store, operation_description).root;
+		const avm::LinkId operation_result = executor.execute(operation_program);
+		assert(avm::decode_integer(store, integers, operation_result) == expected[index]);
+	}
+
+	assert(migration_rejected(Json::array()));
+	assert(migration_rejected(Json::object()));
+	assert(migration_rejected(arithmetic_fixture("%", 7, 3)));
+	assert(migration_rejected(arithmetic_fixture("+", "7", 3)));
+	assert(migration_rejected(arithmetic_fixture("+", 7, 3.5)));
+
+	Json incomplete = Json::object();
+	incomplete["$rel"] = "+";
+	incomplete["$sub"] = 1;
+	Json incomplete_fixture = Json::object();
+	incomplete_fixture["$rel/result"] = std::move(incomplete);
+	assert(migration_rejected(incomplete_fixture));
+
+	Json foreign = arithmetic_fixture("+", 1, 1);
+	foreign["extra"] = true;
+	assert(migration_rejected(foreign));
+
+	return 0;
+}


### PR DESCRIPTION
Closes #195. Part of #174/#169/#122.

## Первый настоящий migration pipeline

```text
frozen legacy jsonRVM fixture
 -> jsonrvm_semantic_migrator.h
 -> duplet-json/1 document
 -> NativeLeafResolver
 -> ProjectionDescription
 -> realize_projection
 -> canonical RelationEntity
 -> ordinary Executor + IntegerVocabulary
 -> canonical Integer result
```

Migrator является adapter-only JSON→JSON semantic compiler. Он не принимает `LinkStore`, не вызывает `Executor`, не materialize-ит LinkId и не хранит runtime context.

## Frozen oracle case

Используется реальный файл:

`compat/jsonrvm-legacy-fixtures/arithmetic-add.json`

Pinned oracle даёт `/result = 2`.

Migrator компилирует legacy:

```json
{"$rel/result":{"$rel":"+","$sub":1,"$obj":1}}
```

в Native Duplet form direct Integer relation. После уничтожения source DOM generated document всё ещё проецируется и ordinary Executor возвращает canonical Integer(2).

## Supported arithmetic subset

Один accepted Integer domain:

- `+ -> integer_add`
- `- -> integer_subtract`
- `* -> integer_multiply`
- `/ -> integer_divide`

Unknown operator, non-integer operand, incomplete relation и mixed root envelope отклоняются deterministic `MigrationError` до projection/materialization.

Division semantics не изобретается migrator-ом и остаётся accepted #165 truncation-toward-zero contract.

## State boundary

После #191 pure Integer arithmetic не делает hidden `$rel := result`.

Этот PR intentionally проверяет только arithmetic observable result. Legacy relation-state threading будет следующим #174 subgate через explicit state-transition semantics поверх #153/#162, а не возвратом mutable slot в Integer primitive.

## Differential metadata

`MigrationResult` отдельно хранит `observable_json_pointer = /result` для test/oracle harness. Это metadata и не становится generic Object/Map runtime value.

## Tests / docs

- новый `jsonrvm_semantic_migrator_test.cpp` читает exact frozen fixture;
- проверяет non-mutating projection/find;
- проверяет direct triune decoded relation/operands;
- исполняет результат обычным Executor;
- покрывает `+ - * /` и malformed/unknown cases;
- target включён в `avm_core_tests`, поэтому идёт через strict, ASan/UBSan и portable matrix;
- добавлен русский `docs/jsonrvm-semantic-migrator.md`.

## Veto

Нет второго executor, JSON runtime value universe, hidden LinkId registry, legacy special cases в Native Duplet parser, изменения frozen jsonRVM или implicit compatibility fallback.